### PR TITLE
Add Flag for compile warnings, lf cotag read by iceman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
 
 ### Added
+- Added lf cotag read, and added it to lf search (iceman)
 - Added hitag2 read UID only and added that to lf search (marshmellow)
 - Added lf pyramid commands (iceman)
 - Added lf presco commands - some bits not fully understood... (iceman)

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1028,6 +1028,9 @@ void UsbPacketReceived(uint8_t *packet, int len)
 		case CMD_VIKING_CLONE_TAG:
 			CopyVikingtoT55xx(c->arg[0], c->arg[1], c->arg[2]);
 			break;
+		case CMD_COTAG:
+			Cotag(c->arg[0]);
+			break;
 #endif
 
 #ifdef WITH_HITAG

--- a/armsrc/apps.h
+++ b/armsrc/apps.h
@@ -89,6 +89,7 @@ void TurnReadLFOn();
 //void T55xxReadTrace(void);
 void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode);
 void EM4xWriteWord(uint32_t Data, uint8_t Address, uint32_t Pwd, uint8_t PwdMode);
+void Cotag(uint32_t arg0);
 
 /// iso14443.h
 void SimulateIso14443bTag(void);

--- a/armsrc/lfsampling.h
+++ b/armsrc/lfsampling.h
@@ -2,6 +2,13 @@
 #define LFSAMPLING_H
 
 /**
+* acquisition of Cotag LF signal. Similar to other LF,  since the Cotag has such long datarate RF/384
+* and is Manchester?,  we directly gather the manchester data into bigbuff
+**/
+void doCotagAcquisition(size_t sample_size);
+uint32_t doCotagAcquisitionManchester(void);
+
+/**
 * acquisition of T55x7 LF signal. Similart to other LF, but adjusted with @marshmellows thresholds
 * the data is collected in BigBuf.
 **/

--- a/armsrc/util.c
+++ b/armsrc/util.c
@@ -345,7 +345,7 @@ void StartCountUS()
 	}
 
 uint32_t RAMFUNC GetCountUS(){
-	return (AT91C_BASE_TC1->TC_CV * 0x8000) + ((AT91C_BASE_TC0->TC_CV / 15) * 10);
+	return (AT91C_BASE_TC1->TC_CV * 0x8000) + ((AT91C_BASE_TC0->TC_CV * 2) / 3); //was  /15) * 10);
 }
 
 static uint32_t GlobalUsCounter = 0;
@@ -418,8 +418,13 @@ void StartCountSspClk()
 	// we can use the counter.
 	while (AT91C_BASE_TC0->TC_CV < 0xFFF0);
 }
