### PR TITLE
Iceman's fixes for #93, #96, #97

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2270,6 +2270,7 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 	if (_7BUID) {
 		rATQA[0] = 0x44;
 		rUIDBCC1[0] = 0x88;
+		rUIDBCC1[4] = rUIDBCC1[0] ^ rUIDBCC1[1] ^ rUIDBCC1[2] ^ rUIDBCC1[3];
 		rUIDBCC2[4] = rUIDBCC2[0] ^ rUIDBCC2[1] ^ rUIDBCC2[2] ^ rUIDBCC2[3];
 	}
 

--- a/client/scripting.c
+++ b/client/scripting.c
@@ -261,7 +261,7 @@ static int l_aes(lua_State *L)
 
     aes_context ctx;
     aes_init(&ctx);
-    aes_setkey_enc(&ctx,(const unsigned char *)p_key,128);
+    aes_setkey_dec(&ctx, aes_key, 128);
 	aes_crypt_cbc(&ctx,AES_DECRYPT,sizeof(indata), iv, indata,outdata );
     //Push decrypted array as a string
 	lua_pushlstring(L,(const char *)&outdata, sizeof(outdata));


### PR DESCRIPTION
mf sim 7 byte uid bug
identifying MF UL, UL-C, UL-EV1 differences
scripting aes bug.