### PR TITLE
Clean mfu dump output

### DIFF
--- a/client/cmdhfmfu.c
+++ b/client/cmdhfmfu.c
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------------
 // High frequency MIFARE ULTRALIGHT (C) commands
 //-----------------------------------------------------------------------------
+#include <ctype.h>
 #include "loclass/des.h"
 #include "cmdhfmfu.h"
 #include "cmdhfmf.h"
@@ -1230,6 +1231,7 @@ int CmdHF14AMfUDump(const char *Cmd){
 	bool manualPages = false;
 	uint8_t startPage = 0;
 	char tempStr[50];
+	char cleanASCII[4];
 
 	while(param_getchar(Cmd, cmdp) != 0x00)
 	{
@@ -1372,7 +1374,7 @@ int CmdHF14AMfUDump(const char *Cmd){
 	PrintAndLog("---------------------------------");
 	for (i = 0; i < Pages; ++i) {
 		if ( i < 3 ) {
-			PrintAndLog("%02d/0x%02X | %s|   | ", i+startPage, i+startPage, sprint_hex(data + i * 4, 4));
+			PrintAndLog("%3d/0x%02X | %s|   | ", i+startPage, i+startPage, sprint_hex(data + i * 4, 4));
 			continue;
 		}
 		switch(i){
@@ -1419,7 +1421,17 @@ int CmdHF14AMfUDump(const char *Cmd){
 			case 43: tmplockbit = bit2[9]; break;  //auth1
 			default: break;
 		}
-		PrintAndLog("%02d/0x%02X | %s| %d | %.4s", i+startPage, i+startPage, sprint_hex(data + i * 4, 4), tmplockbit, data+i*4);
+
+		// convert unprintable characters and line breaks to dots
+		memcpy(cleanASCII, data+i*4, 4);
+
+		for (size_t clean_i = 0; clean_i < 4; clean_i++) {
+			if (!isprint(cleanASCII[clean_i])) {
+				cleanASCII[clean_i] = '.';
+			}
+		}
+
+		PrintAndLog("%3d/0x%02X | %s| %d | %.4s", i+startPage, i+startPage, sprint_hex(data + i * 4, 4), tmplockbit, cleanASCII);
 	}
 	PrintAndLog("---------------------------------");
 

--- a/client/cmdhfmfu.c
+++ b/client/cmdhfmfu.c
@@ -1231,7 +1231,7 @@ int CmdHF14AMfUDump(const char *Cmd){
 	bool manualPages = false;
 	uint8_t startPage = 0;
 	char tempStr[50];
-	char cleanASCII[4];
+	unsigned char cleanASCII[4];
 
 	while(param_getchar(Cmd, cmdp) != 0x00)
 	{
@@ -1424,12 +1424,7 @@ int CmdHF14AMfUDump(const char *Cmd){
 
 		// convert unprintable characters and line breaks to dots
 		memcpy(cleanASCII, data+i*4, 4);
-
-		for (size_t clean_i = 0; clean_i < 4; clean_i++) {
-			if (!isprint(cleanASCII[clean_i])) {
-				cleanASCII[clean_i] = '.';
-			}
-		}
+		clean_ascii(cleanASCII, 4);
 
 		PrintAndLog("%3d/0x%02X | %s| %d | %.4s", i+startPage, i+startPage, sprint_hex(data + i * 4, 4), tmplockbit, cleanASCII);
 	}

--- a/client/util.c
+++ b/client/util.c
@@ -8,6 +8,7 @@
 // utilities
 //-----------------------------------------------------------------------------
 
+#include <ctype.h>
 #include "util.h"
 #define MAX_BIN_BREAK_LENGTH   (3072+384+1)
 
@@ -580,4 +581,13 @@ void rol(uint8_t *data, const size_t len){
         data[i] = data[i+1];
     }
     data[len-1] = first;
+}
+
+
+// Replace unprintable characters with a dot in char buffer
+void clean_ascii(unsigned char *buf, size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    if (!isprint(buf[i]))
+      buf[i] = '.';
+  }
 }

--- a/client/util.h
+++ b/client/util.h
@@ -76,3 +76,5 @@ void xor(unsigned char *dst, unsigned char *src, size_t len);
 int32_t le24toh(uint8_t data[3]);
 uint32_t le32toh (uint8_t *data);
 void rol(uint8_t *data, const size_t len);
+
+void clean_ascii(unsigned char *buf, size_t len);


### PR DESCRIPTION
Replace unprintable characters with a dot in the `hf mfu dump` preview to prevent them from scrambling the console output. `cmdhf15.c` does something similar.