### PR TITLE
Fix Makefile and make it can work with QT5

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -29,9 +29,9 @@ ifneq (,$(findstring MINGW,$(platform)))
         QTLDLIBS = -L$(QTDIR)/lib -lQtCore4 -lQtGui4
     endif
 else ifeq ($(platform),Darwin)
-    CXXFLAGS = $(shell pkg-config --cflags QtCore QtGui 2>/dev/null) -Wall -O4
-    QTLDLIBS = $(shell pkg-config --libs QtCore QtGui 2>/dev/null)
-    MOC = $(shell pkg-config --variable=moc_location QtCore)
+    CXXFLAGS = $(shell pkg-config --cflags Qt5Core Qt5Gui Qt5Widgets 2>/dev/null) -Wall -O4
+    QTLDLIBS = $(shell pkg-config --libs Qt5Core Qt5Gui Qt5Widgets 2>/dev/null)
+    MOC = $(shell pkg-config --variable=moc_location Qt5Core 2>/dev/null)
     LUAPLATFORM = macosx
 else
     CXXFLAGS = $(shell pkg-config --cflags QtCore QtGui 2>/dev/null) -Wall -O4


### PR DESCRIPTION
Fix issue #189[](https://github.com/Proxmark/proxmark3/issues/189)

This is my first pull request, I think this patch is helpful and I have edited the [Wiki OS X](https://github.com/Proxmark/proxmark3/wiki/OSX), so that the change of Makefile can work.

These contents are added by me in Wiki:

If you choose to use HomeBrew, you need add QT to PKG_CONFIG_PATH so that pkg-config can find QT5.
`export PKG_CONFIG_PATH=/usr/local/Cellar/qt5/5.6.1-1/lib/pkgconfig/`
And you need add moc_location in Qt5Core.pc file.

```
export QT_PKG_CONFIG_QT5CORE=`find /usr -name Qt5Core.pc 2>/dev/null`
chmod 666 $QT_PKG_CONFIG_QT5CORE
echo "moc_location=\${prefix}/bin/moc" >> $QT_PKG_CONFIG_QT5CORE
chmod 444 $QT_PKG_CONFIG_QT5CORE
```
