### PR TITLE
AWID26 Extended Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 
 ## [unreleased][unreleased]
 
+### Added
+- AWID26 command context added as 'lf awid' containing realtime demodulation as well as cloning/simulation based on tag numbers (Craig Young)
+
 ### Changed
 - EPA functions (`hf epa`) now support both ISO 14443-A and 14443-B cards (frederikmoellers)
 

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -681,6 +681,9 @@ void UsbPacketReceived(uint8_t *packet, int len)
 		case CMD_EM4X_WRITE_WORD:
 			EM4xWriteWord(c->arg[0], c->arg[1], c->arg[2], c->d.asBytes[0]);
 			break;
+		case CMD_AWID_DEMOD_FSK: // Set realtime AWID demodulation
+			CmdAWIDdemodFSK(c->arg[0], 0, 0, 1);
+                        break;
 #endif
 
 #ifdef WITH_HITAG

--- a/armsrc/apps.h
+++ b/armsrc/apps.h
@@ -69,6 +69,7 @@ void CmdFSKsimTAG(uint16_t arg1, uint16_t arg2, size_t size, uint8_t *BitStream)
 void CmdASKsimTag(uint16_t arg1, uint16_t arg2, size_t size, uint8_t *BitStream);
 void CmdPSKsimTag(uint16_t arg1, uint16_t arg2, size_t size, uint8_t *BitStream);
 void CmdHIDdemodFSK(int findone, int *high, int *low, int ledcontrol);
+void CmdAWIDdemodFSK(int findone, int *high, int *low, int ledcontrol); // Realtime demodulation mode for AWID26
 void CmdEM410xdemod(int findone, int *high, int *low, int ledcontrol);
 void CmdIOdemodFSK(int findone, int *high, int *low, int ledcontrol);
 void CopyIOtoT55x7(uint32_t hi, uint32_t lo, uint8_t longFMT); // Clone an ioProx card to T5557/T5567

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -399,10 +399,14 @@ void SimulateTagLowFrequency(int period, int gap, int ledcontrol)
  #define OPEN_COIL()		HIGH(GPIO_SSC_DOUT)
 
 	i = 0;