-
-
+void ResetSspClk(void) {
+	//enable clock of timer and software trigger
+	AT91C_BASE_TC0->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
+	AT91C_BASE_TC1->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
+	AT91C_BASE_TC2->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
+	while (AT91C_BASE_TC2->TC_CV > 0);
+}
 uint32_t RAMFUNC GetCountSspClk(){
 	uint32_t tmp_count;
 	tmp_count = (AT91C_BASE_TC2->TC_CV << 16) | AT91C_BASE_TC0->TC_CV;
@@ -429,6 +434,67 @@ uint32_t RAMFUNC GetCountSspClk(){
 	else {
 		return tmp_count;
 	}
+}
+
+//  -------------------------------------------------------------------------
+//  Timer for bitbanging,  or LF stuff when you need a very precis timer
+//  1us = 1.5ticks
+//  -------------------------------------------------------------------------
+void StartTicks(void){
+	//initialization of the timer
+	// tc1 is higher 0xFFFF0000
+	// tc0 is lower 0x0000FFFF
+	AT91C_BASE_PMC->PMC_PCER |= (1 << AT91C_ID_TC0) | (1 << AT91C_ID_TC1);
+	AT91C_BASE_TCB->TCB_BMR = AT91C_TCB_TC0XC0S_NONE | AT91C_TCB_TC1XC1S_TIOA0 | AT91C_TCB_TC2XC2S_NONE;
+	AT91C_BASE_TC0->TC_CCR = AT91C_TC_CLKDIS;
+	AT91C_BASE_TC0->TC_CMR = AT91C_TC_CLKS_TIMER_DIV3_CLOCK | // MCK(48MHz) / 32 
+								AT91C_TC_WAVE | AT91C_TC_WAVESEL_UP_AUTO | AT91C_TC_ACPA_CLEAR |
+								AT91C_TC_ACPC_SET | AT91C_TC_ASWTRG_SET;
+	AT91C_BASE_TC0->TC_RA = 1;
+	AT91C_BASE_TC0->TC_RC = 0; 
+
+	AT91C_BASE_TC1->TC_CCR = AT91C_TC_CLKDIS;	// timer disable  
+	AT91C_BASE_TC1->TC_CMR = AT91C_TC_CLKS_XC1; // from TC0
+	
+	AT91C_BASE_TC0->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
+	AT91C_BASE_TC1->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
+	AT91C_BASE_TCB->TCB_BCR = 1;
+	
+	// wait until timer becomes zero.
+	while (AT91C_BASE_TC1->TC_CV > 0);
+}
+
+// Wait - Spindelay in ticks.
+// if called with a high number, this will trigger the WDT...
+void WaitTicks(uint32_t ticks){
+	if ( ticks == 0 ) return;
+	ticks += GET_TICKS;	
+	while (GET_TICKS < ticks);
+}
+// Wait / Spindelay in us (microseconds) 
+// 1us = 1.5ticks.
+void WaitUS(uint16_t us){
+	if ( us == 0 ) return;
+	WaitTicks(  (uint32_t)(us * 1.5) );
+}
+void WaitMS(uint16_t ms){
+	if (ms == 0) return;
+	WaitTicks( (uint32_t)(ms * 1500) );
+}
+// Starts Clock and waits until its reset
+void ResetTicks(void){
+	AT91C_BASE_TC0->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
+	AT91C_BASE_TC1->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
+	while (AT91C_BASE_TC1->TC_CV > 0);
+}
+void ResetTimer(AT91PS_TC timer){
+	timer->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
+	while(timer->TC_CV > 0) ;
+}
+// stop clock
+void StopTicks(void){
+	AT91C_BASE_TC0->TC_CCR = AT91C_TC_CLKDIS;
+	AT91C_BASE_TC1->TC_CCR = AT91C_TC_CLKDIS;	
 }
 
 static uint64_t next_random = 1;

--- a/armsrc/util.h
+++ b/armsrc/util.h
@@ -36,13 +36,19 @@ void rol(uint8_t *data, const size_t len);
 void lsl (uint8_t *data, size_t len);
 int32_t le24toh (uint8_t data[3]);
 
-void SpinDelay(int ms);
-void SpinDelayUs(int us);
 void LED(int led, int ms);
 void LEDsoff();
 int BUTTON_CLICKED(int ms);
 int BUTTON_HELD(int ms);
 void FormatVersionInformation(char *dst, int len, const char *prefix, void *version_information);
+
+//iceman's ticks.h
+#ifndef GET_TICKS
+# define GET_TICKS   (uint32_t)((AT91C_BASE_TC1->TC_CV << 16) | AT91C_BASE_TC0->TC_CV)
+#endif
+
+void SpinDelay(int ms);
+void SpinDelayUs(int us);
 
 void StartTickCount();
 uint32_t RAMFUNC GetTickCount();
@@ -52,7 +58,17 @@ uint32_t RAMFUNC GetCountUS();
 uint32_t RAMFUNC GetDeltaCountUS();
 
 void StartCountSspClk();
+void ResetSspClk(void);
 uint32_t RAMFUNC GetCountSspClk();
+
+extern void StartTicks(void);
+extern void WaitTicks(uint32_t ticks);
+extern void WaitUS(uint16_t us);
+extern void WaitMS(uint16_t ms);
+extern void ResetTicks();
+extern void ResetTimer(AT91PS_TC timer);
+extern void StopTicks(void);
+// end iceman's ticks.h
 
 uint32_t prand();
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -103,6 +103,7 @@ CMDSRCS = 	nonce2key/crapto1.c\
 			cmdlfviking.c\
 			cmdlfpresco.c\
 			cmdlfpyramid.c\
+			cmdlfcotag.c\
 			pm3_binlib.c\
 			scripting.c\
 			cmdscript.c\

--- a/client/Makefile
+++ b/client/Makefile
@@ -19,6 +19,7 @@ CFLAGS = -std=c99 -I. -I../include -I../common -I../zlib -I/opt/local/include -I
 LUAPLATFORM = generic
 
 ifneq (,$(findstring MINGW,$(platform)))
+    CFLAGS += -D__USE_MINGW_ANSI_STDIO=1
     CXXFLAGS = -I$(QTDIR)/include -I$(QTDIR)/include/QtCore -I$(QTDIR)/include/QtGui
     MOC = $(QTDIR)/bin/moc
     LUAPLATFORM = mingw

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -33,6 +33,8 @@
 #include "cmdlfpcf7931.h"// for pcf7931 menu
 #include "cmdlfpyramid.h"// for pyramid menu
 #include "cmdlfviking.h" // for viking menu
+#include "cmdlfcotag.h"  // for COTAG menu
+
 
 static int CmdHelp(const char *Cmd);
 
@@ -1080,6 +1082,7 @@ int CmdVchDemod(const char *Cmd)
 int CmdLFfind(const char *Cmd)
 {
 	int ans=0;
+	size_t minLength = 1000;
 	char cmdp = param_getchar(Cmd, 0);
 	char testRaw = param_getchar(Cmd, 1);
 	if (strlen(Cmd) > 3 || cmdp == 'h' || cmdp == 'H') {
@@ -1098,7 +1101,7 @@ int CmdLFfind(const char *Cmd)
 	if (!offline && (cmdp != '1')){
 		CmdLFRead("s");
 		getSamples("30000",false);
-	} else if (GraphTraceLen < 1000) {
+	} else if (GraphTraceLen < minLength) {
 		PrintAndLog("Data in Graphbuffer was too small.");
 		return 0;
 	}
@@ -1107,6 +1110,24 @@ int CmdLFfind(const char *Cmd)
 	PrintAndLog("NOTE: some demods output possible binary\n  if it finds something that looks like a tag");
 	PrintAndLog("False Positives ARE possible\n");  
 	PrintAndLog("\nChecking for known tags:\n");
+
+	size_t testLen = minLength;
+	// only run if graphbuffer is just noise as it should be for hitag/cotag
+	if (graphJustNoise(GraphBuffer, testLen)) {
+		// only run these tests if we are in online mode 
+		if (!offline && (cmdp != '1')){
+			ans=CmdLFHitagReader("26");
+			if (ans==0) {
+				return 1;
+			}
+			ans=CmdCOTAGRead("");
+			if (ans>0){
+				PrintAndLog("\nValid COTAG ID Found!");
+				return 1;
+			}
+		}
+		return 0;
+	}
 
 	ans=CmdFSKdemodIO("");
 	if (ans>0) {
@@ -1180,17 +1201,6 @@ int CmdLFfind(const char *Cmd)
 		return 1;
 	}
 
-	size_t testLen = (GraphTraceLen < 500) ? GraphTraceLen : 500;
-	// only run if graphbuffer is just noise as it should be for hitag
-	if (graphJustNoise(GraphBuffer, testLen)) { 
-		if (!offline && (cmdp != '1')){
-			ans=CmdLFHitagReader("26");
-			if (ans==0) {
-				return 1;
-			}
-		}
-	}
-
 	PrintAndLog("\nNo Known Tags Found!\n");
 	if (testRaw=='u' || testRaw=='U'){
 		//test unknown tag formats (raw mode)
@@ -1228,6 +1238,7 @@ static command_t CommandTable[] =
 {
 	{"help",        CmdHelp,            1, "This help"},
 	{"awid",        CmdLFAWID,          1, "{ AWID RFIDs...    }"},
+	{"cotag",       CmdLFCOTAG,         1, "{ COTAG RFIDs...   }"},
 	{"em4x",        CmdLFEM4X,          1, "{ EM4X RFIDs...    }"},
 	{"hid",         CmdLFHID,           1, "{ HID RFIDs...     }"},
 	{"hitag",       CmdLFHitag,         1, "{ Hitag tags and transponders... }"},

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -1180,10 +1180,14 @@ int CmdLFfind(const char *Cmd)
 		return 1;
 	}
 
-	if (!offline && (cmdp != '1')){
-		ans=CmdLFHitagReader("26");
-		if (ans==0) {
-			return 1;
+	size_t testLen = (GraphTraceLen < 500) ? GraphTraceLen : 500;
+	// only run if graphbuffer is just noise as it should be for hitag
+	if (graphJustNoise(GraphBuffer, testLen)) { 
+		if (!offline && (cmdp != '1')){
+			ans=CmdLFHitagReader("26");
+			if (ans==0) {
+				return 1;
+			}
 		}
 	}
 

--- a/client/cmdlfcotag.c
+++ b/client/cmdlfcotag.c
@@ -1,0 +1,120 @@
+//-----------------------------------------------------------------------------
+// Authored by Iceman
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// Low frequency COTAG commands
+//-----------------------------------------------------------------------------
+#include "cmdlfcotag.h"  // COTAG function declarations
+
+static int CmdHelp(const char *Cmd);
+
+int usage_lf_cotag_read(void){
+	PrintAndLog("Usage: lf COTAG read [h] <signaldata>");
+	PrintAndLog("Options:");
+	PrintAndLog("      h          : This help");
+	PrintAndLog("      <0|1|2>    : 0 - HIGH/LOW signal; maxlength bigbuff");
+	PrintAndLog("                 : 1 - translation of HI/LO into bytes with manchester 0,1");
+	PrintAndLog("                 : 2 - raw signal; maxlength bigbuff");
+	PrintAndLog("");
+	PrintAndLog("Sample:");
+	PrintAndLog("        lf cotag read 0");
+	PrintAndLog("        lf cotag read 1");
+	return 0;
+}
+
+// COTAG demod should be able to use GraphBuffer,
+// when data load samples
+int CmdCOTAGDemod(const char *Cmd) {
+
+	uint8_t bits[COTAG_BITS] = {0};
+	size_t bitlen = COTAG_BITS;
+	memcpy(bits, DemodBuffer, COTAG_BITS);
+	
+	int err = manrawdecode(bits, &bitlen, 1);
+	if (err){
+		if (g_debugMode) PrintAndLog("DEBUG: Error - COTAG too many errors: %d", err);
+		return -1;
+	}
+
+	setDemodBuf(bits, bitlen, 0);
+
+	//got a good demod
+	uint16_t cn = bytebits_to_byteLSBF(bits+1, 16);
+	uint32_t fc = bytebits_to_byteLSBF(bits+1+16, 8);
+	
+	uint32_t raw1 = bytebits_to_byteLSBF(bits, 32);
+	uint32_t raw2 = bytebits_to_byteLSBF(bits+32, 32);
+	uint32_t raw3 = bytebits_to_byteLSBF(bits+64, 32);
+	uint32_t raw4 = bytebits_to_byteLSBF(bits+96, 32);
+	
+	/*
+	fc 161:   1010 0001 -> LSB 1000 0101
+	cn 33593  1000 0011 0011 1001 -> LSB 1001 1100 1100 0001
+        cccc cccc cccc cccc                     ffffffff
+	  0 1001 1100 1100 0001 1000 0101 0000 0000 100001010000000001111011100000011010000010000000000000000000000000000000000000000000000000000000100111001100000110000101000
+        1001 1100 1100 0001                     10000101                                                                                         
+	*/
+	PrintAndLog("COTAG Found: FC %u, CN: %u Raw: %08X%08X%08X%08X", fc, cn, raw1 ,raw2, raw3, raw4);
+	return 1;
+}
+
+// When reading a COTAG.
+// 0 = HIGH/LOW signal - maxlength bigbuff
+// 1 = translation for HI/LO into bytes with manchester 0,1 - length 300
+// 2 = raw signal -  maxlength bigbuff		
+int CmdCOTAGRead(const char *Cmd) {
+	
+	if (Cmd[0] == 'h' || Cmd[0] == 'H') return usage_lf_cotag_read();
+	
+	uint32_t rawsignal = 1;
+	sscanf(Cmd, "%u", &rawsignal);
+ 
+	UsbCommand c = {CMD_COTAG, {rawsignal, 0, 0}};
+	clearCommandBuffer();
+	SendCommand(&c);
+	if ( !WaitForResponseTimeout(CMD_ACK, NULL, 7000) ) {
+		PrintAndLog("command execution time out");
+		return -1;	
+	}
+	
+	switch ( rawsignal ){
+		case 0: 
+		case 2: {
+			CmdPlot("");
+			CmdGrid("384");
+			getSamples("", true); break;
+		}
+		case 1: {
+			GetFromBigBuf(DemodBuffer, COTAG_BITS, 0);
+			DemodBufferLen = COTAG_BITS;
+			UsbCommand response;
+			if ( !WaitForResponseTimeout(CMD_ACK, &response, 1000) ) {
+				PrintAndLog("timeout while waiting for reply.");
+				return -1;
+			}
+			return CmdCOTAGDemod("");
+		}
+	}	
+	return 0;
+}
+
+static command_t CommandTable[] = {
+	{"help",      CmdHelp,         1, "This help"},
+	{"demod",     CmdCOTAGDemod,   1, "Tries to decode a COTAG signal"},
+	{"read",      CmdCOTAGRead,    0, "Attempt to read and extract tag data"},
+	{NULL, NULL, 0, NULL}
+};
+
+int CmdLFCOTAG(const char *Cmd) {
+	clearCommandBuffer();
+	CmdsParse(CommandTable, Cmd);
+	return 0;
+}
+
+int CmdHelp(const char *Cmd) {
+	CmdsHelp(CommandTable);
+	return 0;
+}

--- a/client/cmdlfcotag.h
+++ b/client/cmdlfcotag.h
@@ -1,0 +1,32 @@
+//-----------------------------------------------------------------------------
+// Authored by Iceman
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// Low frequency COTAG commands
+//-----------------------------------------------------------------------------
+
+#ifndef CMDLFCOTAG_H__
+#define CMDLFCOTAG_H__
+
+#include "proxmark3.h"// Definitions, USB controls, COTAG_BITS
+#include "util.h"     // FALSE / TRUE
+#include "cmddata.h"  // getSamples
+#include "cmdparser.h"// CmdsParse, CmdsHelp
+#include "cmdmain.h"
+#include "ui.h"       // PrintAndLog
+#include "cmdlf.h"    // Setconfig 
+#include "lfdemod.h"  // manrawdecode, bytebits_tobyteLSBF
+
+#ifndef COTAG_BITS
+#define COTAG_BITS 264
+#endif
+
+int CmdLFCOTAG(const char *Cmd);
+int CmdCOTAGRead(const char *Cmd);
+int CmdCOTAGDemod(const char *Cmd);
+
+int usage_lf_cotag_read(void);
+#endif

--- a/client/graph.c
+++ b/client/graph.c
@@ -270,7 +270,7 @@ uint8_t fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, bool verbose)
 }
 bool graphJustNoise(int *BitStream, int size)
 {
-	static const uint8_t THRESHOLD = 10; //might not be high enough for noisy environments
+	static const uint8_t THRESHOLD = 15; //might not be high enough for noisy environments
 	//test samples are not just noise
 	bool justNoise1 = 1;
 	for(int idx=0; idx < size && justNoise1 ;idx++){

--- a/client/graph.c
+++ b/client/graph.c
@@ -268,3 +268,13 @@ uint8_t fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, bool verbose)
 	}
 	return 1;
 }
+bool graphJustNoise(int *BitStream, int size)
+{
+	static const uint8_t THRESHOLD = 10; //might not be high enough for noisy environments
+	//test samples are not just noise
+	bool justNoise1 = 1;
+	for(int idx=0; idx < size && justNoise1 ;idx++){
+		justNoise1 = BitStream[idx] < THRESHOLD;
+	}
+	return justNoise1;
+}

--- a/client/graph.h
+++ b/client/graph.h
@@ -22,6 +22,7 @@ uint8_t GetPskCarrier(const char str[], bool printAns, bool verbose);
 uint8_t GetNrzClock(const char str[], bool printAns, bool verbose);
 uint8_t GetFskClock(const char str[], bool printAns, bool verbose);
 uint8_t fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, bool verbose);
+bool graphJustNoise(int *BitStream, int size);
 void setGraphBuf(uint8_t *buff, size_t size);
 void save_restoreGB(uint8_t saveOpt);
 

--- a/client/hid-flasher/usb_cmd.h
+++ b/client/hid-flasher/usb_cmd.h
@@ -87,6 +87,7 @@ typedef struct {
 #define CMD_AWID_DEMOD_FSK                                                0x0221
 #define CMD_VIKING_CLONE_TAG                                              0x0223
 #define CMD_T55XX_WAKEUP                                                  0x0224
+#define CMD_COTAG                                                         0x0225
 
 /* CMD_SET_ADC_MUX: ext1 is 0 for lopkd, 1 for loraw, 2 for hipkd, 3 for hiraw */
 

--- a/client/lualibs/commands.lua
+++ b/client/lualibs/commands.lua
@@ -58,6 +58,7 @@ local _commands = {
 	CMD_AWID_DEMOD_FSK =                                                 0x0221,
 	CMD_VIKING_CLONE_TAG =                                               0x0223,
 	CMD_T55XX_WAKEUP =                                                   0x0224,
+	CMD_COTAG =                                                          0x0225,
 	--/* CMD_SET_ADC_MUX: ext1 is 0 for lopkd, 1 for loraw, 2 for hipkd, 3 for hiraw */
 
 	--// For the 13.56 MHz tags

--- a/include/usb_cmd.h
+++ b/include/usb_cmd.h
@@ -101,6 +101,7 @@ typedef struct{
 #define CMD_AWID_DEMOD_FSK                                                0x0221
 #define CMD_VIKING_CLONE_TAG                                              0x0223
 #define CMD_T55XX_WAKEUP                                                  0x0224
+#define CMD_COTAG                                                         0x0225
 
 
 /* CMD_SET_ADC_MUX: ext1 is 0 for lopkd, 1 for loraw, 2 for hipkd, 3 for hiraw */


### PR DESCRIPTION
D__USE_MINGW_ANSI_STDIO=1 needed for some compilers on W32
added iceman1001 s lf cotag read (plus some timer functions)
added check for wave in graphbuffer and test in lf search, don't try hitag or cotag tests if wave exists.
