### PR TITLE
Reclaim more than 19K of ARM flash memory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ help:
 	@echo +	all           - Make bootrom, armsrc and the OS-specific host directory
 	@echo + client        - Make only the OS-specific host directory
 	@echo + flash-bootrom - Make bootrom and flash it
-	@echo + flash-os      - Make armsrc and flash os
-	@echo + flash-fpga    - Make armsrc and flash fpga
+	@echo + flash-os      - Make armsrc and flash os (includes fpga)
+	@echo + flash-fpga    - (Deprecated:) Make armsrc and flash fpga
 	@echo + flash-both    - Make armsrc and flash os and fpga image
 	@echo + flash-all     - Make bootrom and armsrc and flash bootrom, os and fpga image
 	@echo +	clean         - Clean in bootrom, armsrc and the OS-specific host directory
@@ -37,13 +37,13 @@ flash-bootrom: bootrom/obj/bootrom.elf $(FLASH_TOOL)
 flash-os: armsrc/obj/osimage.elf $(FLASH_TOOL)
 	$(FLASH_TOOL) $(FLASH_PORT) $(subst /,$(PATHSEP),$<)
 
-flash-fpga: armsrc/obj/fpgaimage.elf $(FLASH_TOOL)
-	$(FLASH_TOOL) $(FLASH_PORT) $(subst /,$(PATHSEP),$<)
+#flash-fpga: armsrc/obj/fpgaimage.elf $(FLASH_TOOL)
+#	$(FLASH_TOOL) $(FLASH_PORT) $(subst /,$(PATHSEP),$<)
 
-flash-both: armsrc/obj/osimage.elf armsrc/obj/fpgaimage.elf $(FLASH_TOOL)
+flash-both: armsrc/obj/osimage.elf $(FLASH_TOOL)
 	$(FLASH_TOOL) $(FLASH_PORT) $(subst /,$(PATHSEP),$(filter-out $(FLASH_TOOL),$^))
 
-flash-all: bootrom/obj/bootrom.elf armsrc/obj/osimage.elf armsrc/obj/fpgaimage.elf $(FLASH_TOOL)
+flash-all: bootrom/obj/bootrom.elf armsrc/obj/osimage.elf $(FLASH_TOOL)
 	$(FLASH_TOOL) $(FLASH_PORT) -b $(subst /,$(PATHSEP),$(filter-out $(FLASH_TOOL),$^))
 
 newtarbin:

--- a/armsrc/Makefile
+++ b/armsrc/Makefile
@@ -10,7 +10,7 @@ APP_INCLUDES = apps.h
 
 #remove one of the following defines and comment out the relevant line
 #in the next section to remove that particular feature from compilation  
-APP_CFLAGS	= -DWITH_LF -DWITH_ISO15693 -DWITH_ISO14443a -DWITH_ISO14443b -DWITH_ICLASS -DWITH_LEGICRF -DWITH_HITAG  -DWITH_CRC -DON_DEVICE -fno-strict-aliasing
+APP_CFLAGS	= -DWITH_LF -DWITH_ISO15693 -DWITH_ISO14443a -DWITH_ISO14443b -DWITH_ICLASS -DWITH_LEGICRF -DWITH_HITAG  -DWITH_CRC -DON_DEVICE -fno-strict-aliasing -ffunction-sections -fdata-sections
 #-DWITH_LCD 
 
 #SRC_LCD = fonts.c LCD.c
@@ -51,7 +51,8 @@ APP_CFLAGS += -I.
 # Do not move this inclusion before the definition of {THUMB,ASM,ARM}SRC
 include ../common/Makefile.common
 
-OBJS = $(OBJDIR)/osimage.s19 $(OBJDIR)/fpgaimage.s19
+OBJS = $(OBJDIR)/osimage.s19 
+#$(OBJDIR)/fpgaimage.s19
 
 all: $(OBJS)
 
