### PR TITLE
Added "TRACE_BUFFER_SIZE" for printing of recorded traces

### DIFF
--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -226,7 +226,8 @@ static RAMFUNC int OutOfNDecoding(int bit)
 
 							// Calculate the parity bit for the client...
 							Uart.parityBits <<= 1;
-							Uart.parityBits ^= OddByteParity[(Uart.shiftReg & 0xff)];
+							//Uart.parityBits ^= OddByteParity[(Uart.shiftReg & 0xff)];
+							Uart.parityBits ^= oddparity(Uart.shiftReg & 0xff);
 
 							Uart.bitCnt = 0;
 							Uart.shiftReg = 0;
@@ -249,7 +250,8 @@ static RAMFUNC int OutOfNDecoding(int bit)
 
 					// Calculate the parity bit for the client...
 					Uart.parityBits <<= 1;
-					Uart.parityBits ^= OddByteParity[(Uart.dropPosition & 0xff)];
+					//Uart.parityBits ^= OddByteParity[(Uart.dropPosition & 0xff)];
+					Uart.parityBits ^= oddparity((Uart.dropPosition & 0xff));
 
 					Uart.bitCnt = 0;
 					Uart.shiftReg = 0;
@@ -486,7 +488,8 @@ static RAMFUNC int ManchesterDecoding(int v)
 					Demod.output[Demod.len] = 0x0f;
 					Demod.len++;
 					Demod.parityBits <<= 1;
-					Demod.parityBits ^= OddByteParity[0x0f];
+					//Demod.parityBits ^= OddByteParity[0x0f];
+					Demod.parityBits ^= oddparity(0x0f);
 					Demod.state = DEMOD_UNSYNCD;
 //					error = 0x0f;
 					return TRUE;
@@ -611,7 +614,8 @@ static RAMFUNC int ManchesterDecoding(int v)
 
 				// FOR ISO15639 PARITY NOT SEND OTA, JUST CALCULATE IT FOR THE CLIENT
 				Demod.parityBits <<= 1;
-				Demod.parityBits ^= OddByteParity[(Demod.shiftReg & 0xff)];
+				//Demod.parityBits ^= OddByteParity[(Demod.shiftReg & 0xff)];
+				Demod.parityBits ^= oddparity(Demod.shiftReg & 0xff);
 
 				Demod.bitCount = 0;
 				Demod.shiftReg = 0;

--- a/armsrc/iso14443a.h
+++ b/armsrc/iso14443a.h
@@ -75,7 +75,7 @@ typedef struct {
 
 
 
-extern byte_t oddparity (const byte_t bt);
+//extern uint8_t oddparity(uint8_t bt);
 extern uint32_t GetParity(const uint8_t *pbtCmd, int iLen);
 extern void AppendCrc14443a(uint8_t *data, int len);
 

--- a/armsrc/util.c
+++ b/armsrc/util.c
@@ -44,7 +44,15 @@ uint64_t bytes_to_num(uint8_t* src, size_t len)
 	}
 	return num;
 }
+//added here for parity calulations
 
