### PR TITLE
em cleanup and fix bug in lf config [threshold] option making it not work...

### DIFF
--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -175,8 +175,8 @@ void printEM410x(uint32_t hi, uint64_t id)
 		} else{
 			//output 40 bit em id
 			PrintAndLog("\nEM TAG ID      : %010llX", id);
-			PrintAndLog("Unique TAG ID  : %010llX",  id2lo);
 			PrintAndLog("\nPossible de-scramble patterns");
+			PrintAndLog("Unique TAG ID  : %010llX",  id2lo);
 			PrintAndLog("HoneyWell IdentKey {");
 			PrintAndLog("DEZ 8          : %08lld",id & 0xFFFFFF);
 			PrintAndLog("DEZ 10         : %010lld",id & 0xFFFFFFFF);

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -35,7 +35,7 @@
 #include "cmdlfviking.h" // for viking menu
 #include "cmdlfcotag.h"  // for COTAG menu
 
-
+bool threshold_set = false;
 static int CmdHelp(const char *Cmd);
 
 
@@ -510,7 +510,10 @@ int CmdLFSetConfig(const char *Cmd)
 		case 't':
 			errors |= param_getdec(Cmd,cmdp+1,&unsigned_trigg);
 			cmdp+=2;
-			if(!errors) trigger_threshold = unsigned_trigg;
+			if(!errors) {
+				trigger_threshold = unsigned_trigg;
+				if (trigger_threshold > 0) threshold_set = true;
+			}
 			break;
 		case 'b':
 			errors |= param_getdec(Cmd,cmdp+1,&bps);
@@ -557,7 +560,7 @@ int CmdLFSetConfig(const char *Cmd)
 
 int CmdLFRead(const char *Cmd)
 {
-
+	if (offline) return 0;
 	uint8_t cmdp = 0;
 	bool arg1 = false;
 	if (param_getchar(Cmd, cmdp) == 'h')
@@ -569,12 +572,14 @@ int CmdLFRead(const char *Cmd)
 	UsbCommand c = {CMD_ACQUIRE_RAW_ADC_SAMPLES_125K, {arg1,0,0}};
 	clearCommandBuffer();
 	SendCommand(&c);
-	WaitForResponse(CMD_ACK,NULL);	
-	//if ( !WaitForResponseTimeout(CMD_ACK,NULL,2500) ) {
-	//	PrintAndLog("command execution time out");
-	//	return 1;
-	//}
-
+	if (threshold_set) {
+		WaitForResponse(CMD_ACK,NULL);
+	} else {
+		if ( !WaitForResponseTimeout(CMD_ACK,NULL,2500) ) {
+			PrintAndLog("command execution time out");
+			return 1;
+		}
+	}
 	return 0;
 }
 

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -35,7 +35,7 @@
 #include "cmdlfviking.h" // for viking menu
 #include "cmdlfcotag.h"  // for COTAG menu
 
-bool threshold_set = false;
+bool g_lf_threshold_set = false;
 static int CmdHelp(const char *Cmd);
 
 
@@ -512,7 +512,7 @@ int CmdLFSetConfig(const char *Cmd)
 			cmdp+=2;
 			if(!errors) {
 				trigger_threshold = unsigned_trigg;
-				if (trigger_threshold > 0) threshold_set = true;
+				if (trigger_threshold > 0) g_lf_threshold_set = true;
 			}
 			break;
 		case 'b':
@@ -572,7 +572,7 @@ int CmdLFRead(const char *Cmd)
 	UsbCommand c = {CMD_ACQUIRE_RAW_ADC_SAMPLES_125K, {arg1,0,0}};
 	clearCommandBuffer();
 	SendCommand(&c);
-	if (threshold_set) {
+	if (g_lf_threshold_set) {
 		WaitForResponse(CMD_ACK,NULL);
 	} else {
 		if ( !WaitForResponseTimeout(CMD_ACK,NULL,2500) ) {

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -569,11 +569,11 @@ int CmdLFRead(const char *Cmd)
 	UsbCommand c = {CMD_ACQUIRE_RAW_ADC_SAMPLES_125K, {arg1,0,0}};
 	clearCommandBuffer();
 	SendCommand(&c);
-	//WaitForResponse(CMD_ACK,NULL);	
-	if ( !WaitForResponseTimeout(CMD_ACK,NULL,2500) ) {
-		PrintAndLog("command execution time out");
-		return 1;
-	}
+	WaitForResponse(CMD_ACK,NULL);	
+	//if ( !WaitForResponseTimeout(CMD_ACK,NULL,2500) ) {
+	//	PrintAndLog("command execution time out");
+	//	return 1;
+	//}
 
 	return 0;
 }

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -183,7 +183,7 @@ int CmdEM410xWrite(const char *Cmd)
 	int card = 0xFF; // invalid card value
 	unsigned int clock = 0; // invalid clock value
 
-	sscanf(Cmd, "%" PRIx64 " %d %d", &id, &card, &clock);
+	sscanf(Cmd, "%" SCNx64 " %d %d", &id, &card, &clock);
 
 	// Check ID
 	if (id == 0xFFFFFFFFFFFFFFFF) {

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -63,6 +63,20 @@ int CmdEM410xRead(const char *Cmd)
 	return 1;
 }
 
+int usage_lf_em410x_sim(void) {
+	PrintAndLog("Simulating EM410x tag");
+	PrintAndLog("");
+	PrintAndLog("Usage:  lf em 410xsim [h] <uid> <clock>");
+	PrintAndLog("Options:");
+	PrintAndLog("       h         - this help");
+	PrintAndLog("       uid       - uid (10 HEX symbols)");
+	PrintAndLog("       clock     - clock (32|64) (optional)");
+	PrintAndLog("samples:");
+	PrintAndLog("      lf em 410xsim 0F0368568B");
+	PrintAndLog("      lf em 410xsim 0F0368568B 32");
+	return 0;
+}
+
 // emulate an EM410X tag
 int CmdEM410xSim(const char *Cmd)
 {
@@ -71,12 +85,7 @@ int CmdEM410xSim(const char *Cmd)
 	char cmdp = param_getchar(Cmd, 0);
 	uint8_t uid[5] = {0x00};
 
-	if (cmdp == 'h' || cmdp == 'H') {
-		PrintAndLog("Usage:  lf em 410xsim <UID> <clock>");
-		PrintAndLog("");
-		PrintAndLog("     sample: lf em 410xsim 0F0368568B");
-		return 0;
-	}
+	if (cmdp == 'h' || cmdp == 'H') return usage_lf_em410x_sim();
 	/* clock is 64 in EM410x tags */
 	uint8_t clock = 64;
 

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -540,7 +540,7 @@ bool EM4x05testDemodReadData(uint32_t *word, bool readCmd) {
 	// sanity check
 	size = (size > DemodBufferLen) ? DemodBufferLen : size;
 	// test preamble
-	if ( !onePreambleSearch(DemodBuffer, preamble, sizeof(preamble), size, &startIdx) ) {
+	if ( !preambleSearchEx(DemodBuffer, preamble, sizeof(preamble), &size, &startIdx, true) ) {
 		if (g_debugMode) PrintAndLog("DEBUG: Error - EM4305 preamble not found :: %d", startIdx);
 		return false;
 	}
@@ -550,13 +550,13 @@ bool EM4x05testDemodReadData(uint32_t *word, bool readCmd) {
 			if (g_debugMode) PrintAndLog("DEBUG: Error - End Parity check failed");
 			return false;
 		}
-		// test for even parity bits.
-		if ( removeParity(DemodBuffer, startIdx + sizeof(preamble),9,0,44) == 0 ) {		
+		// test for even parity bits and remove them. (leave out the end row of parities so 36 bits)
+		if ( removeParity(DemodBuffer, startIdx + sizeof(preamble),9,0,36) == 0 ) {		
 			if (g_debugMode) PrintAndLog("DEBUG: Error - Parity not detected");
 			return false;
 		}
 
-		setDemodBuf(DemodBuffer, 40, 0);
+		setDemodBuf(DemodBuffer, 32, 0);
 		*word = bytebits_to_byteLSBF(DemodBuffer, 32);
 	}
 	return true;

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -288,6 +288,7 @@ int cleanAskRawDemod(uint8_t *BinStream, size_t *size, int clk, int invert, int 
 }
 
 //by marshmellow
+//amplify based on ask edge detection
 void askAmp(uint8_t *BitStream, size_t size)
 {
 	uint8_t Last = 128;

--- a/common/lfdemod.h
+++ b/common/lfdemod.h
@@ -39,7 +39,7 @@ int      manrawdecode(uint8_t *BitStream, size_t *size, uint8_t invert);
 int      nrzRawDemod(uint8_t *dest, size_t *size, int *clk, int *invert);
 uint8_t  parityTest(uint32_t bits, uint8_t bitLen, uint8_t pType);
 uint8_t  preambleSearch(uint8_t *BitStream, uint8_t *preamble, size_t pLen, size_t *size, size_t *startIdx);
-bool     onePreambleSearch(uint8_t *BitStream, uint8_t *preamble, size_t pLen, size_t size, size_t *startIdx);
+bool     preambleSearchEx(uint8_t *BitStream, uint8_t *preamble, size_t pLen, size_t *size, size_t *startIdx, bool findone);
 int      pskRawDemod(uint8_t dest[], size_t *size, int *clock, int *invert);
 void     psk2TOpsk1(uint8_t *BitStream, size_t size);
 void     psk1TOpsk2(uint8_t *BitStream, size_t size);


### PR DESCRIPTION
...as desired due to a timeout on the client side.

if threshold is specified in lf config then we set the lf read command (and therefore lf search) to wait until the device signals it is finished.  this may create the appearance the client is hanging until a tag strong outputs a wave strong enough to trigger the threshold.   

this now allows you to set a threshold and bring a card to the antenna and catch the card as soon as it is close enough to read, instead of setting a card on the antenna and reading...

when a threshold is not set it will send the command to the device and timeout if the device fails to respond as expected. (as it was before)

this pull req also moves the "Unique TAG ID" printout of an em410x tag to a lower position to avoid confusion as to which is the "Main" ID  or the em410x ID.