### PR TITLE
14b additions + some bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [Unreleased][unreleased]
 
 ### Changed
-- Changed lf config's `threshold` to a graph (signed) metric and it will trigger on + or - value set to. (example: set to 50 and recording would begin at first graphed value of >= 50 or <= -50) (marshmellow)
+- Added `hf 14b raw -s` option to auto select a 14b std tag before raw command 
 - Changed `hf 14b write` to `hf 14b sriwrite` as it only applied to sri tags (marshmellow)
-- Added `hf 14b reader` to `hf search` (marshmellow)
+- Added `hf 14b info` to `hf search` (marshmellow)
 
 ### Added
-- Add `hf 14b reader` to find and print general info about known 14b tags (marshmellow)
-- Add `hf 14b info` to find and print full info about std 14b tags and sri tags (using 14b raw commands in the client)  (marshmellow)
+- Add `hf 14b info` to find and print info about std 14b tags and sri tags (using 14b raw commands in the client)  (marshmellow)
 - Add PACE replay functionality (frederikmoellers)
 
 ### Fixed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [Unreleased][unreleased]
 
 ### Changed
+- Changed lf config's `threshold` to a graph (signed) metric and it will trigger on + or - value set to. (example: set to 50 and recording would begin at first graphed value of >= 50 or <= -50) (marshmellow)
 - Changed `hf 14b write` to `hf 14b sriwrite` as it only applied to sri tags (marshmellow)
-- Added `hf 14b info` to `hf search` (marshmellow)
+- Added `hf 14b reader` to `hf search` (marshmellow)
 
 ### Added
-- Add `hf 14b info` to find and print info about std 14b tags and sri tags (using 14b raw commands in the client)  (marshmellow)
+- Add `hf 14b reader` to find and print general info about known 14b tags (marshmellow)
+- Add `hf 14b info` to find and print full info about std 14b tags and sri tags (using 14b raw commands in the client)  (marshmellow)
 - Add PACE replay functionality (frederikmoellers)
 
 ### Fixed 

--- a/armsrc/iso14443b.c
+++ b/armsrc/iso14443b.c
@@ -334,6 +334,8 @@ void SimulateIso14443bTag(void)
 		0x00, 0x21, 0x85, 0x5e, 0xd7
 	};
 
+	FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
+
 	clear_trace();
 	set_tracing(TRUE);
 
@@ -347,8 +349,6 @@ void SimulateIso14443bTag(void)
 
 	uint16_t len;
 	uint16_t cmdsRecvd = 0;
-
-	FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
 
 	// prepare the (only one) tag answer:
 	CodeIso14443bAsTag(response1, sizeof(response1));
@@ -908,9 +908,6 @@ static void CodeAndTransmit14443bAsReader(const uint8_t *cmd, int len)
 //-----------------------------------------------------------------------------
 void ReadSTMemoryIso14443b(uint32_t dwLast)
 {
-	clear_trace();
-	set_tracing(TRUE);
-
 	uint8_t i = 0x00;
 
 	FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
@@ -928,6 +925,9 @@ void ReadSTMemoryIso14443b(uint32_t dwLast)
 	LED_D_ON();
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_READER_RX_XCORR | FPGA_HF_READER_RX_XCORR_848_KHZ);
 	SpinDelay(200);
+
+	clear_trace();
+	set_tracing(TRUE);
 
 	// First command: wake up the tag using the INITIATE command
 	uint8_t cmd1[] = {0x06, 0x00, 0x97, 0x5b};
