### PR TITLE
fixed target "help" in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help:
 	@echo +	all           - Make bootrom, armsrc and the OS-specific host directory
 	@echo + client        - Make only the OS-specific host directory
 	@echo + flash-bootrom - Make bootrom and flash it
-	@echo + flash-os      - Make armsrc and flash os (includes fpga)
+	@echo + flash-os      - Make armsrc and flash os \(includes fpga\)
 	@echo + flash-all     - Make bootrom and armsrc and flash bootrom and os image
 	@echo +	clean         - Clean in bootrom, armsrc and the OS-specific host directory
 


### PR DESCRIPTION
Without this commit, running `make help` produced the below output.

    $ make help
    Multi-OS Makefile, you are running on Linux
    Possible targets:
    + all - Make bootrom, armsrc and the OS-specific host directory
    + client - Make only the OS-specific host directory
    + flash-bootrom - Make bootrom and flash it
    /bin/sh: 1: Syntax error: "(" unexpected
    Makefile:20: recipe for target 'help' failed
    make: *** [help] Error 2

This issue was introduced in e335ca2846d57f660ab7f4c75b58226cca264e0e six months ago, the above output was produced on Debian GNU/Linux, where `/bin/sh` is usually a symbolic link to `/bin/dash`.