### PR TITLE
EM4x05/EM4x69 command rewrite and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
 
 ### Added
+- Added EM4x05/EM4x69 chip detection to lf search (marshmellow) 
+- Added lf em 4x05dump command to read and output all the blocks of the chip (marshmellow)
+- Added lf em 4x05info command to read and display information about the chip (marshmellow)
 - Added lf cotag read, and added it to lf search (iceman)
 - Added hitag2 read UID only and added that to lf search (marshmellow)
 - Added lf pyramid commands (iceman)
@@ -38,6 +41,10 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added option c to 'hf list' (mark CRC bytes) (piwi)
 
 ### Changed
+- small changes to lf psk and fsk demods to improve results when the trace begins with noise or the chip isn't broadcasting yet (marshmellow)
+- NOTE CHANGED ALL `lf em4x em*` cmds to simpler `lf em ` - example: `lf em4x em410xdemod` is now `lf em 410xdemod`
+- Renamed and rebuilt `lf em readword` && readwordpwd to `lf em 4x05readword` - it now demods and outputs the read block (marshmellow/iceman)
+- Renamed and rebuilt `lf em writeword` && writewordpwd to `lf em 4x05writeword` - it now also reads validation output from the tag (marshmellow/iceman)
 - Fixed bug in lf sim and continuous demods not turning off antenna when finished
 - Fixed bug(s) in hf iclass write
 - Fixed bug in lf biphase sim - `lf simask b` (and any tagtype that relies on it - gproxii...) (marshmellow)

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1017,10 +1017,10 @@ void UsbPacketReceived(uint8_t *packet, int len)
 			WritePCF7931(c->d.asBytes[0],c->d.asBytes[1],c->d.asBytes[2],c->d.asBytes[3],c->d.asBytes[4],c->d.asBytes[5],c->d.asBytes[6], c->d.asBytes[9], c->d.asBytes[7]-128,c->d.asBytes[8]-128, c->arg[0], c->arg[1], c->arg[2]);
 			break;
 		case CMD_EM4X_READ_WORD:
-			EM4xReadWord(c->arg[1], c->arg[2],c->d.asBytes[0]);
+			EM4xReadWord(c->arg[0], c->arg[1],c->arg[2]);
 			break;
 		case CMD_EM4X_WRITE_WORD:
-			EM4xWriteWord(c->arg[0], c->arg[1], c->arg[2], c->d.asBytes[0]);
+			EM4xWriteWord(c->arg[0], c->arg[1], c->arg[2]);
 			break;
 		case CMD_AWID_DEMOD_FSK: // Set realtime AWID demodulation
 			CmdAWIDdemodFSK(c->arg[0], 0, 0, 1);

--- a/armsrc/apps.h
+++ b/armsrc/apps.h
@@ -88,7 +88,7 @@ void T55xxWakeUp(uint32_t Pwd);
 void TurnReadLFOn();
 //void T55xxReadTrace(void);
 void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode);
-void EM4xWriteWord(uint32_t Data, uint8_t Address, uint32_t Pwd, uint8_t PwdMode);
+void EM4xWriteWord(uint32_t flag, uint32_t Data, uint32_t Pwd);
 void Cotag(uint32_t arg0);
 
 /// iso14443.h

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1628,7 +1628,7 @@ void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
 	SendForward(fwd_bit_count);
 
 	// Now do the acquisition
-	doT55x7Acquisition(6000);
+	DoPartialAcquisition(20, true, 5500);
 	
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
 	LED_A_OFF();
