### PR TITLE
fix compile warning in client/flasher.c with gcc 6.2.0

### DIFF
--- a/client/flasher.c
+++ b/client/flasher.c
@@ -24,12 +24,12 @@ static char* serial_port_name;
 
 void cmd_debug(UsbCommand* UC) {
   //  Debug
-  printf("UsbCommand length[len=%zd]\n",sizeof(UsbCommand));
-  printf("  cmd[len=%zd]: %016"llx"\n",sizeof(UC->cmd),UC->cmd);
-  printf(" arg0[len=%zd]: %016"llx"\n",sizeof(UC->arg[0]),UC->arg[0]);
-  printf(" arg1[len=%zd]: %016"llx"\n",sizeof(UC->arg[1]),UC->arg[1]);
-  printf(" arg2[len=%zd]: %016"llx"\n",sizeof(UC->arg[2]),UC->arg[2]);
-  printf(" data[len=%zd]: ",sizeof(UC->d.asBytes));
+  printf("UsbCommand length[len=%d]\n",sizeof(UsbCommand));
+  printf("  cmd[len=%d]: %016"llx"\n",sizeof(UC->cmd),UC->cmd);
+  printf(" arg0[len=%d]: %016"llx"\n",sizeof(UC->arg[0]),UC->arg[0]);
+  printf(" arg1[len=%d]: %016"llx"\n",sizeof(UC->arg[1]),UC->arg[1]);
+  printf(" arg2[len=%d]: %016"llx"\n",sizeof(UC->arg[2]),UC->arg[2]);
+  printf(" data[len=%d]: ",sizeof(UC->d.asBytes));
   for (size_t i=0; i<16; i++) {
     printf("%02x",UC->d.asBytes[i]);
   }


### PR DESCRIPTION
env: MINGW32(in MSYS2), Qt5.6.1-1, devkitARM_r45
There are some warning in client/flasher.c when i compiled client with gcc 6.2.0.

like that:
flasher.c:27:34: warning: unknown conversion type character 'z' in format [-Wformat=]
   printf("UsbCommand length[len=%zd]\n",sizeof(UsbCommand));

And i tested in ProxSpace with no warning. I don't think this change has a big impact.