### PR TITLE
ISO 14443 type B support for (German) electronic ID cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 
 ## [unreleased][unreleased]
 
+### Changed
+- EPA functions (`hf epa`) now support both ISO 14443-A and 14443-B cards (frederikmoellers)
 
 ## [2.2.0][2015-07-12]
 

--- a/armsrc/Makefile
+++ b/armsrc/Makefile
@@ -9,17 +9,17 @@
 APP_INCLUDES = apps.h
 
 #remove one of the following defines and comment out the relevant line
-#in the next section to remove that particular feature from compilation  
+#in the next section to remove that particular feature from compilation
 APP_CFLAGS	= -DWITH_LF -DWITH_ISO15693 -DWITH_ISO14443a -DWITH_ISO14443b -DWITH_ICLASS -DWITH_LEGICRF -DWITH_HITAG  -DWITH_CRC -DON_DEVICE \
 				-fno-strict-aliasing -ffunction-sections -fdata-sections
-#-DWITH_LCD 
+#-DWITH_LCD
 
 #SRC_LCD = fonts.c LCD.c
 SRC_LF = lfops.c hitag2.c lfsampling.c
 SRC_ISO15693 = iso15693.c iso15693tools.c
 SRC_ISO14443a = epa.c iso14443a.c mifareutil.c mifarecmd.c mifaresniff.c
 SRC_ISO14443b = iso14443b.c
-SRC_CRAPTO1 = crapto1.c crypto1.c des.c aes.c 
+SRC_CRAPTO1 = crapto1.c crypto1.c des.c aes.c
 SRC_CRC = iso14443crc.c crc.c crc16.c crc32.c
 
 #the FPGA bitstream files. Note: order matters!
@@ -65,7 +65,7 @@ ARMSRC = fpgaloader.c \
 # Do not move this inclusion before the definition of {THUMB,ASM,ARM}SRC
 include ../common/Makefile.common
 
-OBJS = $(OBJDIR)/fullimage.s19 
+OBJS = $(OBJDIR)/fullimage.s19
 FPGA_COMPRESSOR = ../client/fpga_compress
 
 all: $(OBJS)
@@ -80,13 +80,13 @@ $(OBJDIR)/fpga_all.bit.z: $(FPGA_BITSTREAMS) $(FPGA_COMPRESSOR)
 
 $(FPGA_COMPRESSOR):
 		make -C ../client $(notdir $(FPGA_COMPRESSOR))
-		
+
 $(OBJDIR)/fullimage.stage1.elf: $(VERSIONOBJ) $(OBJDIR)/fpga_all.o $(THUMBOBJ) $(ARMOBJ)
 	$(CC) $(LDFLAGS) -Wl,-T,ldscript,-Map,$(patsubst %.elf,%.map,$@) -o $@ $^ $(LIBS)
 
 $(OBJDIR)/fullimage.nodata.bin: $(OBJDIR)/fullimage.stage1.elf
 	$(OBJCOPY) -O binary -I elf32-littlearm --remove-section .data $^ $@
-	
+
 $(OBJDIR)/fullimage.nodata.o: $(OBJDIR)/fullimage.nodata.bin
 	$(OBJCOPY) -O elf32-littlearm -I binary -B arm --rename-section .data=stage1_image $^ $@
 
@@ -94,14 +94,14 @@ $(OBJDIR)/fullimage.data.bin: $(OBJDIR)/fullimage.stage1.elf
 	$(OBJCOPY) -O binary -I elf32-littlearm --only-section .data $^ $@
 
 $(OBJDIR)/fullimage.data.bin.z: $(OBJDIR)/fullimage.data.bin $(FPGA_COMPRESSOR)
-	$(FPGA_COMPRESSOR) $(filter %.bin,$^) $@  
-	
+	$(FPGA_COMPRESSOR) $(filter %.bin,$^) $@
+
 $(OBJDIR)/fullimage.data.o: $(OBJDIR)/fullimage.data.bin.z
 	$(OBJCOPY) -O elf32-littlearm -I binary -B arm --rename-section .data=compressed_data $^ $@
 
 $(OBJDIR)/fullimage.elf: $(OBJDIR)/fullimage.nodata.o $(OBJDIR)/fullimage.data.o
 	$(CC) $(LDFLAGS) -Wl,-T,ldscript,-Map,$(patsubst %.elf,%.map,$@) -o $@ $^
