### PR TITLE
Adds random nonce (r) option to `hf mf sim`.

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2329,6 +2329,7 @@ typedef struct {
   * FLAG_7B_UID_IN_DATA - means that there is a 7-byte UID in the data-section, we're expected to use that
   * FLAG_10B_UID_IN_DATA	- use 10-byte UID in the data-section not finished
   *	FLAG_NR_AR_ATTACK  - means we should collect NR_AR responses for bruteforcing later
+  * FLAG_RANDOM_NONCE - means we should generate some pseudo-random nonce data
   *@param exitAfterNReads, exit simulation after n blocks have been read, 0 is infinite ...
   * (unless reader attack mode enabled then it runs util it gets enough nonces to recover all keys attmpted)
   */
@@ -2387,7 +2388,12 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 	uint8_t	mM = 0; //moebius_modifier for collection storage
 
 	// Authenticate response - nonce
-	uint32_t nonce = bytes_to_num(rAUTH_NT, 4);
+	uint32_t nonce;
+	if (flags & FLAG_RANDOM_NONCE) {
+		nonce = prand();
+	} else {
+		nonce = bytes_to_num(rAUTH_NT, 4);
+	}
 	
 	//-- Determine the UID
 	// Can be set from emulator memory, incoming data
@@ -2535,6 +2541,11 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 			LED_C_OFF();
 			crypto1_destroy(pcs);
 			cardAUTHKEY = 0xff;
+			if (flags & FLAG_RANDOM_NONCE) {
+				nonce = prand();
+			} else {
+				nonce++;
+			}
 			continue;
 		}
 		
@@ -2656,7 +2667,11 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 												// switch to moebius collection
 												gettingMoebius = true;
 												mM = ATTACK_KEY_COUNT;
-												nonce = nonce*7;
+												if (flags & FLAG_RANDOM_NONCE) {
+													nonce = prand();
+												} else {
+													nonce = nonce*7;
+												}
 												break;
 											}
 										} else {

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2329,7 +2329,7 @@ typedef struct {
   * FLAG_7B_UID_IN_DATA - means that there is a 7-byte UID in the data-section, we're expected to use that
   * FLAG_10B_UID_IN_DATA	- use 10-byte UID in the data-section not finished
   *	FLAG_NR_AR_ATTACK  - means we should collect NR_AR responses for bruteforcing later
-  * FLAG_RANDOM_NONCE - means we should generate some pseudo-random nonce data
+  * FLAG_RANDOM_NONCE - means we should generate some pseudo-random nonce data (only allows moebius attack)
   *@param exitAfterNReads, exit simulation after n blocks have been read, 0 is infinite ...
   * (unless reader attack mode enabled then it runs util it gets enough nonces to recover all keys attmpted)
   */
@@ -2543,8 +2543,6 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 			cardAUTHKEY = 0xff;
 			if (flags & FLAG_RANDOM_NONCE) {
 				nonce = prand();
-			} else {
-				nonce++;
 			}
 			continue;
 		}

--- a/armsrc/util.c
+++ b/armsrc/util.c
@@ -431,3 +431,19 @@ uint32_t RAMFUNC GetCountSspClk(){
 	}
 }
 
+static uint64_t next_random = 1;
+
+/* Generates a (non-cryptographically secure) 32-bit random number.
+ *
+ * We don't have an implementation of the "rand" function or a clock to seed it
+ * with, so we just call GetTickCount the first time to seed ourselves.
+ */
+uint32_t prand() {
+	if (next_random == 1) {
+		next_random = GetTickCount();
+	}
+
+	next_random = next_random * 6364136223846793005 + 1;
+	return (uint32_t)(next_random >> 32) % 0xffffffff;
+}
+

--- a/armsrc/util.h
+++ b/armsrc/util.h
@@ -54,4 +54,6 @@ uint32_t RAMFUNC GetDeltaCountUS();
 void StartCountSspClk();
 uint32_t RAMFUNC GetCountSspClk();
 