+	byte_t rx[sizeof(UsbCommand)]; // Storage for usb_read call in loop
 	for(;;) {
 		//wait until SSC_CLK goes HIGH
 		while(!(AT91C_BASE_PIOA->PIO_PDSR & GPIO_SSC_CLK)) {
-			if(BUTTON_PRESS() || usb_poll()) {
+			// Craig Young - Adding a usb_read() here to avoid abort on empty UsbCommand
+			// My OS X client does this preventing simulation.
+			// Performance hit should be non-existent since the read is only performed if usb_poll is true
+			if(BUTTON_PRESS() || (usb_poll() && usb_read(rx,sizeof(UsbCommand)))) {
 				DbpString("Stopped");
 				return;
 			}
@@ -835,6 +839,96 @@ void CmdHIDdemodFSK(int findone, int *high, int *low, int ledcontrol)
 			// reset
 		}
 		hi2 = hi = lo = idx = 0;
+		WDT_HIT();
+	}
+	DbpString("Stopped");
+	if (ledcontrol) LED_A_OFF();
+}
+
+// loop to get raw HID waveform then FSK demodulate the TAG ID from it
+void CmdAWIDdemodFSK(int findone, int *high, int *low, int ledcontrol)
+{
+	uint8_t *dest = BigBuf_get_addr();
+	//const size_t sizeOfBigBuff = BigBuf_max_traceLen();
+	size_t size; 
+	int idx=0;
+	// Configure to go in 125Khz listen mode
+	LFSetupFPGAForADC(95, true);
+
+	while(!BUTTON_PRESS()) {
+
+		WDT_HIT();
+		if (ledcontrol) LED_A_ON();
+
+		DoAcquisition_default(-1,true);
+		// FSK demodulator
+		//size = sizeOfBigBuff;  //variable size will change after demod so re initialize it before use
+		size = 50*128*2; //big enough to catch 2 sequences of largest format
+		idx = AWIDdemodFSK(dest, &size);
+		
+		if (idx>0 && size==96){
+	        // Index map
+	        // 0            10            20            30              40            50              60
+	        // |            |             |             |               |             |               |
+	        // 01234567 890 1 234 5 678 9 012 3 456 7 890 1 234 5 678 9 012 3 456 7 890 1 234 5 678 9 012 3 - to 96
+	        // -----------------------------------------------------------------------------
+	        // 00000001 000 1 110 1 101 1 011 1 101 1 010 0 000 1 000 1 010 0 001 0 110 1 100 0 000 1 000 1
+	        // premable bbb o bbb o bbw o fff o fff o ffc o ccc o ccc o ccc o ccc o ccc o wxx o xxx o xxx o - to 96
+	        //          |---26 bit---|    |-----117----||-------------142-------------|
+	        // b = format bit len, o = odd parity of last 3 bits
+	        // f = facility code, c = card number
+	        // w = wiegand parity
+	        // (26 bit format shown)
+
+	        //get raw ID before removing parities
+	        uint32_t rawLo = bytebits_to_byte(dest+idx+64,32);
+	        uint32_t rawHi = bytebits_to_byte(dest+idx+32,32);
+	        uint32_t rawHi2 = bytebits_to_byte(dest+idx,32);
+
+	        size = removeParity(dest, idx+8, 4, 1, 88);
+	        // ok valid card found!
+
+	        // Index map
+	        // 0           10         20        30          40        50        60
+	        // |           |          |         |           |         |         |
+	        // 01234567 8 90123456 7890123456789012 3 456789012345678901234567890123456
+	        // -----------------------------------------------------------------------------
+	        // 00011010 1 01110101 0000000010001110 1 000000000000000000000000000000000
+	        // bbbbbbbb w ffffffff cccccccccccccccc w xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+	        // |26 bit|   |-117--| |-----142------|
+	        // b = format bit len, o = odd parity of last 3 bits
+	        // f = facility code, c = card number
+	        // w = wiegand parity
+	        // (26 bit format shown)
+
+	        uint32_t fc = 0;
+	        uint32_t cardnum = 0;
+	        uint32_t code1 = 0;
+	        uint32_t code2 = 0;
+	        uint8_t fmtLen = bytebits_to_byte(dest,8);
+	        if (fmtLen==26){
+	                fc = bytebits_to_byte(dest+9, 8);
+	                cardnum = bytebits_to_byte(dest+17, 16);
+	                code1 = bytebits_to_byte(dest+8,fmtLen);
+	                Dbprintf("AWID Found - BitLength: %d, FC: %d, Card: %d - Wiegand: %x, Raw: %08x%08x%08x", fmtLen, fc, cardnum, code1, rawHi2, rawHi, rawLo);
+	        } else {
+	                cardnum = bytebits_to_byte(dest+8+(fmtLen-17), 16);
+	                if (fmtLen>32){
+                        code1 = bytebits_to_byte(dest+8,fmtLen-32);
+                        code2 = bytebits_to_byte(dest+8+(fmtLen-32),32);
+                        Dbprintf("AWID Found - BitLength: %d -unknown BitLength- (%d) - Wiegand: %x%08x, Raw: %08x%08x%08x", fmtLen, cardnum, code1, code2, rawHi2, rawHi, rawLo);
+                } else{
+                        code1 = bytebits_to_byte(dest+8,fmtLen);
+                        Dbprintf("AWID Found - BitLength: %d -unknown BitLength- (%d) - Wiegand: %x, Raw: %08x%08x%08x", fmtLen, cardnum, code1, rawHi2, rawHi, rawLo);
+                }
+			}
+			if (findone){
+				if (ledcontrol)	LED_A_OFF();
+				return;
+			}
+			// reset
+		}
+		idx = 0;
 		WDT_HIT();
 	}
 	DbpString("Stopped");

--- a/client/Makefile
+++ b/client/Makefile
@@ -89,6 +89,7 @@ CMDSRCS = 	nonce2key/crapto1.c\
 			cmdlf.c \
 			cmdlfio.c \
 			cmdlfhid.c \
+			cmdlfawid.c \
 			cmdlfem4x.c \
 			cmdlfhitag.c \
 			cmdlfti.c \

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -22,6 +22,7 @@
 #include "util.h"
 #include "cmdlf.h"
 #include "cmdlfhid.h"
+#include "cmdlfawid.h"
 #include "cmdlfti.h"
 #include "cmdlfem4x.h"
 #include "cmdlfhitag.h"
@@ -1130,6 +1131,7 @@ static command_t CommandTable[] =
 	{"config",      CmdLFSetConfig,     0, "Set config for LF sampling, bit/sample, decimation, frequency"},
 	{"flexdemod",   CmdFlexdemod,       1, "Demodulate samples for FlexPass"},
 	{"hid",         CmdLFHID,           1, "{ HID RFIDs... }"},
+	{"awid",		CmdLFAWID,		    1, "{ AWID RFIDs... }"},
 	{"io",       	  CmdLFIO,	          1, "{ ioProx tags... }"},
 	{"indalademod", CmdIndalaDemod,     1, "['224'] -- Demodulate samples for Indala 64 bit UID (option '224' for 224 bit)"},
 	{"indalaclone", CmdIndalaClone,     0, "<UID> ['l']-- Clone Indala to T55x7 (tag must be in antenna)(UID in HEX)(option 'l' for 224 UID"},

--- a/client/cmdlfawid.c
+++ b/client/cmdlfawid.c
@@ -19,10 +19,54 @@
 
 static int CmdHelp(const char *Cmd);
 
+
+int usage_lf_awid_fskdemod(void) {
+  PrintAndLog("Enables AWID26 compatible reader mode printing details of scanned AWID26 tags.");
+  PrintAndLog("By default, values are printed and logged until the button is pressed or another USB command is issued.");
+  PrintAndLog("If the ['1'] option is provided, reader mode is exited after reading a single AWID26 card.");
+  PrintAndLog("");
+  PrintAndLog("Usage:  lf awid fskdemod ['1']");
+  PrintAndLog("  Options : ");
+  PrintAndLog("  1 : (optional) stop after reading a single card");
+  PrintAndLog("");
+  PrintAndLog("   sample : lf awid fskdemod");
+  PrintAndLog("          : lf awid fskdemod 1");
+  return 0;
+}
+
+int usage_lf_awid_sim(void) {
+  PrintAndLog("Enables simulation of AWID26 card with specified facility-code and card number.");
+  PrintAndLog("Simulation runs until the button is pressed or another USB command is issued.");
+  PrintAndLog("Per AWID26 format, the facility-code is 8-bit and the card number is 16-bit.  Larger values are truncated.");
+  PrintAndLog("");
+  PrintAndLog("Usage:  lf awid sim <Facility-Code> <Card-Number>");
+  PrintAndLog("  Options : ");
+  PrintAndLog("  <Facility-Code> : 8-bit value representing the AWID facility code");
+  PrintAndLog("  <Card Number>   : 16-bit value representing the AWID card number");
+  PrintAndLog("");
+  PrintAndLog("   sample : lf awid sim 224 1337");
+  return 0;
+}
+
+int usage_lf_awid_clone(void) {
+  PrintAndLog("Enables cloning of AWID26 card with specified facility-code and card number onto T55x7.");
+  PrintAndLog("The T55x7 must be on the antenna when issuing this command.  T55x7 blocks are calculated and printed in the process.");
+  PrintAndLog("Per AWID26 format, the facility-code is 8-bit and the card number is 16-bit.  Larger values are truncated.");
+  PrintAndLog("");
+  PrintAndLog("Usage:  lf awid clone <Facility-Code> <Card-Number>");
+  PrintAndLog("  Options : ");
+  PrintAndLog("  <Facility-Code> : 8-bit value representing the AWID facility code");
+  PrintAndLog("  <Card Number>   : 16-bit value representing the AWID card number");
+  PrintAndLog("");
+  PrintAndLog("   sample : lf awid clone 224 1337");
+  return 0;
+}
+
 int CmdAWIDDemodFSK(const char *Cmd)
 {
   int findone=0;
-        if(Cmd[0]=='1') findone=1;
+  if(Cmd[0]=='1') findone=1;
+  if (Cmd[0]=='h' || Cmd[0] == 'H') return usage_lf_awid_fskdemod();
   UsbCommand c={CMD_AWID_DEMOD_FSK};
   c.arg[0]=findone;
   SendCommand(&c);
@@ -98,8 +142,7 @@ int CmdAWIDSim(const char *Cmd)
   uint64_t arg2 = 50; // clk RF/50 invert=0
   BS = BitStream;
   if (sscanf(Cmd, "%u %u", &fc, &cn ) != 2) {
-    PrintAndLog("Usage: lf awid sim <facility-code> <card number>");
-    return 0;
+    return usage_lf_awid_sim();
   }
 
   fcode=(fc & 0x000000FF);
@@ -137,8 +180,7 @@ int CmdAWIDClone(const char *Cmd)
   
 
   if (sscanf(Cmd, "%u %u", &fc, &cn ) != 2) {
-    PrintAndLog("Usage: lf awid clone <facility-code> <card number>");
-    return 0;
+    return usage_lf_awid_clone();
   }
 
   if ((fc & 0xFF) != fc) {

--- a/client/cmdlfawid.c
+++ b/client/cmdlfawid.c
@@ -1,0 +1,191 @@
+//-----------------------------------------------------------------------------
+// Authored by Craig Young <cyoung@tripwire.com> based on cmdlfhid.c structure
+//
+// cmdlfhid.c is Copyright (C) 2010 iZsh <izsh at fail0verflow.com>
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// Low frequency AWID26 commands
+//-----------------------------------------------------------------------------
+
+#include <stdio.h>      // sscanf
+#include "proxmark3.h"  // Definitions, USB controls, etc
+#include "ui.h"         // PrintAndLog
+#include "cmdparser.h"  // CmdsParse, CmdsHelp
+#include "cmdlfawid.h"  // AWID function declarations
+#include "lfdemod.h"    // parityTest
+
+static int CmdHelp(const char *Cmd);
+
+int CmdAWIDDemodFSK(const char *Cmd)
+{
+  int findone=0;
+        if(Cmd[0]=='1') findone=1;
+  UsbCommand c={CMD_AWID_DEMOD_FSK};
+  c.arg[0]=findone;
+  SendCommand(&c);
+  return 0;   
+}
+
+int getAWIDBits(unsigned int fc, unsigned int cn, uint8_t *AWIDBits)
+{
+  int i;
+  uint32_t fcode=(fc & 0x000000FF), cnum=(cn & 0x0000FFFF), uBits=0;
+  if (fcode != fc)
+    PrintAndLog("NOTE: Facility code truncated for AWID26 format (8-bit facility code)");
+  if (cnum!=cn)
+    PrintAndLog("NOTE: Card number was truncated for AWID26 format (16-bit card number)");
+
+  AWIDBits[0] = 0x01; // 6-bit Preamble with 2 parity bits
+  AWIDBits[1] = 0x1D; // First byte from card format (26-bit) plus parity bits
+  AWIDBits[2] = 0x80; // Set the next two bits as 0b10 to finish card format
+  uBits = (fcode<<4) + (cnum>>12);
+  if (!parityTest(uBits,12,0))
+    AWIDBits[2] |= (1<<5); // If not already even parity, set bit to make even
+  uBits = AWIDBits[2]>>5;
+  if (!parityTest(uBits, 3, 1))
+    AWIDBits[2] |= (1<<4);
+  uBits = fcode>>5; // first 3 bits of facility-code
+  AWIDBits[2] += (uBits<<1);
+  if (!parityTest(uBits, 3, 1))
+    AWIDBits[2]++; // Set parity bit to make odd parity
+  uBits = (fcode & 0x1C)>>2;
+  AWIDBits[3] = 0;
+  if (!parityTest(uBits,3,1))
+    AWIDBits[3] |= (1<<4);
+  AWIDBits[3] += (uBits<<5);
+  uBits = ((fcode & 0x3)<<1) + ((cnum & 0x8000)>>15); // Grab/shift 2 LSBs from facility code and add shifted MSB from cardnum
+  if (!parityTest(uBits,3,1))
+    AWIDBits[3]++; // Set LSB for parity
+  AWIDBits[3]+= (uBits<<1);
+  uBits = (cnum & 0x7000)>>12;
+  AWIDBits[4] = uBits<<5;
+  if (!parityTest(uBits,3,1))
+    AWIDBits[4] |= (1<<4);
+  uBits = (cnum & 0x0E00)>>9;
+  AWIDBits[4] += (uBits<<1);
+  if (!parityTest(uBits,3,1))
+    AWIDBits[4]++; // Set LSB for parity
+  uBits = (cnum & 0x1C0)>>6; // Next bits from card number
+  AWIDBits[5]=(uBits<<5);
+  if (!parityTest(uBits,3,1))
+    AWIDBits[5] |= (1<<4); // Set odd parity bit as needed
+  uBits = (cnum & 0x38)>>3;
+  AWIDBits[5]+= (uBits<<1);
+  if (!parityTest(uBits,3,1))
+    AWIDBits[5]++; // Set odd parity bit as needed
+  uBits = (cnum & 0x7); // Last three bits from card number!
+  AWIDBits[6] = (uBits<<5);
+  if (!parityTest(uBits,3,1))
+    AWIDBits[6] |= (1<<4);
+  uBits = (cnum & 0x0FFF);
+  if (!parityTest(uBits,12,1))
+    AWIDBits[6] |= (1<<3);
+  else
+    AWIDBits[6]++;
+  for (i = 7; i<12; i++)
+    AWIDBits[i]=0x11;
+  return 1;
+}
+
+int CmdAWIDSim(const char *Cmd)
+{
+  uint32_t fcode = 0, cnum = 0, fc=0, cn=0, i=0;
+  uint8_t *BS, BitStream[12];
+  uint64_t arg1 = (10<<8) + 8; // fcHigh = 10, fcLow = 8
+  uint64_t arg2 = 50; // clk RF/50 invert=0
+  BS = BitStream;
+  if (sscanf(Cmd, "%u %u", &fc, &cn ) != 2) {
+    PrintAndLog("Usage: lf awid sim <facility-code> <card number>");
+    return 0;
+  }
+
+  fcode=(fc & 0x000000FF);
+  cnum=(cn & 0x0000FFFF);
+  if (fc!=fcode)
+    PrintAndLog("Facility-Code (%u) truncated to 8-bits: %u",fc,fcode);
+  if (cn!=cnum)
+    PrintAndLog("Card number (%u) truncated to 16-bits: %u",cn,cnum);
+  PrintAndLog("Emulating AWID26 -- FC: %u; CN: %u\n",fcode,cnum);
+  PrintAndLog("Press pm3-button to abort simulation or run another command");
+  // AWID uses: fcHigh: 10, fcLow: 8, clk: 50, invert: 0
+  if (getAWIDBits(fc, cn, BS)) {
+      PrintAndLog("Running 'lf simfsk c 50 H 10 L 8 d %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x'", 
+                                        BS[0],BS[1],BS[2],BS[3],BS[4],BS[5],BS[6],
+                                        BS[7],BS[8],BS[9],BS[10],BS[11]);
+    } else
+      PrintAndLog("Error with tag bitstream generation.");
+  UsbCommand c;
+  c.cmd = CMD_FSK_SIM_TAG;
+  c.arg[0] = arg1; // fcHigh<<8 + fcLow
+  c.arg[1] = arg2; // Inversion and clk setting
+  c.arg[2] = 96; // Bitstream length: 96-bits == 12 bytes
+  for (i=0; i < 96; i++)
+    c.d.asBytes[i] = (BS[i/8] & (1<<(7-(i%8))))?1:0;
+  SendCommand(&c);
+  return 0;
+}
+
+int CmdAWIDClone(const char *Cmd)
+{
+  uint32_t fc=0,cn=0,blocks[4] = {0x00107060, 0, 0, 0x11111111}, i=0;
+  uint8_t BitStream[12];
+  uint8_t *BS=BitStream;
+  UsbCommand c;
+  
+
+  if (sscanf(Cmd, "%u %u", &fc, &cn ) != 2) {
+    PrintAndLog("Usage: lf awid clone <facility-code> <card number>");
+    return 0;
+  }
+
+  if ((fc & 0xFF) != fc) {
+    fc &= 0xFF;
+    PrintAndLog("Facility-Code Truncated to 8-bits (AWID26): %u", fc);
+  }
+  if ((cn & 0xFFFF) != cn) {
+    cn &= 0xFFFF;
+    PrintAndLog("Card Number Truncated to 16-bits (AWID26): %u", cn);
+  }
+  if (getAWIDBits(fc,cn,BS)) {
+    PrintAndLog("Preparing to clone AWID26 to T55x7 with FC: %u, CN: %u (Raw: %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x)", 
+                  fc,cn, BS[0],BS[1],BS[2],BS[3],BS[4],BS[5],BS[6],BS[7],BS[8],BS[9],BS[10],BS[11]);
+    blocks[1] = (BS[0]<<24) + (BS[1]<<16) + (BS[2]<<8) + (BS[3]);
+    blocks[2] = (BS[4]<<24) + (BS[5]<<16) + (BS[6]<<8) + (BS[7]);
+    PrintAndLog("Block 0: 0x%08x", blocks[0]);
+    PrintAndLog("Block 1: 0x%08x", blocks[1]);
+    PrintAndLog("Block 2: 0x%08x", blocks[2]);
+    PrintAndLog("Block 3: 0x%08x", blocks[3]);
+    for (i=0; i<4; i++) {
+      c.cmd = CMD_T55XX_WRITE_BLOCK;
+      c.arg[0] = blocks[i];
+      c.arg[1] = i;
+      c.arg[2] = 0;
+      SendCommand(&c);
+    }
+  }
+  return 0;
+}
+
+static command_t CommandTable[] = 
+{
+  {"help",      CmdHelp,        1, "This help"},
+  {"fskdemod",  CmdAWIDDemodFSK, 0, "['1'] Realtime AWID FSK demodulator (option '1' for one tag only)"},
+  {"sim",       CmdAWIDSim,      0, "<Facility-Code> <Card Number> -- AWID tag simulator"},
+  {"clone",     CmdAWIDClone,    0, "<Facility-Code> <Card Number> -- Clone AWID to T55x7 (tag must be in range of antenna)"},
+  {NULL, NULL, 0, NULL}
+};
+
+int CmdLFAWID(const char *Cmd)
+{
+  CmdsParse(CommandTable, Cmd);
+  return 0;
+}
+
+int CmdHelp(const char *Cmd)
+{
+  CmdsHelp(CommandTable);
+  return 0;
+}

--- a/client/cmdlfawid.h
+++ b/client/cmdlfawid.h
@@ -1,0 +1,21 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) 2010 iZsh <izsh at fail0verflow.com>
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// Low frequency AWID commands
+//-----------------------------------------------------------------------------
+
+#ifndef CMDLFAWID_H__
+#define CMDLFAWID_H__
+
+int CmdLFAWID(const char *Cmd);
+//int CmdAWIDDemod(const char *Cmd);
+int CmdAWIDDemodFSK(const char *Cmd);
+int CmdAWIDSim(const char *Cmd);
+int CmdAWIDClone(const char *Cmd);
+int getAWIDBits(unsigned int fc, unsigned int cn, uint8_t *AWIDBits);
+
+#endif

--- a/client/cmdlfawid.h
+++ b/client/cmdlfawid.h
@@ -17,5 +17,8 @@ int CmdAWIDDemodFSK(const char *Cmd);
 int CmdAWIDSim(const char *Cmd);
 int CmdAWIDClone(const char *Cmd);
 int getAWIDBits(unsigned int fc, unsigned int cn, uint8_t *AWIDBits);
+int usage_lf_awid_fskdemod(void);
+int usage_lf_awid_clone(void);
+int usage_lf_awid_sim(void);
 
 #endif

--- a/client/hid-flasher/usb_cmd.h
+++ b/client/hid-flasher/usb_cmd.h
@@ -84,6 +84,7 @@ typedef struct {
 #define CMD_FSK_SIM_TAG                                                   0x021E
 #define CMD_ASK_SIM_TAG                                                   0x021F
 #define CMD_PSK_SIM_TAG                                                   0x0220
+#define CMD_AWID_DEMOD_FSK                                                0x0221
 
 /* CMD_SET_ADC_MUX: ext1 is 0 for lopkd, 1 for loraw, 2 for hipkd, 3 for hiraw */
 

--- a/client/lualibs/commands.lua
+++ b/client/lualibs/commands.lua
@@ -54,6 +54,7 @@ local _commands = {
 	CMD_FSK_SIM_TAG =                                                    0x021E,
 	CMD_ASK_SIM_TAG =                                                    0x021F,
 	CMD_PSK_SIM_TAG =                                                    0x0220,
+	CMD_AWID_DEMOD_FSK =                                                 0x0221,
 
 	--/* CMD_SET_ADC_MUX: ext1 is 0 for lopkd, 1 for loraw, 2 for hipkd, 3 for hiraw */
 

--- a/include/usb_cmd.h
+++ b/include/usb_cmd.h
@@ -95,6 +95,7 @@ typedef struct{
 #define CMD_FSK_SIM_TAG                                                   0x021E
 #define CMD_ASK_SIM_TAG                                                   0x021F
 #define CMD_PSK_SIM_TAG                                                   0x0220
+#define CMD_AWID_DEMOD_FSK                                                0x0221
 
 /* CMD_SET_ADC_MUX: ext1 is 0 for lopkd, 1 for loraw, 2 for hipkd, 3 for hiraw */
 


### PR DESCRIPTION
These changes build upon Marshmellow's AWID demodulation function by adding the 'lf awid' conext for working with AWID26 format tags.  The main advantage of this command context is that it allows one to simulate or clone an AWID26 tag based on the facility code and card number typically printed on the card without needing to manually calculate the tag's raw bitstream.