### PR TITLE
small patches and small added features listed below:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
 
 ### Added
+- Added markers in the graph around found Sequence Terminator after askmandemod.
+- Added data mtrim <start> <stop> command to trim out samples between start and stop
+- Added data setgraphmarkers <orange> <blue> command to set two extra markers on the graph (marshmellow)
 - Added EM4x05/EM4x69 chip detection to lf search (marshmellow) 
 - Added lf em 4x05dump command to read and output all the blocks of the chip (marshmellow)
 - Added lf em 4x05info command to read and display information about the chip (marshmellow)
@@ -41,6 +44,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added option c to 'hf list' (mark CRC bytes) (piwi)
 
 ### Changed
+- hf mf dump - added retry loops to try each read attempt up to 3 times.  makes getting a complete dump easier with many antennas. 
 - small changes to lf psk and fsk demods to improve results when the trace begins with noise or the chip isn't broadcasting yet (marshmellow)
 - NOTE CHANGED ALL `lf em4x em*` cmds to simpler `lf em ` - example: `lf em4x em410xdemod` is now `lf em 410xdemod`
 - Renamed and rebuilt `lf em readword` && readwordpwd to `lf em 4x05readword` - it now demods and outputs the read block (marshmellow/iceman)

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1571,27 +1571,27 @@ void SendForward(uint8_t fwd_bit_count) {
 	fwd_write_ptr = forwardLink_data;
 	fwd_bit_sz = fwd_bit_count;
 
-	// Set up FPGA, 125kHz
+	// Set up FPGA, 125kHz or 95 divisor
 	LFSetupFPGAForADC(95, true);
 
 	// force 1st mod pulse (start gap must be longer for 4305)
 	fwd_bit_sz--; //prepare next bit modulation
 	fwd_write_ptr++;
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
-	SpinDelayUs(56*8); //55 cycles off (8us each)for 4305  /another reader has 37 here...
+	WaitUS(55*8); //55 cycles off (8us each)for 4305  /another reader has 37 here...
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_ADC | FPGA_LF_ADC_READER_FIELD);//field on
-	SpinDelayUs(18*8); //16 cycles on (8us each)  // another reader has 18 here
+	WaitUS(18*8); //16 cycles on (8us each)  // another reader has 18 here
 
 	// now start writting
 	while(fwd_bit_sz-- > 0) { //prepare next bit modulation
 		if(((*fwd_write_ptr++) & 1) == 1)
-			SpinDelayUs(32*8); //32 cycles at 125Khz (8us each)
+			WaitUS(32*8); //32 cycles at 125Khz (8us each)
 		else {
 			//These timings work for 4469/4269/4305 (with the 55*8 above)
 			FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
-			SpinDelayUs(23*8); //16-4 cycles off (8us each) //23  //one reader goes as high as 25 here
+			WaitUS(23*8); //16-4 cycles off (8us each) //23  //one reader goes as high as 25 here
 			FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_ADC | FPGA_LF_ADC_READER_FIELD);//field on
-			SpinDelayUs(16*8); //16 cycles on (8us each) //9  // another reader goes to 17 here
+			WaitUS(16*8); //16 cycles on (8us each) //9  // another reader goes to 17 here
 		}
 	}
 }
@@ -1618,6 +1618,7 @@ void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
 	BigBuf_Clear_ext(false);
 
 	LED_A_ON();
+	StartTicks();
 	//If password mode do login
 	if (PwdMode == 1) EM4xLogin(Pwd);
 
@@ -1626,7 +1627,7 @@ void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
 	fwd_bit_count += Prepare_Addr( Address );
 
 	SendForward(fwd_bit_count);
-	SpinDelayUs(400);
+	WaitUS(400);
 	// Now do the acquisition
 	DoPartialAcquisition(20, true, 6000);
 	