+uint32_t prand();
+
 #endif

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -1016,7 +1016,7 @@ int CmdHF14AMfChk(const char *Cmd)
 	return 0;
 }
 
-void readerAttack(nonces_t ar_resp[], bool setEmulatorMem) {
+void readerAttack(nonces_t ar_resp[], bool setEmulatorMem, bool doStandardAttack) {
 	#define ATTACK_KEY_COUNT 8 // keep same as define in iso14443a.c -> Mifare1ksim()
 	uint64_t key = 0;
 	typedef struct {
@@ -1034,7 +1034,7 @@ void readerAttack(nonces_t ar_resp[], bool setEmulatorMem) {
 	for (uint8_t i = 0; i<ATTACK_KEY_COUNT; i++) {
 		if (ar_resp[i].ar2 > 0) {
 			//PrintAndLog("DEBUG: Trying sector %d, cuid %08x, nt %08x, ar %08x, nr %08x, ar2 %08x, nr2 %08x",ar_resp[i].sector, ar_resp[i].cuid,ar_resp[i].nonce,ar_resp[i].ar,ar_resp[i].nr,ar_resp[i].ar2,ar_resp[i].nr2);
-			if (mfkey32(ar_resp[i], &key)) {
+			if (doStandardAttack && mfkey32(ar_resp[i], &key)) {
 				PrintAndLog("  Found Key%s for sector %02d: [%04x%08x]", (ar_resp[i].keytype) ? "B" : "A", ar_resp[i].sector, (uint32_t) (key>>32), (uint32_t) (key &0xFFFFFFFF));
 
 				for (uint8_t ii = 0; ii<ATTACK_KEY_COUNT; ii++) {
@@ -1054,6 +1054,34 @@ void readerAttack(nonces_t ar_resp[], bool setEmulatorMem) {
 						}
 					}
 				}
+			} else if (tryMfk32_moebius(ar_resp[i+ATTACK_KEY_COUNT], &key)) {
+				uint8_t sectorNum = ar_resp[i+ATTACK_KEY_COUNT].sector;
+				uint8_t keyType = ar_resp[i+ATTACK_KEY_COUNT].keytype;
+
+				PrintAndLog("M-Found Key%s for sector %02d: [%012"llx"]"
+					, keyType ? "B" : "A"
+					, sectorNum
+					, key
+				);
+
+				for (uint8_t ii = 0; ii<ATTACK_KEY_COUNT; ii++) {
+					if (key_cnt[ii]==0 || stSector[ii]==sectorNum) {
+						if (keyType==0) {
+							//keyA
+							sector_trailer[ii].keyA = key;
+							stSector[ii] = sectorNum;
+							key_cnt[ii]++;
+							break;
+						} else {
+							//keyB
+							sector_trailer[ii].keyB = key;
+							stSector[ii] = sectorNum;
+							key_cnt[ii]++;
+							break;
+						}
+					}
+				}
+				continue;
 			}
 		}
 	}
@@ -1100,7 +1128,7 @@ int usage_hf14_mf1ksim(void) {
 	PrintAndLog("      x    (Optional) Crack, performs the 'reader attack', nr/ar attack against a legitimate reader, fishes out the key(s)");
 	PrintAndLog("      e    (Optional) set keys found from 'reader attack' to emulator memory (implies x and i)");
 	PrintAndLog("      f    (Optional) get UIDs to use for 'reader attack' from file 'f <filename.txt>' (implies x and i)");
-	PrintAndLog("      r    (Optional) Generate random nonces instead of sequential nonces.");
+	PrintAndLog("      r    (Optional) Generate random nonces instead of sequential nonces. Standard reader attack won't work with this option, only moebius attack works.");
 	PrintAndLog("samples:");
 	PrintAndLog("           hf mf sim u 0a0a0a0a");
 	PrintAndLog("           hf mf sim u 11223344556677");
@@ -1252,7 +1280,8 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 			//got a response
 			nonces_t ar_resp[ATTACK_KEY_COUNT*2];
 			memcpy(ar_resp, resp.d.asBytes, sizeof(ar_resp));
-			readerAttack(ar_resp, setEmulatorMem);
+			// We can skip the standard attack if we have RANDOM_NONCE set.
+			readerAttack(ar_resp, setEmulatorMem, !(flags & FLAG_RANDOM_NONCE));
 			if ((bool)resp.arg[1]) {
 				PrintAndLog("Device button pressed - quitting");
 				fclose(f);
@@ -1284,7 +1313,8 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 			if (flags & FLAG_NR_AR_ATTACK) {
 				nonces_t ar_resp[ATTACK_KEY_COUNT*2];
 				memcpy(ar_resp, resp.d.asBytes, sizeof(ar_resp));
-				readerAttack(ar_resp, setEmulatorMem);
+				// We can skip the standard attack if we have RANDOM_NONCE set.
+				readerAttack(ar_resp, setEmulatorMem, !(flags & FLAG_RANDOM_NONCE));
 			}
 		}
 	}

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -1100,6 +1100,7 @@ int usage_hf14_mf1ksim(void) {
 	PrintAndLog("      x    (Optional) Crack, performs the 'reader attack', nr/ar attack against a legitimate reader, fishes out the key(s)");
 	PrintAndLog("      e    (Optional) set keys found from 'reader attack' to emulator memory (implies x and i)");
 	PrintAndLog("      f    (Optional) get UIDs to use for 'reader attack' from file 'f <filename.txt>' (implies x and i)");
+	PrintAndLog("      r    (Optional) Generate random nonces instead of sequential nonces.");
 	PrintAndLog("samples:");
 	PrintAndLog("           hf mf sim u 0a0a0a0a");
 	PrintAndLog("           hf mf sim u 11223344556677");
@@ -1163,6 +1164,11 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 		case 'N':
 			exitAfterNReads = param_get8(Cmd, pnr+1);
 			cmdp += 2;
+			break;
+		case 'r':
+		case 'R':
+			flags |= FLAG_RANDOM_NONCE;
+			cmdp++;
 			break;
 		case 'u':
 		case 'U':

--- a/include/usb_cmd.h
+++ b/include/usb_cmd.h
@@ -217,6 +217,7 @@ typedef struct{
 #define FLAG_7B_UID_IN_DATA   0x04
 #define FLAG_10B_UID_IN_DATA  0x08
 #define FLAG_NR_AR_ATTACK     0x10
+#define FLAG_RANDOM_NONCE     0x20
 
 
 //Iclass reader flags


### PR DESCRIPTION
This makes the PM3 generate pseudo-random nonces rather than sequential nonces, to make it act a bit more like a "real" MFC card.  A reader may otherwise be able to detect the PM3 probing based on the predictable nonces and throw different authentication challenges (or refuse to authenticate at all).

The code includes an implementation of a rand-like function (prand), similar to the one from libc, which is seeded automatically based on the time it takes between the PM3 starting up and the first call to the RNG.

This isn't cryptographically random, but should be "good enough" to be able to evade basic detection.

This is [a port of a similar patch I wrote for @iceman1001's branch](https://github.com/micolous/proxmark3/commit/3508ed9eb5257ede1e32039e37e9af0b0060ed83), except this uses a different set of [LCG](https://en.wikipedia.org/wiki/Linear_congruential_generator) parameters.

I haven't seen any readers in the wild attempt to detect the sequential nonces (the ones in Proxmark upstream `n*=7` are slightly harder to predict than @iceman1001's branch `n++`), but I suspect that it is possible.

I wrote this code while trying to troubleshoot key extraction with one particularly difficult reader, but it turns out that I just had another bug in my code.