@@ -1656,10 +1656,10 @@ void EM4xWriteWord(uint32_t flag, uint32_t Data, uint32_t Pwd) {
 	SendForward(fwd_bit_count);
 
 	//Wait for write to complete
-	SpinDelay(10);
+	//SpinDelay(10);
 
 	//Capture response if one exists
-	DoAcquisition_default(20, TRUE);
+	DoPartialAcquisition(20, true, 5500);
 
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
 	LED_A_OFF();

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1628,7 +1628,7 @@ void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
 	SendForward(fwd_bit_count);
 
 	// Now do the acquisition
-	DoAcquisition_default(30,TRUE);
+	DoAcquisition_default(0,TRUE);
 	
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
 	LED_A_OFF();
@@ -1656,7 +1656,7 @@ void EM4xWriteWord(uint32_t flag, uint32_t Data, uint32_t Pwd) {
 	SendForward(fwd_bit_count);
 
 	//Wait for write to complete
-	SpinDelayUs(8000);
+	SpinDelay(10);
 
 	//Capture response if one exists
 	DoAcquisition_default(20, TRUE);

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -684,7 +684,7 @@ void CmdASKsimTag(uint16_t arg1, uint16_t arg2, size_t size, uint8_t *BitStream)
 		for (i=0; i<size; i++){
 			askSimBit(BitStream[i]^invert, &n, clk, encoding);
 		}
-		if (encoding==0 && BitStream[0]==BitStream[size-1]){ //run a second set inverted (for biphase phase)
+		if (encoding==0 && BitStream[0]==BitStream[size-1]){ //run a second set inverted (for ask/raw || biphase phase)
 			for (i=0; i<size; i++){
 				askSimBit(BitStream[i]^invert^1, &n, clk, encoding);
 			}
@@ -1358,7 +1358,7 @@ void CopyIndala224toT55x7(uint32_t uid1, uint32_t uid2, uint32_t uid3, uint32_t 
 	//Config for Indala (RF/32;PSK1 with RF/2;Maxblock=7)
 	data[0] = T55x7_BITRATE_RF_32 | T55x7_MODULATION_PSK1 | (7 << T55x7_MAXBLOCK_SHIFT);
 	//TODO add selection of chip for Q5 or T55x7
-	// data[0] = (((32-2)/2)<<T5555_BITRATE_SHIFT) | T5555_MODULATION_PSK1 | 7 << T5555_MAXBLOCK_SHIFT;
+	// data[0] = (((32-2)>>1)<<T5555_BITRATE_SHIFT) | T5555_MODULATION_PSK1 | 7 << T5555_MAXBLOCK_SHIFT;
 	WriteT55xx(data, 0, 8);
 	//Alternative config for Indala (Extended mode;RF/32;PSK1 with RF/2;Maxblock=7;Inverse data)
 	//	T5567WriteBlock(0x603E10E2,0);
@@ -1367,7 +1367,7 @@ void CopyIndala224toT55x7(uint32_t uid1, uint32_t uid2, uint32_t uid3, uint32_t 
 // clone viking tag to T55xx
 void CopyVikingtoT55xx(uint32_t block1, uint32_t block2, uint8_t Q5) {
 	uint32_t data[] = {T55x7_BITRATE_RF_32 | T55x7_MODULATION_MANCHESTER | (2 << T55x7_MAXBLOCK_SHIFT), block1, block2};
-	if (Q5) data[0] = (32 << T5555_BITRATE_SHIFT) | T5555_MODULATION_MANCHESTER | 2 << T5555_MAXBLOCK_SHIFT;
+	if (Q5) data[0] = ( ((32-2)>>1) << T5555_BITRATE_SHIFT) | T5555_MODULATION_MANCHESTER | 2 << T5555_MAXBLOCK_SHIFT;
 	// Program the data blocks for supplied ID and the block 0 config
 	WriteT55xx(data, 0, 3);
 	LED_D_OFF();
@@ -1571,8 +1571,6 @@ void SendForward(uint8_t fwd_bit_count) {
 	fwd_write_ptr = forwardLink_data;
 	fwd_bit_sz = fwd_bit_count;
 
-	LED_D_ON();
-
 	// Set up FPGA, 125kHz
 	LFSetupFPGAForADC(95, true);
 
@@ -1580,7 +1578,7 @@ void SendForward(uint8_t fwd_bit_count) {
 	fwd_bit_sz--; //prepare next bit modulation
 	fwd_write_ptr++;
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
-	SpinDelayUs(55*8); //55 cycles off (8us each)for 4305
+	SpinDelayUs(56*8); //55 cycles off (8us each)for 4305
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_ADC | FPGA_LF_ADC_READER_FIELD);//field on
 	SpinDelayUs(16*8); //16 cycles on (8us each)
 
@@ -1591,9 +1589,9 @@ void SendForward(uint8_t fwd_bit_count) {
 		else {
 			//These timings work for 4469/4269/4305 (with the 55*8 above)
 			FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
-			SpinDelayUs(23*8); //16-4 cycles off (8us each)
+			SpinDelayUs(20*8); //16-4 cycles off (8us each) //23
 			FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_ADC | FPGA_LF_ADC_READER_FIELD);//field on
-			SpinDelayUs(9*8); //16 cycles on (8us each)
+			SpinDelayUs(12*8); //16 cycles on (8us each) //9
 		}
 	}
 }
@@ -1615,13 +1613,11 @@ void EM4xLogin(uint32_t Password) {
 void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
 
 	uint8_t fwd_bit_count;
-	uint8_t *dest = BigBuf_get_addr();
-	uint16_t bufferlength = BigBuf_max_traceLen();
-	uint32_t i = 0;
 
 	// Clear destination buffer before sending the command
 	BigBuf_Clear_ext(false);
 
+	LED_A_ON();
 	//If password mode do login
 	if (PwdMode == 1) EM4xLogin(Pwd);
 
@@ -1629,36 +1625,28 @@ void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
 	fwd_bit_count = Prepare_Cmd( FWD_CMD_READ );
 	fwd_bit_count += Prepare_Addr( Address );
 
-	// Connect the A/D to the peak-detected low-frequency path.
-	SetAdcMuxFor(GPIO_MUXSEL_LOPKD);
-	// Now set up the SSC to get the ADC samples that are now streaming at us.
-	FpgaSetupSsc();
-
 	SendForward(fwd_bit_count);
 
 	// Now do the acquisition
-	i = 0;
-	for(;;) {
-		if (AT91C_BASE_SSC->SSC_SR & AT91C_SSC_TXRDY) {
-			AT91C_BASE_SSC->SSC_THR = 0x43;
-		}
-		if (AT91C_BASE_SSC->SSC_SR & AT91C_SSC_RXRDY) {
-			dest[i] = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
-			i++;
-			if (i >= bufferlength) break;
-		}
-	}
+	DoAcquisition_config(TRUE);
+	
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
+	LED_A_OFF();
 	cmd_send(CMD_ACK,0,0,0,0,0);
-	LED_D_OFF();
 }
 
-void EM4xWriteWord(uint32_t Data, uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
-
+void EM4xWriteWord(uint32_t flag, uint32_t Data, uint32_t Pwd) {
+	
+	bool PwdMode = (flag & 0xF);
+	uint8_t Address = (flag >> 8) & 0xFF;
 	uint8_t fwd_bit_count;
 
+	//clear buffer now so it does not interfere with timing later
+	BigBuf_Clear_ext(false);
+
+	LED_A_ON();
 	//If password mode do login
-	if (PwdMode == 1) EM4xLogin(Pwd);
+	if (PwdMode) EM4xLogin(Pwd);
 
 	forward_ptr = forwardLink_data;
 	fwd_bit_count = Prepare_Cmd( FWD_CMD_WRITE );
@@ -1669,8 +1657,13 @@ void EM4xWriteWord(uint32_t Data, uint8_t Address, uint32_t Pwd, uint8_t PwdMode
 
 	//Wait for write to complete
 	SpinDelay(20);
+
+	//Capture response if one exists
+	DoAcquisition_config(TRUE);
+
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
-	LED_D_OFF();
+	LED_A_OFF();
+	cmd_send(CMD_ACK,0,0,0,0,0);
 }
 /*
 Reading a COTAG.

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1573,12 +1573,12 @@ void SendForward(uint8_t fwd_bit_count) {
 
 	// Set up FPGA, 125kHz
 	LFSetupFPGAForADC(95, true);
-
+	
 	// force 1st mod pulse (start gap must be longer for 4305)
 	fwd_bit_sz--; //prepare next bit modulation
 	fwd_write_ptr++;
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
-	SpinDelayUs(56*8); //55 cycles off (8us each)for 4305
+	SpinDelayUs(55*8); //55 cycles off (8us each)for 4305
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_ADC | FPGA_LF_ADC_READER_FIELD);//field on
 	SpinDelayUs(16*8); //16 cycles on (8us each)
 
@@ -1628,7 +1628,7 @@ void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
 	SendForward(fwd_bit_count);
 
 	// Now do the acquisition
-	DoAcquisition_config(TRUE);
+	DoAcquisition_default(30,TRUE);
 	
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
 	LED_A_OFF();
@@ -1656,10 +1656,10 @@ void EM4xWriteWord(uint32_t flag, uint32_t Data, uint32_t Pwd) {
 	SendForward(fwd_bit_count);
 
 	//Wait for write to complete
-	SpinDelay(20);
+	//SpinDelay(5);
 
 	//Capture response if one exists
-	DoAcquisition_config(TRUE);
+	DoAcquisition_default(30, TRUE);
 
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
 	LED_A_OFF();

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1626,7 +1626,7 @@ void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
 	fwd_bit_count += Prepare_Addr( Address );
 
 	SendForward(fwd_bit_count);
-
+	SpinDelayUs(700);
 	// Now do the acquisition
 	DoPartialAcquisition(20, true, 5500);
 	
@@ -1658,6 +1658,7 @@ void EM4xWriteWord(uint32_t flag, uint32_t Data, uint32_t Pwd) {
 	//Wait for write to complete
 	//SpinDelay(10);
 
+	SpinDelayUs(6500);
 	//Capture response if one exists
 	DoPartialAcquisition(20, true, 5500);
 

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1656,10 +1656,10 @@ void EM4xWriteWord(uint32_t flag, uint32_t Data, uint32_t Pwd) {
 	SendForward(fwd_bit_count);
 
 	//Wait for write to complete
-	//SpinDelay(5);
+	SpinDelayUs(8000);
 
 	//Capture response if one exists
-	DoAcquisition_default(30, TRUE);
+	DoAcquisition_default(20, TRUE);
 
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
 	LED_A_OFF();

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1628,7 +1628,7 @@ void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
 	SendForward(fwd_bit_count);
 
 	// Now do the acquisition
-	DoAcquisition_default(0,TRUE);
+	doT55x7Acquisition(6000);
 	
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
 	LED_A_OFF();

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1626,9 +1626,9 @@ void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
 	fwd_bit_count += Prepare_Addr( Address );
 
 	SendForward(fwd_bit_count);
-	SpinDelayUs(700);
+	SpinDelayUs(400);
 	// Now do the acquisition
-	DoPartialAcquisition(20, true, 5500);
+	DoPartialAcquisition(20, true, 6000);
 	
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
 	LED_A_OFF();
@@ -1660,7 +1660,7 @@ void EM4xWriteWord(uint32_t flag, uint32_t Data, uint32_t Pwd) {
 
 	SpinDelayUs(6500);
 	//Capture response if one exists
-	DoPartialAcquisition(20, true, 5500);
+	DoPartialAcquisition(20, true, 6000);
 
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
 	LED_A_OFF();

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1573,14 +1573,14 @@ void SendForward(uint8_t fwd_bit_count) {
 
 	// Set up FPGA, 125kHz
 	LFSetupFPGAForADC(95, true);
-	
+
 	// force 1st mod pulse (start gap must be longer for 4305)
 	fwd_bit_sz--; //prepare next bit modulation
 	fwd_write_ptr++;
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
-	SpinDelayUs(55*8); //55 cycles off (8us each)for 4305
+	SpinDelayUs(56*8); //55 cycles off (8us each)for 4305  /another reader has 37 here...
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_ADC | FPGA_LF_ADC_READER_FIELD);//field on
-	SpinDelayUs(16*8); //16 cycles on (8us each)
+	SpinDelayUs(18*8); //16 cycles on (8us each)  // another reader has 18 here
 
 	// now start writting
 	while(fwd_bit_sz-- > 0) { //prepare next bit modulation
@@ -1589,9 +1589,9 @@ void SendForward(uint8_t fwd_bit_count) {
 		else {
 			//These timings work for 4469/4269/4305 (with the 55*8 above)
 			FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
-			SpinDelayUs(20*8); //16-4 cycles off (8us each) //23
+			SpinDelayUs(23*8); //16-4 cycles off (8us each) //23  //one reader goes as high as 25 here
 			FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_ADC | FPGA_LF_ADC_READER_FIELD);//field on
-			SpinDelayUs(12*8); //16 cycles on (8us each) //9
+			SpinDelayUs(16*8); //16 cycles on (8us each) //9  // another reader goes to 17 here
 		}
 	}
 }

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -119,11 +119,11 @@ void LFSetupFPGAForADC(int divisor, bool lf_field)
  * @param silent - is true, now outputs are made. If false, dbprints the status
  * @return the number of bits occupied by the samples.
  */
-uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averaging, int trigger_threshold, bool silent)
+uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averaging, int trigger_threshold, bool silent, int bufsize)
 {
 	//.
 	uint8_t *dest = BigBuf_get_addr();
-    int bufsize = BigBuf_max_traceLen();
+	bufsize = (bufsize > 0 && bufsize < BigBuf_max_traceLen()) ? bufsize : BigBuf_max_traceLen();
 
 	//memset(dest, 0, bufsize); //creates issues with cmdread (marshmellow)
 
@@ -213,7 +213,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
  */
 uint32_t DoAcquisition_default(int trigger_threshold, bool silent)
 {
-	return DoAcquisition(1,8,0,trigger_threshold,silent);
+	return DoAcquisition(1,8,0,trigger_threshold,silent,0);
 }
 uint32_t DoAcquisition_config( bool silent)
 {
@@ -221,7 +221,12 @@ uint32_t DoAcquisition_config( bool silent)
 				  ,config.bits_per_sample
 				  ,config.averaging
 				  ,config.trigger_threshold
-				  ,silent);
+				  ,silent
+				  ,0);
+}
+
+uint32_t DoPartialAcquisition(int trigger_threshold, bool silent, int sample_size) {
+	return DoAcquisition(1,8,0,trigger_threshold,silent,sample_size);
 }
 
 uint32_t ReadLF(bool activeField, bool silent)

--- a/armsrc/lfsampling.h
+++ b/armsrc/lfsampling.h
@@ -24,8 +24,10 @@ uint32_t SampleLF(bool silent);
 * Initializes the FPGA for snoop-mode (field off), and acquires the samples.
 * @return number of bits sampled
 **/
-
 uint32_t SnoopLF();
+
+// adds sample size to default options
+uint32_t DoPartialAcquisition(int trigger_threshold, bool silent, int sample_size);
 
 /**
  * @brief Does sample acquisition, ignoring the config values set in the sample_config.

--- a/client/cmddata.h
+++ b/client/cmddata.h
@@ -22,6 +22,7 @@ command_t * CmdDataCommands();
 int CmdData(const char *Cmd);
 void printDemodBuff(void);
 void setDemodBuf(uint8_t *buff, size_t size, size_t startIdx);
+int CmdPrintDemodBuff(const char *Cmd);
 int CmdAskEM410xDemod(const char *Cmd);
 int CmdVikingDemod(const char *Cmd);
 int CmdG_Prox_II_Demod(const char *Cmd);

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -1265,7 +1265,7 @@ static command_t CommandTable[] =
 	{"help",        CmdHelp,            1, "This help"},
 	{"awid",        CmdLFAWID,          1, "{ AWID RFIDs...    }"},
 	{"cotag",       CmdLFCOTAG,         1, "{ COTAG RFIDs...   }"},
-	{"em4x",        CmdLFEM4X,          1, "{ EM4X RFIDs...    }"},
+	{"em",          CmdLFEM4X,          1, "{ EM4X RFIDs...    }"},
 	{"hid",         CmdLFHID,           1, "{ HID RFIDs...     }"},
 	{"hitag",       CmdLFHitag,         1, "{ Hitag tags and transponders... }"},
 	{"io",          CmdLFIO,            1, "{ ioProx tags...   }"},

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -1078,9 +1078,29 @@ int CmdVchDemod(const char *Cmd)
 	return 0;
 }
 
+
+//by marshmellow
+int CheckChipType(char cmdp) {
+	uint32_t wordData = 0;
+
+	//check for em4x05/em4x69 chips first
+	save_restoreGB(1);
+	if ((!offline && (cmdp != '1')) && EM4x05Block0Test(&wordData)) {
+		PrintAndLog("\nValid EM4x05/EM4x69 Chip Found\nTry lf em 4x05... commands\n");
+		save_restoreGB(0);
+		return 1;
+	}
+
+	//TODO check for t55xx chip...
+
+	save_restoreGB(0);
+	return 1;
+}
+
 //by marshmellow
 int CmdLFfind(const char *Cmd)
 {
+	uint32_t wordData = 0;
 	int ans=0;
 	size_t minLength = 1000;
 	char cmdp = param_getchar(Cmd, 0);
@@ -1115,7 +1135,12 @@ int CmdLFfind(const char *Cmd)
 	// only run if graphbuffer is just noise as it should be for hitag/cotag
 	if (graphJustNoise(GraphBuffer, testLen)) {
 		// only run these tests if we are in online mode 
-		if (!offline && (cmdp != '1')){
+		if (!offline && (cmdp != '1')) {
+			// test for em4x05 in reader talk first mode.
+			if (EM4x05Block0Test(&wordData)) {
+				PrintAndLog("\nValid EM4x05/EM4x69 Chip Found\nUse lf em 4x05readword/dump commands to read\n");
+				return 1;
+			}
 			ans=CmdLFHitagReader("26");
 			if (ans==0) {
 				return 1;
@@ -1132,49 +1157,49 @@ int CmdLFfind(const char *Cmd)
 	ans=CmdFSKdemodIO("");
 	if (ans>0) {
 		PrintAndLog("\nValid IO Prox ID Found!");
-		return 1;
+		return CheckChipType(cmdp);
 	}
 
 	ans=CmdFSKdemodPyramid("");
 	if (ans>0) {
 		PrintAndLog("\nValid Pyramid ID Found!");
-		return 1;
+		return CheckChipType(cmdp);
 	}
 
 	ans=CmdFSKdemodParadox("");
 	if (ans>0) {
 		PrintAndLog("\nValid Paradox ID Found!");
-		return 1;
+		return CheckChipType(cmdp);
 	}
 
 	ans=CmdFSKdemodAWID("");
 	if (ans>0) {
 		PrintAndLog("\nValid AWID ID Found!");
-		return 1;
+		return CheckChipType(cmdp);
 	}
 
 	ans=CmdFSKdemodHID("");
 	if (ans>0) {
 		PrintAndLog("\nValid HID Prox ID Found!");
-		return 1;
+		return CheckChipType(cmdp);
 	}
 
 	ans=CmdAskEM410xDemod("");
 	if (ans>0) {
 		PrintAndLog("\nValid EM410x ID Found!");
-		return 1;
+		return CheckChipType(cmdp);
 	}
 
 	ans=CmdG_Prox_II_Demod("");
 	if (ans>0) {
 		PrintAndLog("\nValid G Prox II ID Found!");
-		return 1;
+		return CheckChipType(cmdp);
 	}
 
 	ans=CmdFDXBdemodBI("");
 	if (ans>0) {
 		PrintAndLog("\nValid FDX-B ID Found!");
-		return 1;
+		return CheckChipType(cmdp);
 	}
 
 	ans=EM4x50Read("", false);
@@ -1186,24 +1211,25 @@ int CmdLFfind(const char *Cmd)
 	ans=CmdVikingDemod("");
 	if (ans>0) {
 		PrintAndLog("\nValid Viking ID Found!");
-		return 1;
+		return CheckChipType(cmdp);
 	}	
 
 	ans=CmdIndalaDecode("");
 	if (ans>0) {
 		PrintAndLog("\nValid Indala ID Found!");
-		return 1;
+		return CheckChipType(cmdp);
 	}
 
 	ans=CmdPSKNexWatch("");
 	if (ans>0) {
 		PrintAndLog("\nValid NexWatch ID Found!");
-		return 1;
+		return CheckChipType(cmdp);
 	}
 
 	PrintAndLog("\nNo Known Tags Found!\n");
 	if (testRaw=='u' || testRaw=='U'){
-		//test unknown tag formats (raw mode)
+		ans=CheckChipType(cmdp);
+		//test unknown tag formats (raw mode)0
 		PrintAndLog("\nChecking for Unknown tags:\n");
 		ans=AutoCorrelate(4000, FALSE, FALSE);
 		if (ans > 0) PrintAndLog("Possible Auto Correlation of %d repeating samples",ans);

--- a/client/cmdlfawid.c
+++ b/client/cmdlfawid.c
@@ -140,7 +140,7 @@ int CmdAWIDClone(const char *Cmd) {
 	if (sscanf(Cmd, "%u %u", &fc, &cn ) != 2) return usage_lf_awid_clone();
 
 	if (param_getchar(Cmd, 3) == 'Q' || param_getchar(Cmd, 3) == 'q')
-		blocks[0] = T5555_MODULATION_FSK2 | T5555_INVERT_OUTPUT | 50<<T5555_BITRATE_SHIFT | 3<<T5555_MAXBLOCK_SHIFT;
+		blocks[0] = T5555_MODULATION_FSK2 | T5555_INVERT_OUTPUT | ((50-2)>>1)<<T5555_BITRATE_SHIFT | 3<<T5555_MAXBLOCK_SHIFT;
 
 	if ((fc & 0xFF) != fc) {
 		fc &= 0xFF;

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -812,26 +812,84 @@ int CmdEM4x05WriteWord(const char *Cmd) {
 	return result;
 }
 
+void printEM4x05config(uint32_t wordData) {
+	uint16_t datarate = (((wordData & 0x3F)+1)*2);
+	uint8_t encoder = ((wordData >> 6) & 0xF);
+	char enc[14];
+	memset(enc,0,sizeof(enc));
+
+	uint8_t PSKcf = (wordData >> 10) & 0x3;
+	char cf[10];
+	memset(cf,0,sizeof(cf));
+	uint8_t delay = (wordData >> 12) & 0x3;
+	char cdelay[33];
+	memset(cdelay,0,sizeof(cdelay));
+	uint8_t LWR = (wordData >> 14) & 0xF; //last word read
+
+	switch (encoder) {
+		case 0: snprintf(enc,sizeof(enc),"NRZ"); break;
+		case 1: snprintf(enc,sizeof(enc),"Manchester"); break;
+		case 2: snprintf(enc,sizeof(enc),"Biphase"); break;
+		case 3: snprintf(enc,sizeof(enc),"Miller"); break;
+		case 4: snprintf(enc,sizeof(enc),"PSK1"); break;
+		case 5: snprintf(enc,sizeof(enc),"PSK2"); break;
+		case 6: snprintf(enc,sizeof(enc),"PSK3"); break;
+		case 7: snprintf(enc,sizeof(enc),"Unknown"); break;
+		case 8: snprintf(enc,sizeof(enc),"FSK1"); break;
+		case 9: snprintf(enc,sizeof(enc),"FSK2"); break;
+		default: snprintf(enc,sizeof(enc),"Unknown"); break;
+	}
+
+	switch (PSKcf) {
+		case 0: snprintf(cf,sizeof(cf),"RF/2"); break;
+		case 1: snprintf(cf,sizeof(cf),"RF/8"); break;
+		case 2: snprintf(cf,sizeof(cf),"RF/4"); break;
+		case 3: snprintf(cf,sizeof(cf),"unknown"); break;
+	}
+
+	switch (delay) {
+		case 0: snprintf(cdelay, sizeof(cdelay),"no delay"); break;
+		case 1: snprintf(cdelay, sizeof(cdelay),"BP/8 or 1/8th bit period delay"); break;
+		case 2: snprintf(cdelay, sizeof(cdelay),"BP/4 or 1/4th bit period delay"); break;
+		case 3: snprintf(cdelay, sizeof(cdelay),"no delay"); break;
+	}
+	PrintAndLog("ConfigWord: %08X (Word 4)\n", wordData);
+	PrintAndLog("Config Breakdown:", wordData);
+	PrintAndLog(" Data Rate:  %02X | RF/%u", wordData & 0x3F, datarate);
+	PrintAndLog("   Encoder:   %u | %s", encoder, enc);
+	PrintAndLog("    PSK CF:   %u | %s", PSKcf, cf);
+	PrintAndLog("     Delay:   %u | %s", delay, cdelay);
+	PrintAndLog(" LastWordR:  %02u | Address of last default word read", LWR);
+	PrintAndLog(" ReadLogin:   %u | Read Login is %s", (wordData & 0x40000)>>18, (wordData & 0x40000) ? "Required" : "Not Required");	
+	PrintAndLog("   ReadHKL:   %u | Read Housekeeping Words Login is %s", (wordData & 0x80000)>>19, (wordData & 0x80000) ? "Required" : "Not Required");	
+	PrintAndLog("WriteLogin:   %u | Write Login is %s", (wordData & 0x100000)>>20, (wordData & 0x100000) ? "Required" : "Not Required");	
+	PrintAndLog("  WriteHKL:   %u | Write Housekeeping Words Login is %s", (wordData & 0x200000)>>21, (wordData & 0x200000) ? "Required" : "Not Required");	
+	PrintAndLog("    R.A.W.:   %u | Read After Write is %s", (wordData & 0x400000)>>22, (wordData & 0x400000) ? "On" : "Off");
+	PrintAndLog("   Disable:   %u | Disable Command is %s", (wordData & 0x800000)>>23, (wordData & 0x800000) ? "Accepted" : "Not Accepted");
+	PrintAndLog("    R.T.F.:   %u | Reader Talk First is %s", (wordData & 0x1000000)>>24, (wordData & 0x1000000) ? "Enabled" : "Disabled");
+	PrintAndLog("    Pigeon:   %u | Pigeon Mode is %s\n", (wordData & 0x4000000)>>26, (wordData & 0x4000000) ? "Enabled" : "Disabled");
+}
+
 void printEM4x05info(uint8_t chipType, uint8_t cap, uint16_t custCode, uint32_t serial) {
 	switch (chipType) {
-		case 9: PrintAndLog("\nChip Type:   %u | EM4305", chipType); break;
-		case 4: PrintAndLog("Chip Type:   %u | Unknown", chipType); break;
-		case 2: PrintAndLog("Chip Type:   %u | EM4469", chipType); break;
+		case 9: PrintAndLog("\n Chip Type:   %u | EM4305", chipType); break;
+		case 4: PrintAndLog(" Chip Type:   %u | Unknown", chipType); break;
+		case 2: PrintAndLog(" Chip Type:   %u | EM4469", chipType); break;
 		//add more here when known
-		default: PrintAndLog("Chip Type:   %u Unknown", chipType); break;
+		default: PrintAndLog(" Chip Type:   %u Unknown", chipType); break;
 	}
 
 	switch (cap) {
-		case 3: PrintAndLog(" Cap Type:   %u | 330pF",cap); break;
-		case 2: PrintAndLog(" Cap Type:   %u | %spF",cap, (chipType==2)? "75":"210"); break;
-		case 1: PrintAndLog(" Cap Type:   %u | 250pF",cap); break;
-		case 0: PrintAndLog(" Cap Type:   %u | no resonant capacitor",cap); break;
-		default: PrintAndLog(" Cap Type:   %u | unknown",cap); break;
+		case 3: PrintAndLog("  Cap Type:   %u | 330pF",cap); break;
+		case 2: PrintAndLog("  Cap Type:   %u | %spF",cap, (chipType==2)? "75":"210"); break;
+		case 1: PrintAndLog("  Cap Type:   %u | 250pF",cap); break;
+		case 0: PrintAndLog("  Cap Type:   %u | no resonant capacitor",cap); break;
+		default: PrintAndLog("  Cap Type:   %u | unknown",cap); break;
 	}
 
-	PrintAndLog("Cust Code: %03u | %s", custCode, (custCode == 0x200) ? "Default": "Unknown");
+	PrintAndLog(" Cust Code: %03u | %s", custCode, (custCode == 0x200) ? "Default": "Unknown");
 	if (serial != 0) {
-		PrintAndLog("\n Serial #: %08X\n", serial);
+		PrintAndLog("\n  Serial #: %08X\n", serial);
 	}
 }
 
@@ -845,22 +903,21 @@ bool EM4x05Block0Test(uint32_t *wordData) {
 
 int CmdEM4x05info(const char *Cmd) {
 	//uint8_t addr = 0;
-	//uint32_t pwd;
+	uint32_t pwd;
 	uint32_t wordData = 0;
-  //	bool usePwd = false;
+  	bool usePwd = false;
 	uint8_t ctmp = param_getchar(Cmd, 0);
 	if ( ctmp == 'H' || ctmp == 'h' ) return usage_lf_em_dump();
 
 	// for now use default input of 1 as invalid (unlikely 1 will be a valid password...)
-	//pwd = param_get32ex(Cmd, 0, 1, 16);
+	pwd = param_get32ex(Cmd, 0, 1, 16);
 	
-	//if ( pwd != 1 ) {
-	//	usePwd = true;
-	//}
-	int success = 1;
-	// read blk 0
+	if ( pwd != 1 ) {
+		usePwd = true;
+	}
 
-	//block 0 can be read even without a password.
+	// read word 0 (chip info)
+	// block 0 can be read even without a password.
 	if ( !EM4x05Block0Test(&wordData) ) 
 		return -1;
 	
@@ -868,16 +925,22 @@ int CmdEM4x05info(const char *Cmd) {
 	uint8_t cap = (wordData >> 5) & 3;
 	uint16_t custCode = (wordData >> 9) & 0x3FF;
 	
+	// read word 1 (serial #) doesn't need pwd
 	wordData = 0;
 	if (EM4x05ReadWord_ext(1, 0, false, &wordData) != 1) {
 		//failed, but continue anyway...
 	}
 	printEM4x05info(chipType, cap, custCode, wordData);
 
-	// add read block 4 and read out config if successful
+	// read word 4 (config block) 
 	// needs password if one is set
-
-	return success;
+	wordData = 0;
+	if ( EM4x05ReadWord_ext(4, pwd, usePwd, &wordData) != 1 ) {
+		//failed
+		return 0;
+	}
+	printEM4x05config(wordData);
+	return 1;
 }
 
 

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -72,9 +72,9 @@ int CmdEM410xSim(const char *Cmd)
 	uint8_t uid[5] = {0x00};
 
 	if (cmdp == 'h' || cmdp == 'H') {
-		PrintAndLog("Usage:  lf em4x em410xsim <UID> <clock>");
+		PrintAndLog("Usage:  lf em 410xsim <UID> <clock>");
 		PrintAndLog("");
-		PrintAndLog("     sample: lf em4x em410xsim 0F0368568B");
+		PrintAndLog("     sample: lf em 410xsim 0F0368568B");
 		return 0;
 	}
 	/* clock is 64 in EM410x tags */

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -567,7 +567,7 @@ int demodEM4x05resp(uint32_t *word, bool readCmd) {
 	int ans = 0;
 
 	// test for FSK wave (easiest to 99% ID)
-	if (GetFskClock("", FALSE, FALSE)) {
+	if (GetFskClock("", false, false)) {
 		//valid fsk clocks found
 		ans = FSKrawDemod("0 0", false);
 		if (!ans) {
@@ -579,10 +579,10 @@ int demodEM4x05resp(uint32_t *word, bool readCmd) {
 		}
 	}
 	// PSK clocks should be easy to detect ( but difficult to demod a non-repeating pattern... )
-	ans = GetPskClock("", FALSE, FALSE);
+	ans = GetPskClock("", false, false);
 	if (ans>0) {
 		//try psk1
-		ans = PSKDemod("0 0 6", FALSE);
+		ans = PSKDemod("0 0 6", false);
 		if (!ans) {
 			if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: PSK1 Demod failed, ans: %d", ans);
 		} else {
@@ -596,7 +596,7 @@ int demodEM4x05resp(uint32_t *word, bool readCmd) {
 				}
 			}
 			//try psk1 inverted
-			ans = PSKDemod("0 1 6", FALSE);
+			ans = PSKDemod("0 1 6", false);
 			if (!ans) {
 				if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: PSK1 Demod failed, ans: %d", ans);
 			} else {
@@ -626,7 +626,7 @@ int demodEM4x05resp(uint32_t *word, bool readCmd) {
 	}
 
 	//try biphase
-	ans = ASKbiphaseDemod("0 0 1", FALSE);
+	ans = ASKbiphaseDemod("0 0 1", false);
 	if (!ans) { 
 		if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: ASK/biphase Demod failed, ans: %d", ans);
 	} else {
@@ -636,7 +636,7 @@ int demodEM4x05resp(uint32_t *word, bool readCmd) {
 	}
 
 	//try diphase (differential biphase or inverted)
-	ans = ASKbiphaseDemod("0 1 1", FALSE);
+	ans = ASKbiphaseDemod("0 1 1", false);
 	if (!ans) { 
 		if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: ASK/biphase Demod failed, ans: %d", ans);
 	} else {
@@ -731,9 +731,9 @@ int CmdEM4x05dump(const char *Cmd) {
 	for (; addr < 16; addr++) {
 		if (addr == 2) {
 			if (usePwd) {
-				PrintAndLog("PWD Address %02u | %08X",addr,pwd);
+				PrintAndLog(" PWD Address %02u | %08X",addr,pwd);
 			} else {
-				PrintAndLog("PWD Address 02 | cannot read");
+				PrintAndLog(" PWD Address 02 | cannot read");
 			}
 		} else {
 			success &= EM4x05ReadWord(addr, pwd, usePwd);

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -533,6 +533,9 @@ uint8_t EMpreambleSearch(uint8_t *BitStream, uint8_t *preamble, size_t pLen, siz
 	return 0;
 }
 
+// FSK, PSK, ASK/MANCHESTER, ASK/BIPHASE, ASK/DIPHASE 
+// should cover 90% of known used configs
+// the rest will need to be manually demoded for now...
 int demodEM4x05resp(uint8_t bitsNeeded) {
 	int ans = 0;
 	bool demodFound = false;
@@ -546,7 +549,6 @@ int demodEM4x05resp(uint8_t bitsNeeded) {
 		ans = FSKrawDemod("0 0", false);
 		if (!ans) {
 			if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: FSK Demod failed");
-			//return -1;
 		} else {
 			// set size to 10 to only test first 4 positions for the preamble
 			size_t size = (10 > DemodBufferLen) ? DemodBufferLen : 10;
@@ -557,7 +559,6 @@ int demodEM4x05resp(uint8_t bitsNeeded) {
 			uint8_t errChk = !EMpreambleSearch(DemodBuffer, preamble, sizeof(preamble), size, &startIdx);
 			if ( errChk == 0) {
 				if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305 preamble not found :: %d", startIdx);
-				//return -1;
 			} else {
 				//can't test size because the preamble doesn't repeat :(
 				//meaning chances of false positives are high.
@@ -565,10 +566,37 @@ int demodEM4x05resp(uint8_t bitsNeeded) {
 			}
 		}
 	}
+	// PSK clocks should be easy to detect ( but difficult to demod a non-repeating pattern... )
+	if (!demodFound) {
+		ans = GetPskClock("", FALSE, FALSE);
+		if (ans>0) {
+			PrintAndLog("PSK response possibly found, run `data rawd p1` to attempt to demod");
+		}
+	}
 
-	ans = GetPskClock("", FALSE, FALSE);
-	if (ans>0) {
-		PrintAndLog("PSK response possibly found, run `data rawd p1` to attempt to demod");
+	// more common than biphase
+	if (!demodFound) {
+		DemodBufferLen = 0x00;
+		// try manchester - NOTE: ST only applies to T55x7 tags.
+		ans = ASKDemod_ext("0,0,1", false, false, 1, false);
+		if (!ans) {
+			if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: ASK/Manchester Demod failed");
+		} else {
+			// set size to 10 to only test first 4 positions for the preamble
+			size_t size = (10 > DemodBufferLen) ? DemodBufferLen : 10;
+			size_t startIdx = 0; 
+
+			if (g_debugMode) PrintAndLog("ANS: %d | %u | %u", ans, startIdx, size);
+
+			uint8_t errChk = !EMpreambleSearch(DemodBuffer, preamble, sizeof(preamble), size, &startIdx);
+			if ( errChk == 0) {
+				if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305 preamble not found :: %d", startIdx);
+			} else {
+				//can't test size because the preamble doesn't repeat :(
+				//meaning chances of false positives are high.
+				demodFound = true;
+			}
+		}
 	}
 
 	if (!demodFound) {
@@ -577,7 +605,6 @@ int demodEM4x05resp(uint8_t bitsNeeded) {
 		ans = ASKbiphaseDemod("0 0 1", FALSE);
 		if (!ans) { 
 			if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: ASK/biphase Demod failed");
-			//return -1;
 		} else {
 			// set size to 10 to only test first 4 positions for the preamble
 			size_t size = (10 > DemodBufferLen) ? DemodBufferLen : 10;
@@ -588,7 +615,6 @@ int demodEM4x05resp(uint8_t bitsNeeded) {
 			uint8_t errChk = !EMpreambleSearch(DemodBuffer, preamble, sizeof(preamble), size, &startIdx);
 			if ( errChk == 0) {
 				if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305 preamble not found :: %d", startIdx);
-				//return -1;
 			} else {
 				//can't test size because the preamble doesn't repeat :(
 				//meaning chances of false positives are high.
@@ -599,11 +625,10 @@ int demodEM4x05resp(uint8_t bitsNeeded) {
 
 	if (!demodFound) {
 		DemodBufferLen = 0x00;
-		// try manchester - NOTE: ST only applies to T55x7 tags.
-		ans = ASKDemod_ext("0,0,1", false, false, 1, false);
-		if (!ans) {
-			if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: ASK/Manchester Demod failed");
-			//return -1;
+		//try diphase (differential biphase or inverted)
+		ans = ASKbiphaseDemod("0 1 1", FALSE);
+		if (!ans) { 
+			if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: ASK/biphase Demod failed");
 		} else {
 			// set size to 10 to only test first 4 positions for the preamble
 			size_t size = (10 > DemodBufferLen) ? DemodBufferLen : 10;
@@ -614,7 +639,6 @@ int demodEM4x05resp(uint8_t bitsNeeded) {
 			uint8_t errChk = !EMpreambleSearch(DemodBuffer, preamble, sizeof(preamble), size, &startIdx);
 			if ( errChk == 0) {
 				if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305 preamble not found :: %d", startIdx);
-				//return -1;
 			} else {
 				//can't test size because the preamble doesn't repeat :(
 				//meaning chances of false positives are high.
@@ -624,8 +648,10 @@ int demodEM4x05resp(uint8_t bitsNeeded) {
 	}
 
 	if (demodFound && bitsNeeded < DemodBufferLen) {
-		setDemodBuf(DemodBuffer + ans + sizeof(preamble), bitsNeeded, 0);
-		CmdPrintDemodBuff("x");
+		if (bitsNeeded > 0) {
+			setDemodBuf(DemodBuffer + ans + sizeof(preamble), bitsNeeded, 0);
+			CmdPrintDemodBuff("x");			
+		}
 		return 1;
 	}
 	return -1;
@@ -673,10 +699,9 @@ int CmdReadWord(const char *Cmd) {
 		return -1;
 	}
 
-	//need 32 bits for read word
-	demodEM4x05resp(32);
-
-	return 1;
+	//attempt demod:
+	//need 32 bits from a read word
+	return demodEM4x05resp(32);
 }
 
 int usage_lf_em_write(void) {
@@ -693,6 +718,7 @@ int usage_lf_em_write(void) {
 	PrintAndLog("      lf em writeword 1 deadc0de 11223344");
 	return 0;
 }
+
 int CmdWriteWord(const char *Cmd) {
 	uint8_t ctmp = param_getchar(Cmd, 0);
 	if ( strlen(Cmd) == 0 || ctmp == 'H' || ctmp == 'h' ) return usage_lf_em_write();
@@ -738,7 +764,14 @@ int CmdWriteWord(const char *Cmd) {
 	}
 	setGraphBuf(got, sizeof(got));
 	//todo: check response for 00001010 then write data for write confirmation!
-	return 0;
+	
+	//attempt demod:
+	//need 0 bits demoded (after preamble) to verify write cmd
+	int result = demodEM4x05resp(0);
+	if (result == 1) {
+		PrintAndLog("Write Verified");
+	}
+	return result;
 }
 
 /*

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -512,6 +512,125 @@ int usage_lf_em_read(void) {
 	PrintAndLog("      lf em readword 1 11223344");
 	return 0;
 }
+
+//search for given preamble in given BitStream and return success=1 or fail=0 and startIndex
+uint8_t EMpreambleSearch(uint8_t *BitStream, uint8_t *preamble, size_t pLen, size_t size, size_t *startIdx)
+{
+	// Sanity check.  If preamble length is bigger than bitstream length.
+	if ( size <= pLen ) return 0;
+	// em only sends preamble once, so look for it once in the first x bits
+	uint8_t foundCnt = 0;
+	for (int idx = 0; idx < size - pLen; idx++){
+		if (memcmp(BitStream+idx, preamble, pLen) == 0){
+			//first index found
+			foundCnt++;
+			if (foundCnt == 1) {
+				*startIdx = idx;
+				return 1;
+			}
+		}
+	}
+	return 0;
+}
+
+int demodEM4x05resp(uint8_t bitsNeeded) {
+	int ans = 0;
+	bool demodFound = false;
+	DemodBufferLen = 0x00;
+	// skip first two 0 bits as they might have been missed in the demod 
+	uint8_t preamble[6] = {0,0,1,0,1,0};
+
+	// test for FSK wave (easiest to 99% ID)
+	if (GetFskClock("", FALSE, FALSE)) {
+		//valid fsk clocks found
+		ans = FSKrawDemod("0 0", false);
+		if (!ans) {
+			if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: FSK Demod failed");
+			//return -1;
+		} else {
+			// set size to 10 to only test first 4 positions for the preamble
+			size_t size = (10 > DemodBufferLen) ? DemodBufferLen : 10;
+			size_t startIdx = 0; 
+
+			if (g_debugMode) PrintAndLog("ANS: %d | %u | %u", ans, startIdx, size);
+
+			uint8_t errChk = !EMpreambleSearch(DemodBuffer, preamble, sizeof(preamble), size, &startIdx);
+			if ( errChk == 0) {
+				if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305 preamble not found :: %d", startIdx);
+				//return -1;
+			} else {
+				//can't test size because the preamble doesn't repeat :(
+				//meaning chances of false positives are high.
+				demodFound = true;
+			}
+		}
+	}
+
+	ans = GetPskClock("", FALSE, FALSE);
+	if (ans>0) {
+		PrintAndLog("PSK response possibly found, run `data rawd p1` to attempt to demod");
+	}
+
+	if (!demodFound) {
+		DemodBufferLen = 0x00;
+		//try biphase
+		ans = ASKbiphaseDemod("0 0 1", FALSE);
+		if (!ans) { 
+			if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: ASK/biphase Demod failed");
+			//return -1;
+		} else {
+			// set size to 10 to only test first 4 positions for the preamble
+			size_t size = (10 > DemodBufferLen) ? DemodBufferLen : 10;
+			size_t startIdx = 0; 
+
+			if (g_debugMode) PrintAndLog("ANS: %d | %u | %u", ans, startIdx, size);
+
+			uint8_t errChk = !EMpreambleSearch(DemodBuffer, preamble, sizeof(preamble), size, &startIdx);
+			if ( errChk == 0) {
+				if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305 preamble not found :: %d", startIdx);
+				//return -1;
+			} else {
+				//can't test size because the preamble doesn't repeat :(
+				//meaning chances of false positives are high.
+				demodFound = true;
+			}
+		}
+	}
+
+	if (!demodFound) {
+		DemodBufferLen = 0x00;
+		// try manchester - NOTE: ST only applies to T55x7 tags.
+		ans = ASKDemod_ext("0,0,1", false, false, 1, false);
+		if (!ans) {
+			if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305: ASK/Manchester Demod failed");
+			//return -1;
+		} else {
+			// set size to 10 to only test first 4 positions for the preamble
+			size_t size = (10 > DemodBufferLen) ? DemodBufferLen : 10;
+			size_t startIdx = 0; 
+
+			if (g_debugMode) PrintAndLog("ANS: %d | %u | %u", ans, startIdx, size);
+
+			uint8_t errChk = !EMpreambleSearch(DemodBuffer, preamble, sizeof(preamble), size, &startIdx);
+			if ( errChk == 0) {
+				if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305 preamble not found :: %d", startIdx);
+				//return -1;
+			} else {
+				//can't test size because the preamble doesn't repeat :(
+				//meaning chances of false positives are high.
+				demodFound = true;
+			}
+		}
+	}
+
+	if (demodFound && bitsNeeded < DemodBufferLen) {
+		setDemodBuf(DemodBuffer + ans + sizeof(preamble), bitsNeeded, 0);
+		CmdPrintDemodBuff("x");
+		return 1;
+	}
+	return -1;
+}
+
 int CmdReadWord(const char *Cmd) {
 	int addr, pwd;
 	bool usePwd = false;
@@ -540,15 +659,23 @@ int CmdReadWord(const char *Cmd) {
 		PrintAndLog("Command timed out");
 		return -1;
 	}
-	
-	uint8_t got[6000]; // 8 bit preamble + 32 bit word response (max clock (128) * 40bits = 5120 samples)
+
+	uint8_t got[6000];
 	GetFromBigBuf(got, sizeof(got), 0);
-	if ( !WaitForResponseTimeout(CMD_ACK, NULL, 8000) ) {
+	if ( !WaitForResponseTimeout(CMD_ACK, NULL, 2500) ) {
 		PrintAndLog("command execution time out");
-		return 0;
+		return -1;
 	}
 	setGraphBuf(got, sizeof(got));
-	//todo: demodulate read data 
+	int testLen = (GraphTraceLen < 1000) ? GraphTraceLen : 1000;
+	if (graphJustNoise(GraphBuffer, testLen)) {
+		PrintAndLog("no tag not found");
+		return -1;
+	}
+
+	//need 32 bits for read word
+	demodEM4x05resp(32);
+
 	return 1;
 }
 

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -534,8 +534,8 @@ bool EM4x05testDemodReadData(uint32_t *word, bool readCmd) {
 	// skip first two 0 bits as they might have been missed in the demod
 	uint8_t preamble[] = {0,0,1,0,1,0};
 	size_t startIdx = 0;
-	// set size to 15 to only test first 9 positions for the preamble
-	size_t size = (15 > DemodBufferLen) ? DemodBufferLen : 15;
+	// set size to 20 to only test first 14 positions for the preamble
+	size_t size = (20 > DemodBufferLen) ? DemodBufferLen : 20;
 
 	//test preamble
 	if ( !onePreambleSearch(DemodBuffer, preamble, sizeof(preamble), size, &startIdx) ) {

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -823,8 +823,9 @@ void printEM4x05info(uint8_t chipType, uint8_t cap, uint16_t custCode, uint32_t 
 
 	switch (cap) {
 		case 3: PrintAndLog(" Cap Type:   %u | 330pF",cap); break;
-		case 2: PrintAndLog(" Cap Type:   %u | 210pF",cap); break;
+		case 2: PrintAndLog(" Cap Type:   %u | %spF",cap, (chipType==2)? "75":"210"); break;
 		case 1: PrintAndLog(" Cap Type:   %u | 250pF",cap); break;
+		case 0: PrintAndLog(" Cap Type:   %u | no resonant capacitor",cap); break;
 		default: PrintAndLog(" Cap Type:   %u | unknown",cap); break;
 	}
 

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -719,7 +719,12 @@ int CmdEM4x05ReadWord(const char *Cmd) {
 		usePwd = true;
 		PrintAndLog("Reading address %02u | password %08X", addr, pwd);
 	}
-	return EM4x05ReadWord(addr, pwd, usePwd);
+
+	int result = EM4x05ReadWord(addr, pwd, usePwd);
+	if (result == -1)
+		PrintAndLog("Read failed");
+	
+	return result;
 }
 
 int usage_lf_em_dump(void) {

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -675,7 +675,7 @@ int EM4x05ReadWord(uint8_t addr, uint32_t pwd, bool usePwd) {
 	uint32_t wordData = 0;
 	int success = EM4x05ReadWord_ext(addr, pwd, usePwd, &wordData);
 	if (success == 1)
-		PrintAndLog(" Got Address %02d | %08X",addr,wordData);
+		PrintAndLog("%s Address %02d | %08X", (addr>13) ? "Lock":" Got",addr,wordData);
 	else
 		PrintAndLog("Read Address %02d | failed",addr);
 
@@ -859,11 +859,11 @@ void printEM4x05config(uint32_t wordData) {
 	}
 	PrintAndLog("ConfigWord: %08X (Word 4)\n", wordData);
 	PrintAndLog("Config Breakdown:", wordData);
-	PrintAndLog(" Data Rate:  %02X | RF/%u", wordData & 0x3F, datarate);
+	PrintAndLog(" Data Rate:  %02u | RF/%u", wordData & 0x3F, datarate);
 	PrintAndLog("   Encoder:   %u | %s", encoder, enc);
 	PrintAndLog("    PSK CF:   %u | %s", PSKcf, cf);
 	PrintAndLog("     Delay:   %u | %s", delay, cdelay);
-	PrintAndLog(" LastWordR:  %02u | Address of last default word read", LWR);
+	PrintAndLog(" LastWordR:  %02u | Address of last word for default read", LWR);
 	PrintAndLog(" ReadLogin:   %u | Read Login is %s", (wordData & 0x40000)>>18, (wordData & 0x40000) ? "Required" : "Not Required");	
 	PrintAndLog("   ReadHKL:   %u | Read Housekeeping Words Login is %s", (wordData & 0x80000)>>19, (wordData & 0x80000) ? "Required" : "Not Required");	
 	PrintAndLog("WriteLogin:   %u | Write Login is %s", (wordData & 0x100000)>>20, (wordData & 0x100000) ? "Required" : "Not Required");	
@@ -898,8 +898,11 @@ void printEM4x05info(uint8_t chipType, uint8_t cap, uint16_t custCode, uint32_t 
 }
 
 void printEM4x05ProtectionBits(uint32_t wordData) {
-	for (uint8_t i = 0; i < 14; i++) {
-		PrintAndLog("      Word:  %02u | %s", i, (((1 << i) & wordData ) || i < 2) ? "Is Locked" : "Is Not Locked");
+	for (uint8_t i = 0; i < 15; i++) {
+		PrintAndLog("      Word:  %02u | %s", i, (((1 << i) & wordData ) || i < 2) ? "Is Write Locked" : "Is Not Write Locked");
+		if (i==14) {
+			PrintAndLog("      Word:  %02u | %s", i+1, (((1 << i) & wordData ) || i < 2) ? "Is Write Locked" : "Is Not Write Locked");
+		}
 	}
 }
 

--- a/client/cmdlfem4x.h
+++ b/client/cmdlfem4x.h
@@ -18,11 +18,14 @@ int CmdEM410xWatch(const char *Cmd);
 int CmdEM410xWatchnSpoof(const char *Cmd);
 int CmdEM410xWrite(const char *Cmd);
 int CmdEM4x50Read(const char *Cmd);
-int CmdLFEM4X(const char *Cmd);
-int CmdReadWord(const char *Cmd);
-int CmdReadWordPWD(const char *Cmd);
-int CmdWriteWord(const char *Cmd);
-int CmdWriteWordPWD(const char *Cmd);
 int EM4x50Read(const char *Cmd, bool verbose);
+int CmdLFEM4X(const char *Cmd);
+bool EM4x05Block0Test(uint32_t *wordData);
+int CmdEM4x05info(const char *Cmd);
+int CmdEM4x05WriteWord(const char *Cmd);
+int CmdEM4x05dump(const char *Cmd);
+int CmdEM4x05ReadWord(const char *Cmd);
+int EM4x05ReadWord_ext(uint8_t addr, uint32_t pwd, bool usePwd, uint32_t *wordData);
+
 
 #endif

--- a/client/cmdlfpresco.c
+++ b/client/cmdlfpresco.c
@@ -178,7 +178,7 @@ int CmdPrescoClone(const char *Cmd) {
 	if (GetWiegandFromPresco(Cmd, &sitecode, &usercode, &fullcode, &Q5) == -1) return usage_lf_presco_clone();
 
 	if (Q5)
-		blocks[0] = T5555_MODULATION_MANCHESTER | 32<<T5555_BITRATE_SHIFT | 4<<T5555_MAXBLOCK_SHIFT | T5555_ST_TERMINATOR;
+		blocks[0] = T5555_MODULATION_MANCHESTER | ((32-2)>>1)<<T5555_BITRATE_SHIFT | 4<<T5555_MAXBLOCK_SHIFT | T5555_ST_TERMINATOR;
 
 	if ((sitecode & 0xFF) != sitecode) {
 		sitecode &= 0xFF;

--- a/client/graph.c
+++ b/client/graph.c
@@ -14,6 +14,7 @@
 #include "ui.h"
 #include "graph.h"
 #include "lfdemod.h"
+#include "cmddata.h" //for g_debugmode
 
 int GraphBuffer[MAX_GRAPH_TRACE_LEN];
 int GraphTraceLen;
@@ -255,7 +256,7 @@ uint8_t fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, bool verbose)
 	if (size==0) return 0;
 	uint16_t ans = countFC(BitStream, size, 1); 
 	if (ans==0) {
-		if (verbose) PrintAndLog("DEBUG: No data found");
+		if (verbose || g_debugMode) PrintAndLog("DEBUG: No data found");
 		return 0;
 	}
 	*fc1 = (ans >> 8) & 0xFF;
@@ -263,7 +264,7 @@ uint8_t fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, bool verbose)
 
 	*rf1 = detectFSKClk(BitStream, size, *fc1, *fc2);
 	if (*rf1==0) {
-		if (verbose) PrintAndLog("DEBUG: Clock detect error");
+		if (verbose || g_debugMode) PrintAndLog("DEBUG: Clock detect error");
 		return 0;
 	}
 	return 1;

--- a/client/util.h
+++ b/client/util.h
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include <time.h>
+#include <time.h>    //time, gmtime
 #include "data.h"    //for FILE_PATH_SIZE
 
 #ifndef ROTR
@@ -42,12 +42,16 @@ void print_hex(const uint8_t * data, const size_t len);
 char * sprint_hex(const uint8_t * data, const size_t len);
 char * sprint_bin(const uint8_t * data, const size_t len);
 char * sprint_bin_break(const uint8_t *data, const size_t len, const uint8_t breaks);
+char * sprint_hex_ascii(const uint8_t *data, const size_t len);
+char * sprint_ascii(const uint8_t *data, const size_t len);
 
 void num_to_bytes(uint64_t n, size_t len, uint8_t* dest);
 uint64_t bytes_to_num(uint8_t* src, size_t len);
 void num_to_bytebits(uint64_t	n, size_t len, uint8_t *dest);
+void num_to_bytebitsLSBF(uint64_t n, size_t len, uint8_t *dest);
 char * printBits(size_t const size, void const * const ptr);
 uint8_t *SwapEndian64(const uint8_t *src, const size_t len, const uint8_t blockSize);
+void SwapEndian64ex(const uint8_t *src, const size_t len, const uint8_t blockSize, uint8_t *dest);
 
 char param_getchar(const char *line, int paramnum);
 int param_getptr(const char *line, int *bg, int *en, int paramnum);

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -1343,7 +1343,10 @@ uint8_t detectFSKClk(uint8_t *BitStream, size_t size, uint8_t fcHigh, uint8_t fc
 			continue;		
 		// else new peak 
 		// if we got less than the small fc + tolerance then set it to the small fc
-		if (fcCounter < fcLow+fcTol) 
+		// if it is inbetween set it to the last counter
+		if (fcCounter < fcHigh && fcCounter > fcLow)
+			fcCounter = lastFCcnt;
+		else if (fcCounter < fcLow+fcTol) 
 			fcCounter = fcLow;
 		else //set it to the large fc
 			fcCounter = fcHigh;
@@ -1409,7 +1412,7 @@ uint8_t detectFSKClk(uint8_t *BitStream, size_t size, uint8_t fcHigh, uint8_t fc
 		}
 	}
 
-	if (ii<0) return 0; // oops we went too far
+	if (ii<2) return 0; // oops we went too far
 
 	return clk[ii];
 }

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -62,7 +62,7 @@ uint8_t parityTest(uint32_t bits, uint8_t bitLen, uint8_t pType)
 	for (uint8_t i = 0; i < bitLen; i++){
 		ans ^= ((bits >> i) & 1);
 	}
-	//PrintAndLog("DEBUG: ans: %d, ptype: %d",ans,pType);
+	if (g_debugMode) prnt("DEBUG: ans: %d, ptype: %d, bits: %08X",ans,pType,bits);
 	return (ans == pType);
 }
 
@@ -73,11 +73,13 @@ size_t removeParity(uint8_t *BitStream, size_t startIdx, uint8_t pLen, uint8_t p
 {
 	uint32_t parityWd = 0;
 	size_t j = 0, bitCnt = 0;
-	for (int word = 0; word < (bLen); word+=pLen){
-		for (int bit=0; bit < pLen; bit++){
+	for (int word = 0; word < (bLen); word+=pLen) {
+		for (int bit=0; bit < pLen; bit++) {
 			parityWd = (parityWd << 1) | BitStream[startIdx+word+bit];
 			BitStream[j++] = (BitStream[startIdx+word+bit]);
 		}
+		if (word+pLen >= bLen) break;
+
 		j--; // overwrite parity with next data
 		// if parity fails then return 0
 		switch (pType) {

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -1375,10 +1375,10 @@ uint16_t countFC(uint8_t *BitStream, size_t size, uint8_t fskAdj)
 	uint8_t fcLens[] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 	uint16_t fcCnts[] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 	uint8_t fcLensFnd = 0;
-	uint8_t lastFCcnt=0;
+	uint8_t lastFCcnt = 0;
 	uint8_t fcCounter = 0;
 	size_t i;
-	if (size == 0) return 0;
+	if (size < 180) return 0;
 
 	// prime i to first up transition
 	for (i = 160; i < size-20; i++)

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -148,6 +148,9 @@ uint32_t bytebits_to_byteLSBF(uint8_t *src, size_t numbits)
 //search for given preamble in given BitStream and return success=1 or fail=0 and startIndex and length
 uint8_t preambleSearch(uint8_t *BitStream, uint8_t *preamble, size_t pLen, size_t *size, size_t *startIdx)
 {
+	// Sanity check.  If preamble length is bigger than bitstream length.
+	if ( *size <= pLen ) return 0;
+
 	uint8_t foundCnt=0;
 	for (int idx=0; idx < *size - pLen; idx++){
 		if (memcmp(BitStream+idx, preamble, pLen) == 0){

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -170,6 +170,23 @@ uint8_t preambleSearch(uint8_t *BitStream, uint8_t *preamble, size_t pLen, size_
 	return 0;
 }
 
+// search for given preamble in given BitStream and return success=1 or fail=0 and startIndex (where it was found)
+// does not look for a repeating preamble
+// em4x05/4x69 only sends preamble once, so look for it once in the first pLen bits
+// leave it generic so it could be reused later...
+bool onePreambleSearch(uint8_t *BitStream, uint8_t *preamble, size_t pLen, size_t size, size_t *startIdx) {
+	// Sanity check.  If preamble length is bigger than bitstream length.
+	if ( size <= pLen ) return false;
+	for (size_t idx = 0; idx < size - pLen; idx++) {
+		if (memcmp(BitStream+idx, preamble, pLen) == 0) {
+			if (g_debugMode) prnt("DEBUG: preamble found at %u", idx);
+			*startIdx = idx;
+			return true;
+		}
+	}
+	return false;
+}
+
 //by marshmellow
 //takes 1s and 0s and searches for EM410x format - output EM ID
 uint8_t Em410xDecode(uint8_t *BitStream, size_t *size, size_t *startIdx, uint32_t *hi, uint64_t *lo)

--- a/common/lfdemod.h
+++ b/common/lfdemod.h
@@ -39,6 +39,7 @@ int      manrawdecode(uint8_t *BitStream, size_t *size, uint8_t invert);
 int      nrzRawDemod(uint8_t *dest, size_t *size, int *clk, int *invert);
 uint8_t  parityTest(uint32_t bits, uint8_t bitLen, uint8_t pType);
 uint8_t  preambleSearch(uint8_t *BitStream, uint8_t *preamble, size_t pLen, size_t *size, size_t *startIdx);
+bool     onePreambleSearch(uint8_t *BitStream, uint8_t *preamble, size_t pLen, size_t size, size_t *startIdx);
 int      pskRawDemod(uint8_t dest[], size_t *size, int *clock, int *invert);
 void     psk2TOpsk1(uint8_t *BitStream, size_t size);
 void     psk1TOpsk2(uint8_t *BitStream, size_t size);


### PR DESCRIPTION
This cleans up and clarifies the lf em commands
IMPORTANT NOTICE: lf em command structure has changed!!!  lf em4x em4x...  is now lf em 4x...
also lf em readword and lf em writeword have been changed to lf em 4x05readword and lf em 4x05 writeword to clear up some confusion.

other lf em 4x05 commands have been added along with the full read back of what you read automatically.

some small improvements were also made to lf psk and lf fsk demods.

also added em4x05/em4x69 chip detection to lf search