@@ -1199,7 +1199,7 @@ void SendRawCommand14443B(uint32_t datalen, uint32_t recv, uint8_t powerfield, u
 	FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
 	SetAdcMuxFor(GPIO_MUXSEL_HIPKD);
 	FpgaSetupSsc();
-	
+
 	if (datalen){
 		set_tracing(TRUE);
 		

--- a/armsrc/iso14443b.c
+++ b/armsrc/iso14443b.c
@@ -321,16 +321,14 @@ static int GetIso14443bCommandFromReader(uint8_t *received, uint16_t *len)
 //-----------------------------------------------------------------------------
 void SimulateIso14443bTag(void)
 {
-	// the only commands we understand is REQB, AFI=0, Select All, N=8:
-	static const uint8_t cmd1[] = { 0x05, 0x00, 0x08, 0x39, 0x73 }; // REQB
-	// ... and REQB, AFI=0, Normal Request, N=0:
+	// the only commands we understand is WUPB, AFI=0, Select All, N=1:
+	static const uint8_t cmd1[] = { 0x05, 0x00, 0x08, 0x39, 0x73 }; // WUPB
+	// ... and REQB, AFI=0, Normal Request, N=1:
 	static const uint8_t cmd2[] = { 0x05, 0x00, 0x00, 0x71, 0xFF }; // REQB
-	// ... and WUPB, AFI=0, N=8:
-	static const uint8_t cmd3[] = { 0x05, 0x08, 0x08, 0xF9, 0xBD }; // WUPB
 	// ... and HLTB
-	static const uint8_t cmd4[] = { 0x50, 0xff, 0xff, 0xff, 0xff }; // HLTB
+	static const uint8_t cmd3[] = { 0x50, 0xff, 0xff, 0xff, 0xff }; // HLTB
 	// ... and ATTRIB
-	static const uint8_t cmd5[] = { 0x1D, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}; // ATTRIB
+	static const uint8_t cmd4[] = { 0x1D, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}; // ATTRIB
 
 	// ... and we always respond with ATQB, PUPI = 820de174, Application Data = 0x20381922,
 	// supports only 106kBit/s in both directions, max frame size = 32Bytes,
@@ -391,14 +389,13 @@ void SimulateIso14443bTag(void)
 
 		// Good, look at the command now.
 		if ( (len == sizeof(cmd1) && memcmp(receivedCmd, cmd1, len) == 0)
-			|| (len == sizeof(cmd2) && memcmp(receivedCmd, cmd2, len) == 0)
-			|| (len == sizeof(cmd3) && memcmp(receivedCmd, cmd3, len) == 0) ) {
+			|| (len == sizeof(cmd2) && memcmp(receivedCmd, cmd2, len) == 0) ) {
 			resp = response1; 
 			respLen = sizeof(response1);
 			respCode = resp1Code; 
 			respCodeLen = resp1CodeLen;
-		} else if ( (len == sizeof(cmd4) && receivedCmd[0] == cmd4[0])
-			|| (len == sizeof(cmd5) && receivedCmd[0] == cmd5[0]) ) {
+		} else if ( (len == sizeof(cmd3) && receivedCmd[0] == cmd3[0])
+			|| (len == sizeof(cmd4) && receivedCmd[0] == cmd4[0]) ) {
 			resp = response2; 
 			respLen = sizeof(response2);
 			respCode = resp2Code; 
@@ -412,6 +409,7 @@ void SimulateIso14443bTag(void)
 				if(b1 != receivedCmd[len-2] || b2 != receivedCmd[len-1]) {
 					// Not so good, try again.
 					DbpString("+++CRC fail");
+		
 				} else {
 					DbpString("CRC passes");
 				}

--- a/armsrc/iso14443b.c
+++ b/armsrc/iso14443b.c
@@ -360,13 +360,13 @@ void SimulateIso14443bTag(void)
 	// prepare the (only one) tag answer:
 	CodeIso14443bAsTag(response1, sizeof(response1));
 	uint8_t *resp1Code = BigBuf_malloc(ToSendMax);
-	memcpy(resp1Code, ToSend, ToSendMax); 
+	memcpy(resp1Code, ToSend, ToSendMax);
 	uint16_t resp1CodeLen = ToSendMax;
 
 	// prepare the (other) tag answer:
 	CodeIso14443bAsTag(response2, sizeof(response2));
 	uint8_t *resp2Code = BigBuf_malloc(ToSendMax);
-	memcpy(resp2Code, ToSend, ToSendMax); 
+	memcpy(resp2Code, ToSend, ToSendMax);
 	uint16_t resp2CodeLen = ToSendMax;
 
 	// We need to listen to the high-frequency, peak-detected path.
@@ -390,15 +390,15 @@ void SimulateIso14443bTag(void)
 		// Good, look at the command now.
 		if ( (len == sizeof(cmd1) && memcmp(receivedCmd, cmd1, len) == 0)
 			|| (len == sizeof(cmd2) && memcmp(receivedCmd, cmd2, len) == 0) ) {
-			resp = response1; 
+			resp = response1;
 			respLen = sizeof(response1);
-			respCode = resp1Code; 
+			respCode = resp1Code;
 			respCodeLen = resp1CodeLen;
 		} else if ( (len == sizeof(cmd3) && receivedCmd[0] == cmd3[0])
 			|| (len == sizeof(cmd4) && receivedCmd[0] == cmd4[0]) ) {
-			resp = response2; 
+			resp = response2;
 			respLen = sizeof(response2);
-			respCode = resp2Code; 
+			respCode = resp2Code;
 			respCodeLen = resp2CodeLen;
 		} else {
 			Dbprintf("new cmd from reader: len=%d, cmdsRecvd=%d", len, cmdsRecvd);
@@ -457,13 +457,13 @@ void SimulateIso14443bTag(void)
 				(void)b;
 			}
 		}
-		
+
 		// trace the response:
 		if (tracing) {
 			uint8_t parity[MAX_PARITY_SIZE];
 			LogTrace(resp, respLen, 0, 0, parity, FALSE);
 		}
-			
+
 	}
 }
 
@@ -541,7 +541,7 @@ static RAMFUNC int Handle14443bSamplesDemod(int ci, int cq)
 		} else { \
 			v -= cq; \
 		} \
