### PR TITLE
Typo fix for CmdPing

### DIFF
--- a/client/cmdhw.c
+++ b/client/cmdhw.c
@@ -449,7 +449,7 @@ int CmdPing(const char *Cmd)
 	UsbCommand c = {CMD_PING};
 	SendCommand(&c);
 	if (WaitForResponseTimeout(CMD_ACK,&resp,1000)) {
-		PrintAndLog("Ping successfull");
+		PrintAndLog("Ping successful");
 	}else{
 		PrintAndLog("Ping failed");
 	}


### PR DESCRIPTION
Quick PR to fix a typo in the hw ping command.

Ping successfull -> Ping successful