### PR TITLE
Add settable ATQA and SAK to hf mf csetuid command.

### DIFF
--- a/client/mifarehost.h
+++ b/client/mifarehost.h
@@ -55,7 +55,7 @@ int mfCheckKeys (uint8_t blockNo, uint8_t keyType, uint8_t keycnt, uint8_t * key
 int mfEmlGetMem(uint8_t *data, int blockNum, int blocksCount);
 int mfEmlSetMem(uint8_t *data, int blockNum, int blocksCount);
 
-int mfCSetUID(uint8_t *uid, uint8_t *oldUID, bool wantWipe);
+int mfCSetUID(uint8_t *uid, uint8_t *atqa, uint8_t *sak, uint8_t *oldUID, bool wantWipe);
 int mfCSetBlock(uint8_t blockNo, uint8_t *data, uint8_t *uid, bool wantWipe, uint8_t params);
 int mfCGetBlock(uint8_t blockNo, uint8_t *data, uint8_t params);
 


### PR DESCRIPTION
There seemed to be someone's code forcing all csetuid calls to set ATQA: 0f01 SAK: 01 (NXP TNP3xxx Activision Game Appliance) instead of preserving existing ATQA/SAK. As there seemed to be need to set ATQA and SAK, I added them as an optional argument.