-	
+
 tarbin: $(OBJS)
 	$(TAR) $(TARFLAGS) ../proxmark3-$(platform)-bin.tar $(OBJS:%=armsrc/%) $(OBJS:%.s19=armsrc/%.elf)
 

--- a/armsrc/epa.c
+++ b/armsrc/epa.c
@@ -12,10 +12,11 @@
 //-----------------------------------------------------------------------------
 
 #include "iso14443a.h"
+#include "iso14443b.h"
 #include "epa.h"
 #include "cmd.h"
 
-// Protocol and Parameter Selection Request
+// Protocol and Parameter Selection Request for ISO 14443 type A cards
 // use regular (1x) speed in both directions
 // CRC is already included
 static const uint8_t pps[] = {0xD0, 0x11, 0x00, 0x52, 0xA6};
@@ -100,6 +101,28 @@ static struct {
 // lengths of the replay APDUs
 static uint8_t apdu_lengths_replay[5];
 
+// type of card (ISO 14443 A or B)
+static char iso_type = 0;
+
+//-----------------------------------------------------------------------------
+// Wrapper for sending APDUs to type A and B cards
+//-----------------------------------------------------------------------------
+int EPA_APDU(uint8_t *apdu, size_t length, uint8_t *response)
+{
+	switch(iso_type)
+	{
+		case 'a':
+			return iso14_apdu(apdu, (uint16_t) length, response);
+			break;
+		case 'b':
+			return iso14443b_apdu(apdu, length, response);
+			break;
+		default:
+			return 0;
+			break;
+	}
+}
+
 //-----------------------------------------------------------------------------
 // Closes the communication channel and turns off the field
 //-----------------------------------------------------------------------------
@@ -107,6 +130,7 @@ void EPA_Finish()
 {
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
 	LEDsoff();
+	iso_type = 0;
 }
 
 //-----------------------------------------------------------------------------
@@ -204,26 +228,26 @@ int EPA_Read_CardAccess(uint8_t *buffer, size_t max_length)
 	int rapdu_length = 0;
 
 	// select the file EF.CardAccess
-	rapdu_length = iso14_apdu((uint8_t *)apdu_select_binary_cardaccess,
+	rapdu_length = EPA_APDU((uint8_t *)apdu_select_binary_cardaccess,
 	                          sizeof(apdu_select_binary_cardaccess),
 	                          response_apdu);
-	if (rapdu_length != 6
+	if (rapdu_length < 6
 	    || response_apdu[rapdu_length - 4] != 0x90
 	    || response_apdu[rapdu_length - 3] != 0x00)
 	{
-		Dbprintf("epa - no select cardaccess");
+		DbpString("Failed to select EF.CardAccess!");
 		return -1;
 	}
 
 	// read the file
-	rapdu_length = iso14_apdu((uint8_t *)apdu_read_binary,
+	rapdu_length = EPA_APDU((uint8_t *)apdu_read_binary,
 	                          sizeof(apdu_read_binary),
 	                          response_apdu);
 	if (rapdu_length <= 6
 	    || response_apdu[rapdu_length - 4] != 0x90
 	    || response_apdu[rapdu_length - 3] != 0x00)
 	{
-		Dbprintf("epa - no read cardaccess");
+		Dbprintf("Failed to read EF.CardAccess!");
 		return -1;
 	}
 
@@ -338,7 +362,7 @@ int EPA_PACE_Get_Nonce(uint8_t requested_length, uint8_t *nonce)
 
 	// send it
 	uint8_t response_apdu[262];
-	int send_return = iso14_apdu(apdu,
+	int send_return = EPA_APDU(apdu,
 	                             sizeof(apdu),
 	                             response_apdu);
 	// check if the command succeeded
@@ -409,7 +433,7 @@ int EPA_PACE_MSE_Set_AT(pace_version_info_t pace_version_info, uint8_t password)
 	apdu[4] = apdu_length - 5;
 	// send it
 	uint8_t response_apdu[6];
-	int send_return = iso14_apdu(apdu,
+	int send_return = EPA_APDU(apdu,
 	                             apdu_length,
 	                             response_apdu);
 	// check if the command succeeded
@@ -460,16 +484,13 @@ void EPA_PACE_Replay(UsbCommand *c)
 		return;
 	}
 
-	// increase the timeout (at least some cards really do need this!)/////////////
-	// iso14a_set_timeout(0x0003FFFF);
-
 	// response APDU
 	uint8_t response_apdu[300] = {0};
 
 	// now replay the data and measure the timings
 	for (int i = 0; i < sizeof(apdu_lengths_replay); i++) {
 		StartCountUS();
-		func_return = iso14_apdu(apdus_replay[i].data,
+		func_return = EPA_APDU(apdus_replay[i].data,
 		                         apdu_lengths_replay[i],
 		                         response_apdu);
 		timings[i] = GetCountUS();
@@ -501,18 +522,33 @@ int EPA_Setup()
 	uint8_t pps_response_par[1];
 	iso14a_card_select_t card_select_info;
 
+	// first, look for type A cards
 	// power up the field
 	iso14443a_setup(FPGA_HF_ISO14443A_READER_MOD);
 	// select the card
 	return_code = iso14443a_select_card(uid, &card_select_info, NULL);
-	if (return_code != 1) {
-		return 1;
+	if (return_code == 1) {
+		// send the PPS request
+		ReaderTransmit((uint8_t *)pps, sizeof(pps), NULL);
+		return_code = ReaderReceive(pps_response, pps_response_par);
+		if (return_code != 3 || pps_response[0] != 0xD0) {
+			return return_code == 0 ? 2 : return_code;
+		}
+		Dbprintf("ISO 14443 Type A");
+		iso_type = 'a';
+		return 0;
 	}
-	// send the PPS request
-	ReaderTransmit((uint8_t *)pps, sizeof(pps), NULL);
-	return_code = ReaderReceive(pps_response, pps_response_par);
-	if (return_code != 3 || pps_response[0] != 0xD0) {
-		return return_code == 0 ? 2 : return_code;
+
+	// if we're here, there is no type A card, so we look for type B
+	// power up the field
+	iso14443b_setup();
+	// select the card
+	return_code = iso14443b_select_card();
+	if (return_code == 1) {
+		Dbprintf("ISO 14443 Type B");
+		iso_type = 'b';
+		return 0;
 	}
-	return 0;
+	Dbprintf("No card found.");
+	return 1;
 }

--- a/armsrc/epa.h
+++ b/armsrc/epa.h
@@ -19,7 +19,7 @@ typedef struct {
 	uint8_t parameter_id;
 } pace_version_info_t;
 
-// note: EPA_PACE_Collect_Nonce is declared in apps.h
+// note: EPA_PACE_Collect_Nonce and EPA_PACE_Replay are declared in apps.h
 
 // general functions
 void EPA_Finish();

--- a/armsrc/iso14443b.c
+++ b/armsrc/iso14443b.c
@@ -311,7 +311,7 @@ static int GetIso14443bCommandFromReader(uint8_t *received, uint16_t *len)
 			}
 		}
 	}
-	
+
 	return FALSE;
 }
 
@@ -353,7 +353,7 @@ void SimulateIso14443bTag(void)
 	// prepare the (only one) tag answer:
 	CodeIso14443bAsTag(response1, sizeof(response1));
 	uint8_t *resp1Code = BigBuf_malloc(ToSendMax);
-	memcpy(resp1Code, ToSend, ToSendMax); 
+	memcpy(resp1Code, ToSend, ToSendMax);
 	uint16_t resp1CodeLen = ToSendMax;
 
 	// We need to listen to the high-frequency, peak-detected path.
@@ -377,9 +377,9 @@ void SimulateIso14443bTag(void)
 		// Good, look at the command now.
 		if ( (len == sizeof(cmd1) && memcmp(receivedCmd, cmd1, len) == 0)
 			|| (len == sizeof(cmd2) && memcmp(receivedCmd, cmd2, len) == 0) ) {
-			resp = response1; 
+			resp = response1;
 			respLen = sizeof(response1);
-			respCode = resp1Code; 
+			respCode = resp1Code;
 			respCodeLen = resp1CodeLen;
 		} else {
 			Dbprintf("new cmd from reader: len=%d, cmdsRecvd=%d", len, cmdsRecvd);
@@ -429,13 +429,13 @@ void SimulateIso14443bTag(void)
 				(void)b;
 			}
 		}
-		
+
 		// trace the response:
 		if (tracing) {
 			uint8_t parity[MAX_PARITY_SIZE];
 			LogTrace(resp, respLen, 0, 0, parity, FALSE);
 		}
-			
+
 	}
 }
 
@@ -513,7 +513,7 @@ static RAMFUNC int Handle14443bSamplesDemod(int ci, int cq)
 		} else { \
 			v -= cq; \
 		} \