@@ -64,11 +65,11 @@ $(OBJDIR)/fpga_hf.o: fpga_hf.bit
 $(OBJDIR)/fullimage.elf: $(VERSIONOBJ) $(OBJDIR)/fpga_lf.o $(OBJDIR)/fpga_hf.o $(THUMBOBJ) $(ARMOBJ)
 	$(CC) $(LDFLAGS) -Wl,-T,ldscript,-Map,$(patsubst %.elf,%.map,$@) -o $@ $^ $(LIBS)
 
-$(OBJDIR)/fpgaimage.elf: $(OBJDIR)/fullimage.elf
-	$(OBJCOPY) -F elf32-littlearm --only-section .fpgaimage $^ $@  
+#$(OBJDIR)/fpgaimage.elf: $(OBJDIR)/fullimage.elf
+#	$(OBJCOPY) -F elf32-littlearm --only-section .fpgaimage $^ $@  
 
 $(OBJDIR)/osimage.elf: $(OBJDIR)/fullimage.elf
-	$(OBJCOPY) -F elf32-littlearm --remove-section .fpgaimage $^ $@
+	$(OBJCOPY) -F elf32-littlearm $^ $@
 
 tarbin: $(OBJS)
 	$(TAR) $(TARFLAGS) ../proxmark3-$(platform)-bin.tar $(OBJS:%=armsrc/%) $(OBJS:%.s19=armsrc/%.elf)

--- a/armsrc/ldscript
+++ b/armsrc/ldscript
@@ -11,8 +11,7 @@ INCLUDE ../common/ldscript.common
 
 PHDRS
 {
-	fpgaimage PT_LOAD FLAGS(4);
-	text PT_LOAD;
+	text PT_LOAD FLAGS(5);
 	data PT_LOAD;
 	bss PT_LOAD;
 }
@@ -20,11 +19,6 @@ PHDRS
 ENTRY(Vector)
 SECTIONS
 {
-	.fpgaimage : {
-		*(fpga_lf_bit.data)
-		*(fpga_hf_bit.data)
-	} >fpgaimage :fpgaimage
-
 	.start : {
 		*(.startos)
 	} >osimage :text
@@ -40,6 +34,8 @@ SECTIONS
 	.rodata : {
 		*(.rodata)
 		*(.rodata.*)
+		*(fpga_lf_bit.data)
+		*(fpga_hf_bit.data)
 		KEEP(*(.version_information))
 	} >osimage :text
 

--- a/common/ldscript.common
+++ b/common/ldscript.common
@@ -1,6 +1,7 @@
 /*
 -----------------------------------------------------------------------------
- This code is licensed to you under the terms of the GNU GPL, version 2 or,
+ This code is licensed to you under the ter 
+ms of the GNU GPL, version 2 or,
  at your option, any later version. See the LICENSE.txt file for the text of
  the license.
 -----------------------------------------------------------------------------
@@ -13,8 +14,7 @@ MEMORY
 {
 	bootphase1 : ORIGIN = 0x00100000, LENGTH = 0x200             /* Phase 1 bootloader: Copies real bootloader to RAM */
 	bootphase2 : ORIGIN = 0x00100200, LENGTH = 0x2000 - 0x200    /* Main bootloader code, stored in Flash, executed from RAM */
-	fpgaimage  : ORIGIN = 0x00102000, LENGTH = 96k - 0x2000      /* Place where the FPGA image will end up */
-	osimage    : ORIGIN = 0x00118000, LENGTH = 256K - 96k        /* Place where the main OS will end up */
+	osimage    : ORIGIN = 0x00102000, LENGTH = 256K - 0x2000     /* Place where the main OS will end up */
 	ram        : ORIGIN = 0x00200000, LENGTH = 64K - 0x20        /* RAM, minus small common area */
 	commonarea : ORIGIN = 0x00200000 + 64K - 0x20, LENGTH = 0x20 /* Communication between bootloader and main OS */
 }

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -36,8 +36,8 @@ int getHiLo(uint8_t *BitStream, size_t size, int *high, int *low, uint8_t fuzzHi
 		if (BitStream[i] < *low) *low = BitStream[i];
 	}
 	if (*high < 123) return -1; // just noise