@@ -1645,6 +1646,7 @@ void EM4xWriteWord(uint32_t flag, uint32_t Data, uint32_t Pwd) {
 	BigBuf_Clear_ext(false);
 
 	LED_A_ON();
+	StartTicks();
 	//If password mode do login
 	if (PwdMode) EM4xLogin(Pwd);
 
@@ -1658,7 +1660,7 @@ void EM4xWriteWord(uint32_t flag, uint32_t Data, uint32_t Pwd) {
 	//Wait for write to complete
 	//SpinDelay(10);
 
-	SpinDelayUs(6500);
+	WaitUS(6500);
 	//Capture response if one exists
 	DoPartialAcquisition(20, true, 6000);
 

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1578,9 +1578,9 @@ void SendForward(uint8_t fwd_bit_count) {
 	fwd_bit_sz--; //prepare next bit modulation
 	fwd_write_ptr++;
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
-	WaitUS(55*8); //55 cycles off (8us each)for 4305  /another reader has 37 here...
+	WaitUS(55*8); //55 cycles off (8us each)for 4305  //another reader has 37 here...
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_ADC | FPGA_LF_ADC_READER_FIELD);//field on
-	WaitUS(18*8); //16 cycles on (8us each)  // another reader has 18 here
+	WaitUS(18*8); //18 cycles on (8us each)
 
 	// now start writting
 	while(fwd_bit_sz-- > 0) { //prepare next bit modulation
@@ -1589,9 +1589,9 @@ void SendForward(uint8_t fwd_bit_count) {
 		else {
 			//These timings work for 4469/4269/4305 (with the 55*8 above)
 			FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
-			WaitUS(23*8); //16-4 cycles off (8us each) //23  //one reader goes as high as 25 here
+			WaitUS(23*8); //23 cycles off (8us each)
 			FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_ADC | FPGA_LF_ADC_READER_FIELD);//field on
-			WaitUS(16*8); //16 cycles on (8us each) //9  // another reader goes to 17 here
+			WaitUS(18*8); //18 cycles on (8us each)
 		}
 	}
 }

--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -348,7 +348,7 @@ int ASKDemod_ext(const char *Cmd, bool verbose, bool emSearch, uint8_t askType, 
 		clk = (clk == 0) ? foundclk : clk;
 		CursorCPos = ststart;
 		CursorDPos = stend;
-		if (verbose || g_debugMode) PrintAndLog("\nFound Sequence Terminator - Second one is shown by orange and blue graph markers");
+		if (verbose || g_debugMode) PrintAndLog("\nFound Sequence Terminator - First one is shown by orange and blue graph markers");
 	}
 	int errCnt = askdemod(BitStream, &BitLen, &clk, &invert, maxErr, askamp, askType);
 	if (errCnt<0 || BitLen<16){  //if fatal error (or -1)
@@ -2169,6 +2169,22 @@ int CmdRtrim(const char *Cmd)
 	return 0;
 }
 
+// trim graph (middle) piece
+int CmdMtrim(const char *Cmd) {
+	int start = 0, stop = 0;
+	sscanf(Cmd, "%i %i", &start, &stop);
+
+	if (start > GraphTraceLen	|| stop > GraphTraceLen || start > stop) return 0;
+	start++; //leave start position sample
+
+	GraphTraceLen -= stop - start;
+	for (int i = 0; i < GraphTraceLen; i++) {
+		GraphBuffer[start+i] = GraphBuffer[stop+i];
+	}
+	return 0;
+}
+
+
 int CmdNorm(const char *Cmd)
 {
 	int i;
@@ -2419,6 +2435,7 @@ static command_t CommandTable[] =
 	{"load",            CmdLoad,            1, "<filename> -- Load trace (to graph window"},
 	{"ltrim",           CmdLtrim,           1, "<samples> -- Trim samples from left of trace"},
 	{"rtrim",           CmdRtrim,           1, "<location to end trace> -- Trim samples from right of trace"},
+	{"mtrim",           CmdMtrim,           1, "<start> <stop> -- Trim out samples from the specified start to the specified stop"},
 	{"manrawdecode",    Cmdmandecoderaw,    1, "[invert] [maxErr] -- Manchester decode binary stream in DemodBuffer"},
 	{"norm",            CmdNorm,            1, "Normalize max/min to +/-128"},
 	{"plot",            CmdPlot,            1, "Show graph window (hit 'h' in window for keystroke help)"},

--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -341,11 +341,14 @@ int ASKDemod_ext(const char *Cmd, bool verbose, bool emSearch, uint8_t askType, 
 		askAmp(BitStream, BitLen); 
 	}
 	bool st = false;
-	if (*stCheck) st = DetectST(BitStream, &BitLen, &foundclk);
+	size_t ststart = 0, stend = 0;
+	if (*stCheck) st = DetectST_ext(BitStream, &BitLen, &foundclk, &ststart, &stend);
 	if (st) {
 		*stCheck = st;
 		clk = (clk == 0) ? foundclk : clk;
-		if (verbose || g_debugMode) PrintAndLog("\nFound Sequence Terminator");
+		CursorCPos = ststart;
+		CursorDPos = stend;
+		if (verbose || g_debugMode) PrintAndLog("\nFound Sequence Terminator - Second one is shown by orange and blue graph markers");
 	}
 	int errCnt = askdemod(BitStream, &BitLen, &clk, &invert, maxErr, askamp, askType);
 	if (errCnt<0 || BitLen<16){  //if fatal error (or -1)

--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -1907,6 +1907,12 @@ int CmdGrid(const char *Cmd)
 	return 0;
 }
 
+int CmdSetGraphMarkers(const char *Cmd) {
+	sscanf(Cmd, "%i %i", &CursorCPos, &CursorDPos);
+	RepaintGraphWindow();
+	return 0;
+}
+
 int CmdHexsamples(const char *Cmd)
 {
 	int i, j;
@@ -2419,6 +2425,7 @@ static command_t CommandTable[] =
 	{"rawdemod",        CmdRawDemod,        1, "[modulation] ... <options> -see help (h option) -- Demodulate the data in the GraphBuffer and output binary"},  
 	{"samples",         CmdSamples,         0, "[512 - 40000] -- Get raw samples for graph window (GraphBuffer)"},
 	{"save",            CmdSave,            1, "<filename> -- Save trace (from graph window)"},
+	{"setgraphmarkers", CmdSetGraphMarkers, 1, "[orange_marker] [blue_marker] (in graph window)"},
 	{"scale",           CmdScale,           1, "<int> -- Set cursor display scale"},
 	{"setdebugmode",    CmdSetDebugMode,    1, "<0|1|2> -- Turn on or off Debugging Level for lf demods"},
 	{"shiftgraphzero",  CmdGraphShiftZero,  1, "<shift> -- Shift 0 for Graphed wave + or - shift value"},

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -328,29 +328,32 @@ int CmdHF14AMfDump(const char *Cmd)
 	PrintAndLog("|-----------------------------------------|");
 	PrintAndLog("|------ Reading sector access bits...-----|");
 	PrintAndLog("|-----------------------------------------|");
-	
+	uint8_t tries = 0;
 	for (sectorNo = 0; sectorNo < numSectors; sectorNo++) {
-		UsbCommand c = {CMD_MIFARE_READBL, {FirstBlockOfSector(sectorNo) + NumBlocksPerSector(sectorNo) - 1, 0, 0}};
-		memcpy(c.d.asBytes, keyA[sectorNo], 6);
-		SendCommand(&c);
+		for (tries = 0; tries < 3; tries++) {		
+			UsbCommand c = {CMD_MIFARE_READBL, {FirstBlockOfSector(sectorNo) + NumBlocksPerSector(sectorNo) - 1, 0, 0}};
+			memcpy(c.d.asBytes, keyA[sectorNo], 6);
+			SendCommand(&c);
 
-		if (WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
-			uint8_t isOK  = resp.arg[0] & 0xff;
-			uint8_t *data  = resp.d.asBytes;
-			if (isOK){
-				rights[sectorNo][0] = ((data[7] & 0x10)>>2) | ((data[8] & 0x1)<<1) | ((data[8] & 0x10)>>4); // C1C2C3 for data area 0
-				rights[sectorNo][1] = ((data[7] & 0x20)>>3) | ((data[8] & 0x2)<<0) | ((data[8] & 0x20)>>5); // C1C2C3 for data area 1
-				rights[sectorNo][2] = ((data[7] & 0x40)>>4) | ((data[8] & 0x4)>>1) | ((data[8] & 0x40)>>6); // C1C2C3 for data area 2
-				rights[sectorNo][3] = ((data[7] & 0x80)>>5) | ((data[8] & 0x8)>>2) | ((data[8] & 0x80)>>7); // C1C2C3 for sector trailer
+			if (WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
+				uint8_t isOK  = resp.arg[0] & 0xff;
+				uint8_t *data  = resp.d.asBytes;
+				if (isOK){
+					rights[sectorNo][0] = ((data[7] & 0x10)>>2) | ((data[8] & 0x1)<<1) | ((data[8] & 0x10)>>4); // C1C2C3 for data area 0
+					rights[sectorNo][1] = ((data[7] & 0x20)>>3) | ((data[8] & 0x2)<<0) | ((data[8] & 0x20)>>5); // C1C2C3 for data area 1
+					rights[sectorNo][2] = ((data[7] & 0x40)>>4) | ((data[8] & 0x4)>>1) | ((data[8] & 0x40)>>6); // C1C2C3 for data area 2
+					rights[sectorNo][3] = ((data[7] & 0x80)>>5) | ((data[8] & 0x8)>>2) | ((data[8] & 0x80)>>7); // C1C2C3 for sector trailer
+					break;
+				} else if (tries == 2) { // on last try set defaults
+					PrintAndLog("Could not get access rights for sector %2d. Trying with defaults...", sectorNo);
+					rights[sectorNo][0] = rights[sectorNo][1] = rights[sectorNo][2] = 0x00;
+					rights[sectorNo][3] = 0x01;
+				}
 			} else {
-				PrintAndLog("Could not get access rights for sector %2d. Trying with defaults...", sectorNo);
+				PrintAndLog("Command execute timeout when trying to read access rights for sector %2d. Trying with defaults...", sectorNo);
 				rights[sectorNo][0] = rights[sectorNo][1] = rights[sectorNo][2] = 0x00;
 				rights[sectorNo][3] = 0x01;
 			}
-		} else {
-			PrintAndLog("Command execute timeout when trying to read access rights for sector %2d. Trying with defaults...", sectorNo);
-			rights[sectorNo][0] = rights[sectorNo][1] = rights[sectorNo][2] = 0x00;
-			rights[sectorNo][3] = 0x01;
 		}
 	}
 	
@@ -362,27 +365,33 @@ int CmdHF14AMfDump(const char *Cmd)
 	for (sectorNo = 0; isOK && sectorNo < numSectors; sectorNo++) {
 		for (blockNo = 0; isOK && blockNo < NumBlocksPerSector(sectorNo); blockNo++) {
 			bool received = false;
-			
-			if (blockNo == NumBlocksPerSector(sectorNo) - 1) {		// sector trailer. At least the Access Conditions can always be read with key A. 
-				UsbCommand c = {CMD_MIFARE_READBL, {FirstBlockOfSector(sectorNo) + blockNo, 0, 0}};
-				memcpy(c.d.asBytes, keyA[sectorNo], 6);
-				SendCommand(&c);
-				received = WaitForResponseTimeout(CMD_ACK,&resp,1500);
-			} else {												// data block. Check if it can be read with key A or key B
-				uint8_t data_area = sectorNo<32?blockNo:blockNo/5;
-				if ((rights[sectorNo][data_area] == 0x03) || (rights[sectorNo][data_area] == 0x05)) {	// only key B would work
-					UsbCommand c = {CMD_MIFARE_READBL, {FirstBlockOfSector(sectorNo) + blockNo, 1, 0}};
-					memcpy(c.d.asBytes, keyB[sectorNo], 6);
-					SendCommand(&c);
-					received = WaitForResponseTimeout(CMD_ACK,&resp,1500);
-				} else if (rights[sectorNo][data_area] == 0x07) {										// no key would work
-					isOK = false;
-					PrintAndLog("Access rights do not allow reading of sector %2d block %3d", sectorNo, blockNo);
-				} else {																				// key A would work
+			for (tries = 0; tries < 3; tries++) {			
+				if (blockNo == NumBlocksPerSector(sectorNo) - 1) {		// sector trailer. At least the Access Conditions can always be read with key A. 
 					UsbCommand c = {CMD_MIFARE_READBL, {FirstBlockOfSector(sectorNo) + blockNo, 0, 0}};
 					memcpy(c.d.asBytes, keyA[sectorNo], 6);
 					SendCommand(&c);
 					received = WaitForResponseTimeout(CMD_ACK,&resp,1500);
+				} else {												// data block. Check if it can be read with key A or key B
+					uint8_t data_area = sectorNo<32?blockNo:blockNo/5;
+					if ((rights[sectorNo][data_area] == 0x03) || (rights[sectorNo][data_area] == 0x05)) {	// only key B would work
+						UsbCommand c = {CMD_MIFARE_READBL, {FirstBlockOfSector(sectorNo) + blockNo, 1, 0}};
+						memcpy(c.d.asBytes, keyB[sectorNo], 6);
+						SendCommand(&c);
+						received = WaitForResponseTimeout(CMD_ACK,&resp,1500);
+					} else if (rights[sectorNo][data_area] == 0x07) {										// no key would work
+						isOK = false;
+						PrintAndLog("Access rights do not allow reading of sector %2d block %3d", sectorNo, blockNo);
+						tries = 2;
+					} else {																				// key A would work
+						UsbCommand c = {CMD_MIFARE_READBL, {FirstBlockOfSector(sectorNo) + blockNo, 0, 0}};
+						memcpy(c.d.asBytes, keyA[sectorNo], 6);
+						SendCommand(&c);
+						received = WaitForResponseTimeout(CMD_ACK,&resp,1500);
+					}
+				}
+				if (received) {
+					isOK  = resp.arg[0] & 0xff;
+					if (isOK) break;
 				}
 			}
 

--- a/client/proxgui.h
+++ b/client/proxgui.h
@@ -23,7 +23,7 @@ void ExitGraphics(void);
 extern int GraphBuffer[MAX_GRAPH_TRACE_LEN];
 extern int GraphTraceLen;
 extern double CursorScaleFactor;
-extern int PlotGridX, PlotGridY, PlotGridXdefault, PlotGridYdefault;
+extern int PlotGridX, PlotGridY, PlotGridXdefault, PlotGridYdefault, CursorCPos, CursorDPos;
 extern int CommandFinished;
 extern int offline;
 

--- a/client/proxguiqt.cpp
+++ b/client/proxguiqt.cpp
@@ -102,7 +102,7 @@ ProxGuiQT::~ProxGuiQT(void)
 void ProxWidget::paintEvent(QPaintEvent *event)
 {
 	QPainter painter(this);
-	QPainterPath penPath, whitePath, greyPath, lightgreyPath, cursorAPath, cursorBPath;
+	QPainterPath penPath, whitePath, greyPath, lightgreyPath, cursorAPath, cursorBPath, cursorCPath, cursorDPath;
 	QRect r;
 	QBrush brush(QColor(100, 255, 100));
 	QPen pen(QColor(100, 255, 100));
@@ -117,6 +117,10 @@ void ProxWidget::paintEvent(QPaintEvent *event)
 		CursorAPos= 0;
 	if(CursorBPos > GraphTraceLen)
 		CursorBPos= 0;
+	if(CursorCPos > GraphTraceLen)
+		CursorCPos= 0;
+	if(CursorDPos > GraphTraceLen)
+		CursorDPos= 0;
 
 	r = rect();
 
@@ -242,13 +246,17 @@ void ProxWidget::paintEvent(QPaintEvent *event)
 			penPath.moveTo(x,y);
 		}
 
-		if(i == CursorAPos || i == CursorBPos) {
+		if(i == CursorAPos || i == CursorBPos || i == CursorCPos || i == CursorDPos) {
 			QPainterPath *cursorPath;
 
 			if(i == CursorAPos) {
 				cursorPath = &cursorAPath;
-			} else {
+			} else if (i == CursorBPos) {
 				cursorPath = &cursorBPath;
+			} else if (i == CursorCPos) {
+				cursorPath = &cursorCPath;
+			} else {
+				cursorPath = &cursorDPath;
 			}
 			cursorPath->moveTo(x, r.top());
 			cursorPath->lineTo(x, r.bottom());
@@ -268,6 +276,10 @@ void ProxWidget::paintEvent(QPaintEvent *event)
 	painter.drawPath(cursorAPath);
 	painter.setPen(QColor(255, 0, 255));
 	painter.drawPath(cursorBPath);
+	painter.setPen(QColor(255, 153, 0)); //orange
+	painter.drawPath(cursorCPath);
+	painter.setPen(QColor(0, 0, 205)); //light blue
+	painter.drawPath(cursorDPath);
 
 	char str[200];
 	sprintf(str, "@%d   max=%d min=%d mean=%d n=%d/%d    dt=%d [%.3f] zoom=%.3f CursorA=%d [%d] CursorB=%d [%d]    GridX=%d GridY=%d (%s)",

--- a/client/ui.c
+++ b/client/ui.c
@@ -19,7 +19,7 @@
 #include "ui.h"
 
 double CursorScaleFactor;
-int PlotGridX, PlotGridY, PlotGridXdefault= 64, PlotGridYdefault= 64;
+int PlotGridX, PlotGridY, PlotGridXdefault= 64, PlotGridYdefault= 64, CursorCPos= 0, CursorDPos= 0;
 int offline;
 int flushAfterWrite = 0;  //buzzy
 extern pthread_mutex_t print_lock;

--- a/client/ui.h
+++ b/client/ui.h
@@ -19,7 +19,7 @@ void PrintAndLog(char *fmt, ...);
 void SetLogFilename(char *fn);
 
 extern double CursorScaleFactor;
-extern int PlotGridX, PlotGridY, PlotGridXdefault, PlotGridYdefault;
+extern int PlotGridX, PlotGridY, PlotGridXdefault, PlotGridYdefault, CursorCPos, CursorDPos;
 extern int offline;
 extern int flushAfterWrite;   //buzzy
 

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -1770,8 +1770,8 @@ bool DetectST_ext(uint8_t buffer[], size_t *size, int *foundclock, size_t *ststa
 			buffer[dataloc+1] = buffer[dataloc+2];
 		}
 		if (firstrun) {
-			*ststart = dataloc;
-			*stend = dataloc+(clk*4);
+			*stend = dataloc;
+			*ststart = dataloc-(clk*4);
 			firstrun=false;
 		}
 		for (i=0; i<datalen; ++i) {

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -218,8 +218,8 @@ uint8_t Em410xDecode(uint8_t *BitStream, size_t *size, size_t *startIdx, uint32_
 	uint8_t FmtLen = 10; // sets of 4 bits = end data 
 	*startIdx = 0;
 	errChk = preambleSearch(BitStream, preamble, sizeof(preamble), size, startIdx);
-	if (errChk == 0 || *size < 64) return 0;
-	if (*size == 110) FmtLen = 22; // 22 sets of 4 bits
+	if ( errChk == 0 || (*size != 64 && *size != 128) ) return 0;
+	if (*size == 128) FmtLen = 22; // 22 sets of 4 bits
 
 	//skip last 4bit parity row for simplicity
 	*size = removeParity(BitStream, *startIdx + sizeof(preamble), 5, 0, FmtLen * 5);

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -1759,6 +1759,10 @@ bool DetectST(uint8_t buffer[], size_t *size, int *foundclock) {
 			for(i=0; i < clk/2-tol; ++i) {
 				buffer[dataloc+i] = high+5;
 			}
+		} //test for single sample outlier (high between two lows) in the case of very strong waves
+		if (buffer[dataloc] >= high && buffer[dataloc+2] <= low) {
+			buffer[dataloc] = buffer[dataloc+2];
+			buffer[dataloc+1] = buffer[dataloc+2];
 		}
 		for (i=0; i<datalen; ++i) {
 			if (i+newloc < bufsize) {

--- a/common/lfdemod.h
+++ b/common/lfdemod.h
@@ -31,6 +31,7 @@ int      DetectNRZClock(uint8_t dest[], size_t size, int clock);
 int      DetectPSKClock(uint8_t dest[], size_t size, int clock);
 int      DetectStrongAskClock(uint8_t dest[], size_t size, uint8_t high, uint8_t low);
 bool     DetectST(uint8_t buffer[], size_t *size, int *foundclock);
+bool     DetectST_ext(uint8_t buffer[], size_t *size, int *foundclock, size_t *ststart, size_t *stend);
 int      fskdemod(uint8_t *dest, size_t size, uint8_t rfLen, uint8_t invert, uint8_t fchigh, uint8_t fclow);
 int      getHiLo(uint8_t *BitStream, size_t size, int *high, int *low, uint8_t fuzzHi, uint8_t fuzzLo);
 uint32_t manchesterEncode2Bytes(uint16_t datain);


### PR DESCRIPTION
Add a retry loop in `hf mf dump` to retry each read up to 3 times (helps fix #200 )
Fixed a small bug in STT detection for strong (or cleaned) signal.
Fixed a bug preventing the detection of EM410x XL format AKA Unique XL or 128 bit Unique ID
add `data setgraphmarkers` <orange> <blue> to allow setting markers on the graph
add `data mtrim` <start> <stop> to allow middle trimming (or trimming out samples between start and stop)
make the askmandemod mark the first STT on the graph if it is found