### PR TITLE
Fix filenames for hf mf esave / eload

### DIFF
--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -1200,9 +1200,9 @@ int CmdHF14AMfELoad(const char *Cmd)
 
 	len = param_getstr(Cmd,nameParamNo,filename);
 	
-	if (len > FILE_PATH_SIZE) len = FILE_PATH_SIZE;
+	if (len > FILE_PATH_SIZE - 4) len = FILE_PATH_SIZE - 4;
 
-	fnameptr += len-4;
+	fnameptr += len;
 
 	sprintf(fnameptr, ".eml"); 
 	
@@ -1299,19 +1299,22 @@ int CmdHF14AMfESave(const char *Cmd)
 
 	len = param_getstr(Cmd,nameParamNo,filename);
 	
-	if (len > FILE_PATH_SIZE) len = FILE_PATH_SIZE;
+	if (len > FILE_PATH_SIZE - 4) len = FILE_PATH_SIZE - 4;
 	
 	// user supplied filename?
 	if (len < 1) {
 		// get filename (UID from memory)
 		if (mfEmlGetMem(buf, 0, 1)) {
 			PrintAndLog("Can\'t get UID from block: %d", 0);
-			sprintf(filename, "dump.eml"); 
+			len = sprintf(fnameptr, "dump");
+			fnameptr += len;
 		}
-		for (j = 0; j < 7; j++, fnameptr += 2)
-			sprintf(fnameptr, "%02X", buf[j]); 
+		else {
+			for (j = 0; j < 7; j++, fnameptr += 2)
+				sprintf(fnameptr, "%02X", buf[j]);
+		}
 	} else {
-		fnameptr += len-4;
+		fnameptr += len;
 	}
 
 	// add file extension


### PR DESCRIPTION
Since https://github.com/Proxmark/proxmark3/commit/e6432f05795ba0eaf1e34bb47b2a7f87a762de29, `hf mf esave` and `hf mf eload` have been broken. I think this PR fixes both of them, plus addresses an issue when `hf mf esave` was used without a providing a filename and the client was not able to get the UID (`else` missing).