+uint8_t oddparity(uint8_t bt)
+{
+    uint16_t v = bt;
+    v ^= v >> 4;
+    v &= 0xF;
+    return ((0x9669 >> v) & 1);
+}
 void LEDsoff()
 {
 	LED_A_OFF();

--- a/armsrc/util.h
+++ b/armsrc/util.h
@@ -32,6 +32,9 @@ uint32_t SwapBits(uint32_t value, int nrbits);
 void num_to_bytes(uint64_t n, size_t len, uint8_t* dest);
 uint64_t bytes_to_num(uint8_t* src, size_t len);
 
+//added parity generation function here
+uint8_t oddparity(uint8_t bt);
+
 void SpinDelay(int ms);
 void SpinDelayUs(int us);
 void LED(int led, int ms);

--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -31,7 +31,6 @@ int CmdHF14AList(const char *Cmd)
 {
 	bool ShowWaitCycles = false;
 	char param = param_getchar(Cmd, 0);
-	
 	if (param == 'h' || (param != 0 && param != 'f')) {
 		PrintAndLog("List data in trace buffer.");
 		PrintAndLog("Usage:  hf 14a list [f]");
@@ -44,7 +43,8 @@ int CmdHF14AList(const char *Cmd)
 		ShowWaitCycles = true;
 	}
 		
-	uint8_t got[1920];
+	//uint8_t got[1920];
+	uint8_t got[TRACE_BUFFER_SIZE]; //changed to retrieve actual trace buffer size in apps.h in armsrc
 	GetFromBigBuf(got,sizeof(got),0);
 	WaitForResponse(CMD_ACK,NULL);
 
@@ -62,7 +62,7 @@ int CmdHF14AList(const char *Cmd)
 	uint32_t EndOfTransmissionTimestamp = 0;
 	
 	for (;;) {
-		if(i >= 1900) {
+		if(i >= TRACE_BUFFER_SIZE) {
 			break;
 		}
 
@@ -86,7 +86,7 @@ int CmdHF14AList(const char *Cmd)
 		if (len > 100) {
 			break;
 		}
-		if (i + len >= 1900) {
+		if (i + len >= TRACE_BUFFER_SIZE) {
 			break;
 		}
 

--- a/client/cmdhf14b.c
+++ b/client/cmdhf14b.c
@@ -145,7 +145,7 @@ demodError:
 
 int CmdHF14BList(const char *Cmd)
 {
-  uint8_t got[960];
+  uint8_t got[TRACE_BUFFER_SIZE];
   GetFromBigBuf(got,sizeof(got),0);
   WaitForResponse(CMD_ACK,NULL);
 
@@ -157,7 +157,8 @@ int CmdHF14BList(const char *Cmd)
   int prev = -1;
 
   for(;;) {
-    if(i >= 900) {
+    //if(i >= 900) {
+    if(i >= TRACE_BUFFER_SIZE) {
       break;
     }
 
@@ -176,7 +177,8 @@ int CmdHF14BList(const char *Cmd)
     if(len > 100) {
       break;
     }
-    if(i + len >= 900) {
+    //if(i + len >= 900) {
+    if(i + len >= TRACE_BUFFER_SIZE) {
       break;
     }
 

--- a/client/cmdhficlass.c
+++ b/client/cmdhficlass.c
@@ -56,7 +56,8 @@ int CmdHFiClassList(const char *Cmd)
 		return 0;
 	}
 
-	uint8_t got[1920];
+	//uint8_t got[1920];
+	uint8_t got[TRACE_BUFFER_SIZE];
 	GetFromBigBuf(got,sizeof(got),0);
 	WaitForResponse(CMD_ACK,NULL);
 
@@ -78,7 +79,7 @@ int CmdHFiClassList(const char *Cmd)
 	uint32_t EndOfTransmissionTimestamp = 0;
 
 
-	for( i=0; i < 1900;)
+	for( i=0; i < TRACE_BUFFER_SIZE;)
 	{
 		//First 32 bits contain
 		// isResponse (1 bit)

--- a/client/cmdlfhitag.c
+++ b/client/cmdlfhitag.c
@@ -30,7 +30,7 @@ size_t nbytes(size_t nbits) {
 
 int CmdLFHitagList(const char *Cmd)
 {
-  uint8_t got[3000];
+  uint8_t got[TRACE_BUFFER_SIZE];
   GetFromBigBuf(got,sizeof(got),0);
   WaitForResponse(CMD_ACK,NULL);
 
@@ -42,7 +42,8 @@ int CmdLFHitagList(const char *Cmd)
   int prev = -1;
 
   for (;;) {
-    if(i >= 1900) {
+    //if(i >= 1900) {
+    if(i >= TRACE_BUFFER_SIZE) {
       break;
     }
 
@@ -69,7 +70,8 @@ int CmdLFHitagList(const char *Cmd)
     if (len > 100) {
       break;
     }
-    if (i + len >= 1900) {
+    //if (i + len >= 1900) {
+    if (i + len >= TRACE_BUFFER_SIZE) {
       break;
     }
 

--- a/client/data.h
+++ b/client/data.h
@@ -12,9 +12,9 @@
 #define DATA_H__
 
 #include <stdint.h>
-
+//trace buffer size as defined in armsrc/apps.h TRACE_SIZE
+#define TRACE_BUFFER_SIZE 3000
 #define SAMPLE_BUFFER_SIZE 64
-
 extern uint8_t* sample_buf;
 extern size_t sample_buf_len;
 #define arraylen(x) (sizeof(x)/sizeof((x)[0]))


### PR DESCRIPTION
This fixes an issue with the proxmark client where not all the trace buffer is printed.
I've added a constant to data.h, and changed the corresponding client code to use it.
This allows for larger traces to be analysed in the client.