### PR TITLE
Warning removal fix

### DIFF
--- a/client/fpga_compress.c
+++ b/client/fpga_compress.c
@@ -87,7 +87,7 @@ int zlib_compress(FILE *infile[], uint8_t num_infiles, FILE *outfile)
 	do {
 
 		if (i >= num_infiles * FPGA_CONFIG_SIZE) {
-			fprintf(stderr, "Input files too big (total > %lu bytes). These are probably not PM3 FPGA config files.\n", num_infiles*FPGA_CONFIG_SIZE);
+			fprintf(stderr, "Input files too big (total > %lu bytes). These are probably not PM3 FPGA config files.\\n", (unsigned long)num_infiles*FPGA_CONFIG_SIZE);
 			for(uint16_t j = 0; j < num_infiles; j++) {
 				fclose(infile[j]);
 			}
@@ -139,7 +139,7 @@ int zlib_compress(FILE *infile[], uint8_t num_infiles, FILE *outfile)
 		ret = deflate(&compressed_fpga_stream, Z_FINISH);
 	}
 	
-	fprintf(stderr, "compressed %lu input bytes to %lu output bytes\n", i, compressed_fpga_stream.total_out);
+	fprintf(stderr, "compressed %lu input bytes to %lu output bytes\\n", (unsigned long)i, (unsigned long)compressed_fpga_stream.total_out);
 
 	if (ret != Z_STREAM_END) {
 		fprintf(stderr, "Error in deflate(): %d %s\n", ret, compressed_fpga_stream.msg);


### PR DESCRIPTION
The altered lines removes the compilation warning on Slackware Linux 14.2.

```
gcc -std=c99 -I. -I../include -I../common -I../zlib -I/opt/local/include -I../liblua -Wall  -g -O4 -DHAVE_GUI -DZ_SOLO -DZ_PREFIX -DNO_GZIP -DZLIB_PM3_TUNED  -c -o obj/fpga_compress.o fpga_compress.c
fpga_compress.c: I funktion "zlib_compress":
fpga_compress.c:90:20: varning: format "%lu" förväntar sig argument av typen "long unsigned int", men argument 3 har typen "int" [-Wformat=]
    fprintf(stderr, "Input files too big (total > %lu bytes). These are probably not PM3 FPGA config files.\n", num_infiles*FPGA_CONF
                    ^
fpga_compress.c:142:18: varning: format "%lu" förväntar sig argument av typen "long unsigned int", men argument 3 har typen "uint32_t {även unsigned int}" [-Wformat=]
  fprintf(stderr, "compressed %lu input bytes to %lu output bytes\n", i, compressed_fpga_stream.total_out);
```