### PR TITLE
Implemented usb_poll() within LF sim. 

### DIFF
--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -16,6 +16,7 @@
 #include "string.h"
 #include "lfdemod.h"
 #include "lfsampling.h"
+#include "usb_cdc.h"
 
 
 /**
@@ -401,7 +402,7 @@ void SimulateTagLowFrequency(int period, int gap, int ledcontrol)
     for(;;) {
         //wait until SSC_CLK goes HIGH
         while(!(AT91C_BASE_PIOA->PIO_PDSR & GPIO_SSC_CLK)) {
-            if(BUTTON_PRESS()) {
+			if(BUTTON_PRESS() || usb_poll()) {
                 DbpString("Stopped");
                 return;
             }


### PR DESCRIPTION
This means the LF sim will be aborted whenever something comes over the USB. This is probably a good thing, but I haven't tested it very thorougly, so I don't know if the check could possibly cause us to miss a beat in the simulation. The `usb_poll`-check looks like it is very quick, checking ARM-registers, but in the borderline between hardware and software, I'm never too sure...