-	*high = (int)(((*high-128)*(((float)fuzzHi)/100))+128);
-	*low = (int)(((*low-128)*(((float)fuzzLo)/100))+128);
+	*high = ((*high-128)*fuzzHi + 12800)/100;
+	*low =  ((*low-128)*fuzzLo + 12800)/100;
 	return 1;
 }
 
@@ -639,12 +639,6 @@ size_t fsk_wave_demod(uint8_t * dest, size_t size, uint8_t fchigh, uint8_t fclow
 	return numBits; //Actually, it returns the number of bytes, but each byte represents a bit: 1 or 0
 }
 
-uint32_t myround2(float f)
-{
-	if (f >= 2000) return 2000;//something bad happened
-	return (uint32_t) (f + (float)0.5);
-}
-
 //translate 11111100000 to 10
 size_t aggregate_bits(uint8_t *dest, size_t size, uint8_t rfLen, uint8_t maxConsequtiveBits,
 		uint8_t invert, uint8_t fchigh, uint8_t fclow)
@@ -653,8 +647,6 @@ size_t aggregate_bits(uint8_t *dest, size_t size, uint8_t rfLen, uint8_t maxCons
 	uint32_t idx=0;
 	size_t numBits=0;
 	uint32_t n=1;
-	float lowWaves = (((float)(rfLen))/((float)fclow));
-	float highWaves = (((float)(rfLen))/((float)fchigh));
 	for( idx=1; idx < size; idx++) {
 
 		if (dest[idx]==lastval) {
@@ -664,20 +656,20 @@ size_t aggregate_bits(uint8_t *dest, size_t size, uint8_t rfLen, uint8_t maxCons
 		n++;
 		//if lastval was 1, we have a 1->0 crossing
 		if (dest[idx-1]==1) {
-			if (!numBits && n < (uint8_t)lowWaves) {
+			if (!numBits && n < rfLen/fclow) {
 				n=0;
 				lastval = dest[idx];
 				continue;
 			}
-			n=myround2(((float)n)/lowWaves);
+			n = (n * fclow + rfLen/2) / rfLen;
 		} else {// 0->1 crossing 
 			//test first bitsample too small
-			if (!numBits && n < (uint8_t)highWaves) {
+			if (!numBits && n < rfLen/fchigh) {
 				n=0;
 				lastval = dest[idx];
 				continue;
 			}
-			n = myround2(((float)n)/highWaves);  //-1 for fudge factor
+			n = (n * fchigh + rfLen/2) / rfLen;  //-1 for fudge factor
 		}
 		if (n == 0) n = 1;
 
@@ -695,11 +687,11 @@ size_t aggregate_bits(uint8_t *dest, size_t size, uint8_t rfLen, uint8_t maxCons
 	}//end for
 
 	// if valid extra bits at the end were all the same frequency - add them in
-	if (n > lowWaves && n > highWaves) {
+	if (n > rfLen/fclow && n > rfLen/fchigh) {
 		if (dest[idx-2]==1) {
-			n=myround2((float)(n+1)/((float)(rfLen)/(float)fclow));
-		} else {
-			n=myround2((float)(n+1)/((float)(rfLen-1)/(float)fchigh));  //-1 for fudge factor			
+			n = ((n+1) * fclow + rfLen/2) / rfLen;
+ 		} else {// 0->1 crossing
+			n = ((n+1) * fchigh + (rfLen-1)/2) / (rfLen-1);  //-1 for fudge factor
 		}
 		memset(dest, dest[idx-1]^invert , n);
 		numBits += n;


### PR DESCRIPTION
- added compiler options -fdata-sections and -ffunction-sections (thanks to iceman for the hint)
- removed float operations from common/lfdemod.c to avoid adding float libraries to the ARM os image
- moved the fpga images to the data section to avoid reserving unused space for a separate section