### PR TITLE
add l/h option to hw tune and optimize order of tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ flasher
 version.c
 lua
 luac
+fpga_compress
 
 fpga/*
 !fpga/tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ of stream transmissions (marshmellow)
 - Added 'hf snoop'. This command take digitalized signal from FPGA and put in BigBuffer. (pwpiwi + enio)
 - Added Topaz (NFC type 1) protocol support ('hf topaz reader', 'hf list topaz', 'hf 14a raw -T', 'hf topaz snoop'). (piwi)
 - Added option c to 'hf list' (mark CRC bytes) (piwi)
+- Added option `l` or `h` to `hw tune` to save time and unnecessary fpga writes if you are only interested in lf or hf.
 
 ### Changed
 - Added `[l] <length>` option to data printdemodbuffer

--- a/armsrc/fpgaloader.c
+++ b/armsrc/fpgaloader.c
@@ -566,3 +566,7 @@ void Fpga_print_status(void)
 	else if(downloaded_bitstream == FPGA_BITSTREAM_LF) Dbprintf("  mode.............LF");
 	else Dbprintf("  mode.............%d", downloaded_bitstream);
 }
+
+int FpgaGetCurrent() {
+	return downloaded_bitstream;
+}

--- a/armsrc/fpgaloader.h
+++ b/armsrc/fpgaloader.h
@@ -18,6 +18,7 @@ void FpgaSetupSsc(void);
 void SetupSpi(int mode);
 bool FpgaSetupSscDma(uint8_t *buf, int len);
 void Fpga_print_status();
+int FpgaGetCurrent();
 #define FpgaDisableSscDma(void)	AT91C_BASE_PDC_SSC->PDC_PTCR = AT91C_PDC_RXTDIS;
 #define FpgaEnableSscDma(void) AT91C_BASE_PDC_SSC->PDC_PTCR = AT91C_PDC_RXTEN;
 void SetAdcMuxFor(uint32_t whichGpio);

--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -2048,10 +2048,20 @@ int CmdSamples(const char *Cmd)
 
 int CmdTuneSamples(const char *Cmd)
 {
-	int timeout = 0;
+	int timeout = 0, arg = FLAG_TUNE_ALL;
+
+	if(*Cmd == 'l') {
+	  arg = FLAG_TUNE_LF;
+	} else if (*Cmd == 'h') {
+	  arg = FLAG_TUNE_HF;
+	} else if (*Cmd != '\0') {
+	  PrintAndLog("use 'tune' or 'tune l' or 'tune h'");
+	  return 0;
+	}
+
 	printf("\nMeasuring antenna characteristics, please wait...");
 
-	UsbCommand c = {CMD_MEASURE_ANTENNA_TUNING};
+	UsbCommand c = {CMD_MEASURE_ANTENNA_TUNING, {arg, 0, 0}};
 	SendCommand(&c);
 
 	UsbCommand resp;

--- a/client/cmdhw.c
+++ b/client/cmdhw.c
@@ -467,7 +467,7 @@ static command_t CommandTable[] =
 	{"reset",         CmdReset,       0, "Reset the Proxmark3"},
 	{"setlfdivisor",  CmdSetDivisor,  0, "<19 - 255> -- Drive LF antenna at 12Mhz/(divisor+1)"},
 	{"setmux",        CmdSetMux,      0, "<loraw|hiraw|lopkd|hipkd> -- Set the ADC mux to a specific value"},
-	{"tune",          CmdTune,        0, "Measure antenna tuning"},
+	{"tune",          CmdTune,        0, "['l'|'h'] -- Measure antenna tuning (option 'l' or 'h' to limit to LF or HF)"},
 	{"version",       CmdVersion,     0, "Show version information about the connected Proxmark"},
 	{"status",        CmdStatus,      0, "Show runtime status information about the connected Proxmark"},
 	{"ping",          CmdPing,        0, "Test if the pm3 is responsive"},

--- a/include/usb_cmd.h
+++ b/include/usb_cmd.h
@@ -228,6 +228,11 @@ typedef struct{
 #define FLAG_ICLASS_READER_CEDITKEY     0x40
 
 
+//hw tune args
+#define FLAG_TUNE_LF   1
+#define FLAG_TUNE_HF   2
+#define FLAG_TUNE_ALL  3
+
 
 // CMD_DEVICE_INFO response packet has flags in arg[0], flag definitions:
 /* Whether a bootloader that understands the common_area is present */


### PR DESCRIPTION
Save time and fpga downloads by only tuning lf/hf as required. If both are required the order is optimized to avoid unnecessary download (i.e. always used to do lf first, but if hf core already loaded will now do the hf first).