-	}		
+	}
  */
 // Subcarrier amplitude v = sqrt(ci^2 + cq^2), approximated here by max(abs(ci),abs(cq)) + 1/2*min(abs(ci),abs(cq)))
 #define CHECK_FOR_SUBCARRIER() { \
@@ -547,7 +547,7 @@ static RAMFUNC int Handle14443bSamplesDemod(int ci, int cq)
 			} \
 		} \
 	}
-	
+
 	switch(Demod.state) {
 		case DEMOD_UNSYNCD:
 			CHECK_FOR_SUBCARRIER();
@@ -645,7 +645,7 @@ static RAMFUNC int Handle14443bSamplesDemod(int ci, int cq)
 					Demod.metric -= Demod.thisBit;
 				}
 				(Demod.metricN)++;
-*/				
+*/
 
 				Demod.shiftReg >>= 1;
 				if(Demod.thisBit > 0) {	// logic '1'
@@ -713,10 +713,10 @@ static void GetSamplesFor14443bDemod(int n, bool quiet)
 	// Allocate memory from BigBuf for some buffers
 	// free all previous allocations first
 	BigBuf_free();
-	
+
 	// The response (tag -> reader) that we're receiving.
 	uint8_t *receivedResponse = BigBuf_malloc(MAX_FRAME_SIZE);
-	
+
 	// The DMA buffer, used to stream samples from the FPGA
 	int8_t *dmaBuf = (int8_t*) BigBuf_malloc(ISO14443B_DMA_BUFFER_SIZE);
 
@@ -1090,7 +1090,7 @@ void RAMFUNC SnoopIso14443b(void)
 
 	bool TagIsActive = FALSE;
 	bool ReaderIsActive = FALSE;
-	
+
 	// And now we loop, receiving samples.
 	for(;;) {
 		int behindBy = (lastRxCounter - AT91C_BASE_PDC_SSC->PDC_RCR) &
@@ -1201,7 +1201,7 @@ void SendRawCommand14443B(uint32_t datalen, uint32_t recv, uint8_t powerfield, u
 	FpgaSetupSsc();
 
 	set_tracing(TRUE);
-	
+
 	CodeAndTransmit14443bAsReader(data, datalen);
 
 	if(recv) {
@@ -1209,7 +1209,7 @@ void SendRawCommand14443B(uint32_t datalen, uint32_t recv, uint8_t powerfield, u
 		uint16_t iLen = MIN(Demod.len, USB_CMD_DATA_SIZE);
 		cmd_send(CMD_ACK, iLen, 0, 0, Demod.output, iLen);
 	}
-	
+
 	if(!powerfield) {
 		FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
 		LED_D_OFF();

--- a/armsrc/iso14443b.h
+++ b/armsrc/iso14443b.h
@@ -1,0 +1,21 @@
+//-----------------------------------------------------------------------------
+// Merlok - June 2011
+// Gerhard de Koning Gans - May 2008
+// Hagen Fritsch - June 2010
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// Routines to support ISO 14443 type A.
+//-----------------------------------------------------------------------------
+
+#ifndef __ISO14443B_H
+#define __ISO14443B_H
+#include "common.h"
+
+int iso14443b_apdu(uint8_t const *message, size_t message_length, uint8_t *response);
+void iso14443b_setup();
+int iso14443b_select_card();
+
+#endif /* __ISO14443B_H */


### PR DESCRIPTION
This adds 2 new functions to iso14443b.c: iso14443b_setup and iso14443b_apdu which perform tasks similar to their counterparts in iso14443a.c. On the long run this should facilitate building functionality that is type-independent (i.e. supports both A and B tags).
As a first implementation, the functionality related to the German ID card (epa.c) has been updated to support both types.
Experiments so far show that both types work fine and can be used for the same tasks.