### PR TITLE
Patching Lua compilation error

### DIFF
--- a/liblua/Makefile
+++ b/liblua/Makefile
@@ -103,7 +103,7 @@ freebsd:
 generic: $(ALL)
 
 linux:
-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl -lreadline"
+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl -lreadline -ltermcap -lncurses"
 
 macosx:
 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" SYSLIBS="-lreadline"


### PR DESCRIPTION
This action fixes the compilation issue on Slackware Linux 14.2.

```

/usr/lib64/gcc/x86_64-slackware-linux/5.4.0/../../../../lib64/libreadline.so: undefined reference to `BC'
collect2: fel: ld returnerade avslutningsstatus 1
Makefile:63: receptet för målet "lua" misslyckades
make[3]: *** [lua] Fel 1
make[3]: Lämnar katalogen "/home/github/proxmark3/proxmark3/liblua"
Makefile:106: receptet för målet "linux" misslyckades
make[2]: *** [linux] Fel 2
make[2]: Lämnar katalogen "/home/github/proxmark3/proxmark3/liblua"
Makefile:163: receptet för målet "lua_build" misslyckades
make[1]: *** [lua_build] Fel 2
make[1]: Lämnar katalogen "/home/github/proxmark3/proxmark3/client"
Makefile:12: receptet för målet "client/all" misslyckades
make: *** [client/all] Fel 2
make: Lämnar katalogen "/home/github/proxmark3/proxmark3"

```