-	}		
+	}
  */
 // Subcarrier amplitude v = sqrt(ci^2 + cq^2), approximated here by max(abs(ci),abs(cq)) + 1/2*min(abs(ci),abs(cq)))
 #define CHECK_FOR_SUBCARRIER() { \
@@ -575,7 +575,7 @@ static RAMFUNC int Handle14443bSamplesDemod(int ci, int cq)
 			} \
 		} \
 	}
-	
+
 	switch(Demod.state) {
 		case DEMOD_UNSYNCD:
 			CHECK_FOR_SUBCARRIER();
@@ -673,7 +673,7 @@ static RAMFUNC int Handle14443bSamplesDemod(int ci, int cq)
 					Demod.metric -= Demod.thisBit;
 				}
 				(Demod.metricN)++;
-*/				
+*/
 
 				Demod.shiftReg >>= 1;
 				if(Demod.thisBit > 0) {	// logic '1'
@@ -741,10 +741,10 @@ static void GetSamplesFor14443bDemod(int n, bool quiet)
 	// Allocate memory from BigBuf for some buffers
 	// free all previous allocations first
 	BigBuf_free();
-	
+
 	// The response (tag -> reader) that we're receiving.
 	uint8_t *receivedResponse = BigBuf_malloc(MAX_FRAME_SIZE);
-	
+
 	// The DMA buffer, used to stream samples from the FPGA
 	int8_t *dmaBuf = (int8_t*) BigBuf_malloc(ISO14443B_DMA_BUFFER_SIZE);
 
@@ -1118,7 +1118,7 @@ void RAMFUNC SnoopIso14443b(void)
 
 	bool TagIsActive = FALSE;
 	bool ReaderIsActive = FALSE;
-	
+
 	// And now we loop, receiving samples.
 	for(;;) {
 		int behindBy = (lastRxCounter - AT91C_BASE_PDC_SSC->PDC_RCR) &
@@ -1238,7 +1238,7 @@ void SendRawCommand14443B(uint32_t datalen, uint32_t recv, uint8_t powerfield, u
 			uint16_t iLen = MIN(Demod.len, USB_CMD_DATA_SIZE);
 			cmd_send(CMD_ACK, iLen, 0, 0, Demod.output, iLen);
 		}
-	} 
+	}
 
 	if(!powerfield) {
 		FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -119,8 +119,7 @@ void LFSetupFPGAForADC(int divisor, bool lf_field)
  * @param silent - is true, now outputs are made. If false, dbprints the status
  * @return the number of bits occupied by the samples.
  */
-
-uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averaging, int trigger_threshold,bool silent)
+uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averaging, int trigger_threshold, bool silent)
 {
 	//.
 	uint8_t *dest = BigBuf_get_addr();
@@ -151,8 +150,12 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
 		if (AT91C_BASE_SSC->SSC_SR & AT91C_SSC_RXRDY) {
 			sample = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
 			LED_D_OFF();
-			if (trigger_threshold > 0 && sample < trigger_threshold)
+			// threshold either high or low values 128 = center 0.  if trigger = 178 
+			if ((trigger_threshold > 0) && (sample < (trigger_threshold+128)) && (sample > (128-trigger_threshold))) // 
 				continue;
+		
+			//if (trigger_threshold > 0 && sample < trigger_threshold) // 
+				//continue;
 
 			trigger_threshold = 0;
 			sample_total_numbers++;

--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -1491,9 +1491,9 @@ int CmdFDXBdemodBI(const char *Cmd){
 
 	setDemodBuf(BitStream, 128, preambleIndex);
 
-	// remove but don't verify parity. (pType = 2)
+	// remove marker bits (1's every 9th digit after preamble) (pType = 2)
 	size = removeParity(BitStream, preambleIndex + 11, 9, 2, 117);
-	if ( size <= 103 ) {
+	if ( size != 104 ) {
 		if (g_debugMode) PrintAndLog("Error removeParity:: %d", size);
 		return 0;
 	}

--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -26,8 +26,8 @@
 #include "crc16.h"
 
 uint8_t DemodBuffer[MAX_DEMOD_BUF_LEN];
-uint8_t g_debugMode;
-size_t DemodBufferLen;
+uint8_t g_debugMode=0;
+size_t DemodBufferLen=0;
 static int CmdHelp(const char *Cmd);
 
 //set the demod buffer with given array of binary (one bit per byte)

--- a/client/cmdhf14b.c
+++ b/client/cmdhf14b.c
@@ -295,7 +295,7 @@ int print_ST_Lock_info(uint8_t model){
 		case 0x7: //             (SRI4K)
 			//only need data[3]
 			blk1 = 9;
-			PrintAndLog("   raw: %s",printBits(8,data+3));
+			PrintAndLog("   raw: %s",printBits(1,data+3));
 			PrintAndLog(" 07/08: %slocked", blk1, (data[3] & 1) ? "not " : "" );
 			for (uint8_t i = 1; i<8; i++){
 				PrintAndLog("    %02u: %slocked", blk1, (data[3] & (1 << i)) ? "not " : "" );
@@ -307,7 +307,7 @@ int print_ST_Lock_info(uint8_t model){
 		case 0xC: //             (SRT512)
 			//need data[2] and data[3]
 			blk1 = 0;
-			PrintAndLog("   raw: %s",printBits(16,data+2));
+			PrintAndLog("   raw: %s",printBits(2,data+2));
 			for (uint8_t b=2; b<4; b++){
 				for (uint8_t i=0; i<8; i++){
 					PrintAndLog("    %02u: %slocked", blk1, (data[b] & (1 << i)) ? "not " : "" );
@@ -318,7 +318,7 @@ int print_ST_Lock_info(uint8_t model){
 		case 0x2: //             (SR176)
 			//need data[2]
 			blk1 = 0;
-			PrintAndLog("   raw: %s",printBits(8,data+2));
+			PrintAndLog("   raw: %s",printBits(1,data+2));
 			for (uint8_t i = 0; i<8; i++){
 				PrintAndLog(" %02u/%02u: %slocked", blk1, blk1+1, (data[2] & (1 << i)) ? "" : "not " );
 				blk1+=2;

--- a/client/cmdhf14b.c
+++ b/client/cmdhf14b.c
@@ -206,7 +206,7 @@ int CmdHF14BCmdRaw (const char *Cmd) {
 		bool crc2 = true;
 		cmd2[0] = 0x05;
 		cmd2[1] = 0x00;
-		cmd2[2] = 0x00;
+		cmd2[2] = 0x08;
 
 		// REQB
 		if (HF14BCmdRaw(true, &crc2, true, cmd2, &cmdLen, false)==0) return rawClose();
@@ -397,7 +397,7 @@ int HF14BStdReader(uint8_t *data, uint8_t *datalen){
 	//std read cmd
 	data[0] = 0x05;
 	data[1] = 0x00;
-	data[2] = 0x00;
+	data[2] = 0x08;
 
 	if (HF14BCmdRaw(true, &crc, true, data, datalen, false)==0) return rawClose();
 

--- a/client/cmdhf14b.c
+++ b/client/cmdhf14b.c
@@ -213,12 +213,12 @@ int CmdHF14BCmdRaw (const char *Cmd) {
 
 		if (cmd2[0] != 0x50 || cmdLen != 14 || !crc2) return rawClose();
 
-		data[0] = 0x1D; 
+		cmd2[0] = 0x1D; 
 		// UID from data[1 - 4]
-		data[5] = 0x00;
-		data[6] = 0x08;
-		data[7] = 0x01;
-		data[8] = 0x00;
+		cmd2[5] = 0x00;
+		cmd2[6] = 0x08;
+		cmd2[7] = 0x01;
+		cmd2[8] = 0x00;
 		cmdLen = 9;
 
 		// attrib

--- a/client/cmdhf14b.c
+++ b/client/cmdhf14b.c
@@ -267,7 +267,7 @@ char *get_ST_Chip_Model(uint8_t data){
 
 int print_ST_Lock_info(uint8_t model){
 	//assume connection open and tag selected...
-	uint8_t data[8] = {0x00};
+	uint8_t data[16] = {0x00};
 	uint8_t datalen = 2;
 	bool crc = true;
 	uint8_t resplen;
@@ -296,9 +296,9 @@ int print_ST_Lock_info(uint8_t model){
 			//only need data[3]
 			blk1 = 9;
 			PrintAndLog("   raw: %s",printBits(1,data+3));
-			PrintAndLog(" 07/08: %slocked", blk1, (data[3] & 1) ? "not " : "" );
+			PrintAndLog(" 07/08:%slocked", (data[3] & 1) ? " not " : " " );
 			for (uint8_t i = 1; i<8; i++){
-				PrintAndLog("    %02u: %slocked", blk1, (data[3] & (1 << i)) ? "not " : "" );
+				PrintAndLog("    %02u:%slocked", blk1, (data[3] & (1 << i)) ? " not " : " " );
 				blk1++;
 			}
 			break;
@@ -310,7 +310,7 @@ int print_ST_Lock_info(uint8_t model){
 			PrintAndLog("   raw: %s",printBits(2,data+2));
 			for (uint8_t b=2; b<4; b++){
 				for (uint8_t i=0; i<8; i++){
-					PrintAndLog("    %02u: %slocked", blk1, (data[b] & (1 << i)) ? "not " : "" );
+					PrintAndLog("    %02u:%slocked", blk1, (data[b] & (1 << i)) ? " not " : " " );
 					blk1++;
 				}
 			}
@@ -320,7 +320,7 @@ int print_ST_Lock_info(uint8_t model){
 			blk1 = 0;
 			PrintAndLog("   raw: %s",printBits(1,data+2));
 			for (uint8_t i = 0; i<8; i++){
-				PrintAndLog(" %02u/%02u: %slocked", blk1, blk1+1, (data[2] & (1 << i)) ? "" : "not " );
+				PrintAndLog(" %02u/%02u:%slocked", blk1, blk1+1, (data[2] & (1 << i)) ? " " : " not " );
 				blk1+=2;
 			}
 			break;
@@ -415,10 +415,11 @@ int HF14B_ST_Reader(uint8_t *data, uint8_t *datalen, bool closeCon){
 
 	//leave power on
 	if (HF14BCmdRaw(true, &crc, true, data, datalen, false)==0) return rawClose();
+
+	if (*datalen != 10 || !crc) return rawClose();
+
 	//power off ?
 	if (closeCon) rawClose();
-
-	if (*datalen != 10 || !crc) return 0;
 
 	PrintAndLog("\n14443-3b ST tag found:");
 	print_st_general_info(data);

--- a/client/cmdhf14b.c
+++ b/client/cmdhf14b.c
@@ -200,7 +200,7 @@ int CmdHF14BCmdRaw (const char *Cmd) {
 		return 0;
 	}
 
-	if (select){
+	if (select){ //auto select 14b tag
 		uint8_t	cmd2[16];
 		uint8_t cmdLen = 3;
 		bool crc2 = true;
@@ -208,17 +208,20 @@ int CmdHF14BCmdRaw (const char *Cmd) {
 		cmd2[1] = 0x00;
 		cmd2[2] = 0x08;
 
+		// REQB
 		if (HF14BCmdRaw(true, &crc2, true, cmd2, &cmdLen, false)==0) return rawClose();
 
 		if (cmd2[0] != 0x50 || cmdLen != 14 || !crc2) return rawClose();
 
-		data[0] = 0x1D;
+		data[0] = 0x1D; 
+		// UID from data[1 - 4]
 		data[5] = 0x00;
 		data[6] = 0x08;
 		data[7] = 0x01;
 		data[8] = 0x00;
-
 		cmdLen = 9;
+
+		// attrib
 		if (HF14BCmdRaw(true, &crc2, true, cmd2, &cmdLen, false)==0) return rawClose();
 
 		if (cmd2[0] != 0x10 || cmdLen != 3 || !crc2) return rawClose();

--- a/client/cmdhf14b.c
+++ b/client/cmdhf14b.c
@@ -197,6 +197,7 @@ int CmdHF14BCmdRaw (const char *Cmd) {
 	return HF14BCmdRaw(reply, &crc, power, data, &datalen, true);
 }
 
+// print full atqb info
 static void print_atqb_resp(uint8_t *data){
 	PrintAndLog ("           UID: %s", sprint_hex(data+1,4));
 	PrintAndLog ("      App Data: %s", sprint_hex(data+5,4));
@@ -245,6 +246,7 @@ static void print_atqb_resp(uint8_t *data){
 	return;
 }
 
+// get SRx chip model (from UID) // from ST Microelectronics
 char *get_ST_Chip_Model(uint8_t data){
 	static char model[20];
 	char *retStr = model;
@@ -263,7 +265,8 @@ char *get_ST_Chip_Model(uint8_t data){
 	return retStr;
 }
 
-static void print_st_info(uint8_t *data){
+// print UID info from SRx chips (ST Microelectronics)
+static void print_st_general_info(uint8_t *data){
 	//uid = first 8 bytes in data
 	PrintAndLog(" UID: %s", sprint_hex(SwapEndian64(data,8,8),8));
 	PrintAndLog(" MFG: %02X, %s", data[6], getTagInfo(data[6]));
@@ -271,8 +274,18 @@ static void print_st_info(uint8_t *data){
 	return;
 }
 
+// 14b get and print Full Info (as much as we know)
 int HF14BStdInfo(uint8_t *data, uint8_t *datalen){
+	if (!HF14BStdReader(data,datalen)) return 0;
 
+	//add more info here
+	print_atqb_resp(data);
+
+	return 1;
+}
+
+// 14b get and print UID only (general info)
+int HF14BStdReader(uint8_t *data, uint8_t *datalen){
 	//05 00 00 = find one tag in field
 	//1d xx xx xx xx 20 00 08 01 00 = attrib xx=crc
 	//a3 = ?  (resp 03 e2 c2)
@@ -294,19 +307,30 @@ int HF14BStdInfo(uint8_t *data, uint8_t *datalen){
 	//std read cmd
 	data[0] = 0x05;
 	data[1] = 0x00;
-	data[2] = 0x00;
+	data[2] = 0x08;
 
 	if (HF14BCmdRaw(true, &crc, false, data, datalen, false)==0) return 0;
 
 	if (data[0] != 0x50  || *datalen != 14 || !crc) return 0;
 
 	PrintAndLog ("\n14443-3b tag found:");
-	print_atqb_resp(data);
+	PrintAndLog ("           UID: %s", sprint_hex(data+1,4));
 
 	return 1;
 }
 
+// SRx get and print full info (needs more info...)
 int HF14B_ST_Info(uint8_t *data, uint8_t *datalen){
+	if (!HF14B_ST_Reader(data, datalen)) return 0;
+	
+	//add locking bit information here.
+
+
+	return 1;
+}
+
+// SRx get and print general info about SRx chip from UID
+int HF14B_ST_Reader(uint8_t *data, uint8_t *datalen){
 	bool crc = true;
 	*datalen = 2;
 	//wake cmd
@@ -342,12 +366,12 @@ int HF14B_ST_Info(uint8_t *data, uint8_t *datalen){
 	if (*datalen != 10 || !crc) return 0;
 
 	PrintAndLog("\n14443-3b ST tag found:");
-	print_st_info(data);
+	print_st_general_info(data);
 	return 1;
 }
 
 // test for other 14b type tags (mimic another reader - don't have tags to identify)
-int HF14B_Other_Info(uint8_t *data, uint8_t *datalen){
+int HF14B_Other_Reader(uint8_t *data, uint8_t *datalen){
 	bool crc = true;
 	*datalen = 4;
 	//std read cmd
@@ -356,7 +380,7 @@ int HF14B_Other_Info(uint8_t *data, uint8_t *datalen){
 	data[2] = 0x3f;
 	data[3] = 0x80;
 
-	if (HF14BCmdRaw(true, &crc, false, data, datalen, false)!=0) {
+	if (HF14BCmdRaw(true, &crc, true, data, datalen, false)!=0) {
 		if (*datalen > 2 || !crc) {
 			PrintAndLog ("\n14443-3b tag found:");
 			PrintAndLog ("Unknown tag type answered to a 0x000b3f80 command ans:");
@@ -369,7 +393,7 @@ int HF14B_Other_Info(uint8_t *data, uint8_t *datalen){
 	*datalen = 1;
 	data[0] = 0x0a;
 
-	if (HF14BCmdRaw(true, &crc, false, data, datalen, false)!=0) {
+	if (HF14BCmdRaw(true, &crc, true, data, datalen, false)!=0) {
 		if (*datalen > 0) {
 			PrintAndLog ("\n14443-3b tag found:");
 			PrintAndLog ("Unknown tag type answered to a 0x0A command ans:");
@@ -382,7 +406,7 @@ int HF14B_Other_Info(uint8_t *data, uint8_t *datalen){
 	*datalen = 1;
 	data[0] = 0x0c;
 
-	if (HF14BCmdRaw(true, &crc, false, data, datalen, false)!=0) {
+	if (HF14BCmdRaw(true, &crc, true, data, datalen, false)!=0) {
 		if (*datalen > 0) {
 			PrintAndLog ("\n14443-3b tag found:");
 			PrintAndLog ("Unknown tag type answered to a 0x0C command ans:");
@@ -390,11 +414,11 @@ int HF14B_Other_Info(uint8_t *data, uint8_t *datalen){
 			return 1;
 		}
 	}
-
+	rawClose();
 	return 0;
-
 }
 
+// get and print all info known about any known 14b tag
 int HF14BInfo(bool verbose){
 	uint8_t data[100];
 	uint8_t datalen = 5;
@@ -407,14 +431,39 @@ int HF14BInfo(bool verbose){
 
 	// try unknown 14b read commands (to be identified later)
 	//   could be read of calypso, CEPAS, moneo, or pico pass.
-	if (HF14B_Other_Info(data, &datalen)) return 1;
+	if (HF14B_Other_Reader(data, &datalen)) return 1;
 
 	if (verbose) PrintAndLog("no 14443B tag found");
 	return 0;
 }
 
+// menu command to get and print all info known about any known 14b tag
 int CmdHF14Binfo(const char *Cmd){
 	return HF14BInfo(true);
+}
+
+// get and print general info about all known 14b chips
+int HF14BReader(bool verbose){
+	uint8_t data[100];
+	uint8_t datalen = 5;
+	
+	// try std 14b (atqb)
+	if (HF14BStdReader(data, &datalen)) return 1;
+
+	// try st 14b
+	if (HF14B_ST_Reader(data, &datalen)) return 1;
+
+	// try unknown 14b read commands (to be identified later)
+	//   could be read of calypso, CEPAS, moneo, or pico pass.
+	if (HF14B_Other_Reader(data, &datalen)) return 1;
+
+	if (verbose) PrintAndLog("no 14443B tag found");
+	return 0;
+}
+
+// menu command to get and print general info about all known 14b chips
+int CmdHF14BReader(const char *Cmd){
+	return HF14BReader(true);
 }
 
 int CmdSriWrite( const char *Cmd){
@@ -487,8 +536,9 @@ int CmdSriWrite( const char *Cmd){
 static command_t CommandTable[] = 
 {
   {"help",        CmdHelp,        1, "This help"},
-	{"info",        CmdHF14Binfo,   0, "Find and print info about a 14b type tag (HF ISO 14443b)"},
-  {"list",        CmdHF14BList,   0, "[Deprecated] List ISO 14443b history"},
+  {"info",        CmdHF14Binfo,   0, "Find and print details about a 14443B tag"},
+  {"list",        CmdHF14BList,   0, "[Deprecated] List ISO 14443B history"},
+  {"reader",      CmdHF14BReader, 0, "Act as a 14443B reader to identify a tag"},
   {"sim",         CmdHF14BSim,    0, "Fake ISO 14443B tag"},
   {"snoop",       CmdHF14BSnoop,  0, "Eavesdrop ISO 14443B"},
   {"sri512read",  CmdSri512Read,  0, "Read contents of a SRI512 tag"},

--- a/client/cmdhf14b.c
+++ b/client/cmdhf14b.c
@@ -274,16 +274,6 @@ static void print_st_general_info(uint8_t *data){
 	return;
 }
 
-// 14b get and print Full Info (as much as we know)
-int HF14BStdInfo(uint8_t *data, uint8_t *datalen){
-	if (!HF14BStdReader(data,datalen)) return 0;
-
-	//add more info here
-	print_atqb_resp(data);
-
-	return 1;
-}
-
 // 14b get and print UID only (general info)
 int HF14BStdReader(uint8_t *data, uint8_t *datalen){
 	//05 00 00 = find one tag in field
@@ -319,12 +309,12 @@ int HF14BStdReader(uint8_t *data, uint8_t *datalen){
 	return 1;
 }
 
-// SRx get and print full info (needs more info...)
-int HF14B_ST_Info(uint8_t *data, uint8_t *datalen){
-	if (!HF14B_ST_Reader(data, datalen)) return 0;
-	
-	//add locking bit information here.
+// 14b get and print Full Info (as much as we know)
+int HF14BStdInfo(uint8_t *data, uint8_t *datalen){
+	if (!HF14BStdReader(data,datalen)) return 0;
 
+	//add more info here
+	print_atqb_resp(data);
 
 	return 1;
 }
@@ -367,6 +357,16 @@ int HF14B_ST_Reader(uint8_t *data, uint8_t *datalen){
 
 	PrintAndLog("\n14443-3b ST tag found:");
 	print_st_general_info(data);
+	return 1;
+}
+
+// SRx get and print full info (needs more info...)
+int HF14B_ST_Info(uint8_t *data, uint8_t *datalen){
+	if (!HF14B_ST_Reader(data, datalen)) return 0;
+	
+	//add locking bit information here.
+
+
 	return 1;
 }
 

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -388,7 +388,7 @@ int usage_lf_config()
 	PrintAndLog("       b <bps>       Sets resolution of bits per sample. Default (max): 8");
 	PrintAndLog("       d <decim>     Sets decimation. A value of N saves only 1 in N samples. Default: 1");
 	PrintAndLog("       a [0|1]       Averaging - if set, will average the stored sample value when decimating. Default: 1");
-	PrintAndLog("       t <threshold> Sets trigger threshold. 0 means no threshold");
+	PrintAndLog("       t <threshold> Sets trigger threshold. 0 means no threshold (range: 0-128)");
 	PrintAndLog("Examples:");
 	PrintAndLog("      lf config b 8 L");
 	PrintAndLog("                    Samples at 125KHz, 8bps.");

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -580,7 +580,7 @@ int IOdemodFSK(uint8_t *dest, size_t size)
 
 // by marshmellow
 // takes a array of binary values, start position, length of bits per parity (includes parity bit),
-//   Parity Type (1 for odd; 0 for even; 2 for just drop it), and binary Length (length to run) 
+//   Parity Type (1 for odd; 0 for even; 2 Always 1's), and binary Length (length to run) 
 size_t removeParity(uint8_t *BitStream, size_t startIdx, uint8_t pLen, uint8_t pType, size_t bLen)
 {
 	uint32_t parityWd = 0;
@@ -590,10 +590,12 @@ size_t removeParity(uint8_t *BitStream, size_t startIdx, uint8_t pLen, uint8_t p
 			parityWd = (parityWd << 1) | BitStream[startIdx+word+bit];
 			BitStream[j++] = (BitStream[startIdx+word+bit]);
 		}
-		j--;
+		j--; // overwrite parity with next data
 		// if parity fails then return 0
-		if (pType != 2) {
-			if (parityTest(parityWd, pLen, pType) == 0) return -1;
+		if (pType == 2) { // then marker bit which should be a 1
+			if (!BitStream[j]) return 0;
+		} else {
+			if (parityTest(parityWd, pLen, pType) == 0) return 0;			
 		}
 		bitCnt+=(pLen-1);
 		parityWd = 0;


### PR DESCRIPTION
change lf config threshold to trigger on top or bottom of wave and is based on graphing metric 0-128.  
add SRx tag lock bit info to hf 14b info command
add SRx tag select to hf 14b raw (-ss option)
add more 14b sim command responses
fixed fdx-b false positives by verifying marker bits and length
