### PR TITLE
FIX:  LF TI WRITE inparameters didn't get copied by sscanf.

### DIFF
--- a/client/cmdlfti.c
+++ b/client/cmdlfti.c
@@ -273,7 +273,8 @@ int CmdTIWrite(const char *Cmd)
   UsbCommand c = {CMD_WRITE_TI_TYPE};
   int res = 0;
 
-  res = sscanf(Cmd, "0x%"PRIu64"x 0x%"PRIu64"x 0x%"PRIu64"x ", &c.arg[0], &c.arg[1], &c.arg[2]);
+  res = sscanf(Cmd, "%012"llx" %012"llx" %012"llx"", &c.arg[0], &c.arg[1], &c.arg[2]);
+  
   if (res == 2) c.arg[2]=0;
   if (res < 2)
     PrintAndLog("Please specify the data as two hex strings, optionally the CRC as a third");


### PR DESCRIPTION
FIX:  LF TI WRITE inparameters didn't get copied by sscanf.  This removes the "PRIu64" and uses the 012"llx" instead.