### PR TITLE
Better Linux compilation compability

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -12,7 +12,7 @@ CXX=g++
 VPATH = ../common ../zlib
 OBJDIR = obj
 
-LDLIBS = -L/opt/local/lib -L/usr/local/lib -lreadline -lpthread -lm
+LDLIBS = -L/opt/local/lib -L/usr/local/lib -lreadline -lpthread -lm -ltermcap -lncurses
 LUALIB = ../liblua/liblua.a
 LDFLAGS = $(COMMON_FLAGS)
 CFLAGS = -std=c99 -I. -I../include -I../common -I../zlib -I/opt/local/include -I../liblua -Wall $(COMMON_FLAGS) -g -O4


### PR DESCRIPTION
Addition of termcap and ncurses libraries fixes the compilation issue on Slackware Linux 14.2.

```
/usr/lib64/gcc/x86_64-slackware-linux/5.4.0/../../../../lib64/libreadline.so: undefined reference to `PC'
collect2: fel: ld returnerade avslutningsstatus 1
Makefile:132: receptet för målet "proxmark3" misslyckades
make[1]: *** [proxmark3] Fel 1
make[1]: Lämnar katalogen "/home/github/proxmark3/proxmark3/client"
Makefile:12: receptet för målet "client/all" misslyckades
make: *** [client/all] Fel 2
make: Lämnar katalogen "/home/github/proxmark3/proxmark3"
```