### PR TITLE
nested attack: really testing default/known keys and

### DIFF
--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -679,25 +679,15 @@ int CmdHF14AMfNested(const char *Cmd)
 
 		PrintAndLog("Testing known keys. Sector count=%d", SectorsCnt);
 		for (i = 0; i < SectorsCnt; i++) {
-			PrintAndLog(". test sector: %03d of %03d", i, SectorsCnt);
 			for (j = 0; j < 2; j++) {
 				if (e_sector[i].foundKey[j]) continue;
 				
-				// new loop to iterate through the given keys
-				for (int h = 0; h < sizeof(keyBlock)/6; h++){
-					res = mfCheckKeys(FirstBlockOfSector(i), j, true, 6, (uint8_t*)(keyBlock + h * 6), &key64);
-
+				res = mfCheckKeys(FirstBlockOfSector(i), j, true, 6, keyBlock, &key64);
 				
-					if (!res) {
-						e_sector[i].Key[j] = key64;
-						e_sector[i].foundKey[j] = 1;
-						NumFound++; // found a new one
-						break;
-					}else if(res == 1){
-						PrintAndLog("Error: No response from Proxmark.\n");
-						free(triedOnes);
-						free(e_sector);
-					}
+				if (!res) {
+					e_sector[i].Key[j] = key64;
+					e_sector[i].foundKey[j] = 1;
+					NumFound++;
 				}
 			}
 		}


### PR DESCRIPTION
nested attack: really testing default/known keys and
restarts nested attack with different found key if not all has been
found, but last round added new ones.

As said in http://www.proxmark.org/forum/viewtopic.php?id=2630 the nested attack don't work as intended.

1) The given/default/known keys are not tested in loop before -> changed (but is slow?)

2) If nested attack fails and only finds maybe 80% of the keys, then another try may find 90%, but ignores the already found keys.
Changed this to a fixpoint iteration: restart nested attack with a new key until every key is known or the last run didn't offer more keys.