### PR TITLE
Client code cleanup:

### DIFF
--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -277,8 +277,8 @@ int AskEm410xDecode(bool verbose, uint32_t *hi, uint64_t *lo )
 
 int AskEm410xDemod(const char *Cmd, uint32_t *hi, uint64_t *lo, bool verbose)
 {
-	bool st = TRUE;
-	if (!ASKDemod_ext(Cmd, FALSE, FALSE, 1, &st)) return 0;
+	bool st = true;
+	if (!ASKDemod_ext(Cmd, false, false, 1, &st)) return 0;
 	return AskEm410xDecode(verbose, hi, lo);
 }
 
@@ -406,13 +406,13 @@ int Cmdaskmandemod(const char *Cmd)
 		PrintAndLog("          : data rawdemod am 64 1 0 = demod an ask/manchester tag from GraphBuffer using a clock of RF/64, inverting data and allowing 0 demod errors");
 		return 0;
 	}
-	bool st = TRUE;
+	bool st = true;
 	if (Cmd[0]=='s') 
-		return ASKDemod_ext(Cmd++, TRUE, TRUE, 1, &st);
+		return ASKDemod_ext(Cmd++, true, true, 1, &st);
 	else if (Cmd[1] == 's')
-		return ASKDemod_ext(Cmd+=2, TRUE, TRUE, 1, &st);
+		return ASKDemod_ext(Cmd+=2, true, true, 1, &st);
 	else
-		return ASKDemod(Cmd, TRUE, TRUE, 1);
+		return ASKDemod(Cmd, true, true, 1);
 }
 
 //by marshmellow
@@ -587,7 +587,7 @@ int Cmdaskbiphdemod(const char *Cmd)
 		PrintAndLog("          : data rawdemod ab 0 64 1 0 0 a = demod an ask/biph tag from GraphBuffer using a clock of RF/64, inverting data and allowing 0 demod errors, and amp");
 		return 0;
 	}
-	return ASKbiphaseDemod(Cmd, TRUE);
+	return ASKbiphaseDemod(Cmd, true);
 }
 
 //by marshmellow
@@ -597,7 +597,7 @@ int Cmdaskbiphdemod(const char *Cmd)
 //if successful it will push askraw data back to demod buffer ready for emulation
 int CmdG_Prox_II_Demod(const char *Cmd)
 {
-	if (!ASKbiphaseDemod(Cmd, FALSE)){
+	if (!ASKbiphaseDemod(Cmd, false)){
 		if (g_debugMode) PrintAndLog("Error gProxII: ASKbiphaseDemod failed 1st try");
 		return 0;
 	}
@@ -702,7 +702,7 @@ int Cmdaskrawdemod(const char *Cmd)
 		PrintAndLog("          : data rawdemod ar 64 1 0 0 a = demod an ask tag from GraphBuffer using a clock of RF/64, inverting data and allowing 0 demod errors, and amp");
 		return 0;
 	}
-	return ASKDemod(Cmd, TRUE, FALSE, 0);
+	return ASKDemod(Cmd, true, false, 0);
 }
 
 int AutoCorrelate(int window, bool SaveGrph, bool verbose)
@@ -767,7 +767,7 @@ int CmdAutoCorr(const char *Cmd)
 		return usage_data_autocorr();
 	int window = 4000; //set default
 	char grph=0;
-	bool updateGrph = FALSE;
+	bool updateGrph = false;
 	sscanf(Cmd, "%i %c", &window, &grph);
 
 	if (window >= GraphTraceLen) {
@@ -775,8 +775,8 @@ int CmdAutoCorr(const char *Cmd)
 			GraphTraceLen);
 		return 0;
 	}
-	if (grph == 'g') updateGrph=TRUE;
-	return AutoCorrelate(window, updateGrph, TRUE);
+	if (grph == 'g') updateGrph=true;
+	return AutoCorrelate(window, updateGrph, true);
 }
 
 int CmdBitsamples(const char *Cmd)
@@ -1035,7 +1035,7 @@ int CmdFSKrawdemod(const char *Cmd)
 		PrintAndLog("          : data rawdemod fs 50 1 10 8 = demod an fsk2a RF/50 tag from GraphBuffer");
 		return 0;
 	}
-	return FSKrawDemod(Cmd, TRUE);
+	return FSKrawDemod(Cmd, true);
 }
 
 //by marshmellow (based on existing demod + holiman's refactor)
@@ -1789,7 +1789,7 @@ int CmdNRZrawDemod(const char *Cmd)
 		PrintAndLog("          : data rawdemod nr 64 1 0 = demod a nrz/direct tag from GraphBuffer using a clock of RF/64, inverting data and allowing 0 demod errors");
 		return 0;
 	}
-	return NRZrawDemod(Cmd, TRUE);
+	return NRZrawDemod(Cmd, true);
 }
 
 // by marshmellow
@@ -1813,7 +1813,7 @@ int CmdPSK1rawDemod(const char *Cmd)
 		PrintAndLog("          : data rawdemod p1 64 1 0 = demod a psk1 tag from GraphBuffer using a clock of RF/64, inverting data and allowing 0 demod errors");
 		return 0;
 	}
-	ans = PSKDemod(Cmd, TRUE);
+	ans = PSKDemod(Cmd, true);
 	//output
 	if (!ans){
 		if (g_debugMode) PrintAndLog("Error demoding: %d",ans); 
@@ -1845,7 +1845,7 @@ int CmdPSK2rawDemod(const char *Cmd)
 		PrintAndLog("          : data rawdemod p2 64 1 0  = demod a psk2 tag from GraphBuffer using a clock of RF/64, inverting output and allowing 0 demod errors");
 		return 0;
 	}
-	ans=PSKDemod(Cmd, TRUE);
+	ans=PSKDemod(Cmd, true);
 	if (!ans){
 		if (g_debugMode) PrintAndLog("Error demoding: %d",ans);  
 		return 0;

--- a/client/cmdhf.c
+++ b/client/cmdhf.c
@@ -11,8 +11,10 @@
 #include <stdio.h>
 #include <string.h>
 #include "proxmark3.h"
-#include "graph.h"
+#include "util.h"
 #include "ui.h"
+#include "iso14443crc.h"
+#include "cmdmain.h"
 #include "cmdparser.h"
 #include "cmdhf.h"
 #include "cmdhf14a.h"

--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -570,14 +570,14 @@ int CmdHF14ASnoop(const char *Cmd) {
 int CmdHF14ACmdRaw(const char *cmd) {
     UsbCommand c = {CMD_READER_ISO_14443a, {0, 0, 0}};
     bool reply=1;
-    bool crc = FALSE;
-    bool power = FALSE;
-    bool active = FALSE;
-    bool active_select = FALSE;
+    bool crc = false;
+    bool power = false;
+    bool active = false;
+    bool active_select = false;
     uint16_t numbits = 0;
-	bool bTimeout = FALSE;
+	bool bTimeout = false;
 	uint32_t timeout = 0;
-	bool topazmode = FALSE;
+	bool topazmode = false;
     char buf[5]="";
     int i = 0;
     uint8_t data[USB_CMD_DATA_SIZE];
@@ -606,19 +606,19 @@ int CmdHF14ACmdRaw(const char *cmd) {
         if (cmd[i]=='-') {
             switch (cmd[i+1]) {
                 case 'r': 
-                    reply = FALSE;
+                    reply = false;
                     break;
                 case 'c':
-                    crc = TRUE;
+                    crc = true;
                     break;
                 case 'p':
-                    power = TRUE;
+                    power = true;
                     break;
                 case 'a':
-                    active = TRUE;
+                    active = true;
                     break;
                 case 's':
-                    active_select = TRUE;
+                    active_select = true;
                     break;
                 case 'b': 
                     sscanf(cmd+i+2,"%d",&temp);
@@ -628,7 +628,7 @@ int CmdHF14ACmdRaw(const char *cmd) {
                     i-=2;
                     break;
 				case 't':
-					bTimeout = TRUE;
+					bTimeout = true;
 					sscanf(cmd+i+2,"%d",&temp);
 					timeout = temp;
 					i+=3;
@@ -636,7 +636,7 @@ int CmdHF14ACmdRaw(const char *cmd) {
 					i-=2;
 					break;
                 case 'T':
-					topazmode = TRUE;
+					topazmode = true;
 					break;
                 default:
                     PrintAndLog("Invalid option");

--- a/client/cmdhfmf.h
+++ b/client/cmdhfmf.h
@@ -11,47 +11,34 @@
 #ifndef CMDHFMF_H__
 #define CMDHFMF_H__
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
-#include "proxmark3.h"
-#include "iso14443crc.h"
-#include "data.h"
-#include "ui.h"
-#include "cmdparser.h"
-#include "common.h"
-#include "util.h"
-#include "mifarehost.h"
+extern int CmdHFMF(const char *Cmd);
 
-int CmdHFMF(const char *Cmd);
-
-int CmdHF14AMfDbg(const char* cmd);
-int CmdHF14AMfRdBl(const char* cmd);
-int CmdHF14AMfURdBl(const char* cmd);
-int CmdHF14AMfRdSc(const char* cmd);
-int CmdHF14SMfURdCard(const char* cmd);
-int CmdHF14AMfDump(const char* cmd);
-int CmdHF14AMfRestore(const char* cmd);
-int CmdHF14AMfWrBl(const char* cmd);
-int CmdHF14AMfUWrBl(const char* cmd);
-int CmdHF14AMfChk(const char* cmd);
-int CmdHF14AMifare(const char* cmd);
-int CmdHF14AMfNested(const char* cmd);
-int CmdHF14AMfSniff(const char* cmd);
-int CmdHF14AMf1kSim(const char* cmd);
-int CmdHF14AMfEClear(const char* cmd);
-int CmdHF14AMfEGet(const char* cmd);
-int CmdHF14AMfESet(const char* cmd);
-int CmdHF14AMfELoad(const char* cmd);
-int CmdHF14AMfESave(const char* cmd);
-int CmdHF14AMfECFill(const char* cmd);
-int CmdHF14AMfEKeyPrn(const char* cmd);
-int CmdHF14AMfCSetUID(const char* cmd);
-int CmdHF14AMfCSetBlk(const char* cmd);
-int CmdHF14AMfCGetBlk(const char* cmd);
-int CmdHF14AMfCGetSc(const char* cmd);
-int CmdHF14AMfCLoad(const char* cmd);
-int CmdHF14AMfCSave(const char* cmd);
+extern int CmdHF14AMfDbg(const char* cmd);
+extern int CmdHF14AMfRdBl(const char* cmd);
+extern int CmdHF14AMfURdBl(const char* cmd);
+extern int CmdHF14AMfRdSc(const char* cmd);
+extern int CmdHF14SMfURdCard(const char* cmd);
+extern int CmdHF14AMfDump(const char* cmd);
+extern int CmdHF14AMfRestore(const char* cmd);
+extern int CmdHF14AMfWrBl(const char* cmd);
+extern int CmdHF14AMfUWrBl(const char* cmd);
+extern int CmdHF14AMfChk(const char* cmd);
+extern int CmdHF14AMifare(const char* cmd);
+extern int CmdHF14AMfNested(const char* cmd);
+extern int CmdHF14AMfSniff(const char* cmd);
+extern int CmdHF14AMf1kSim(const char* cmd);
+extern int CmdHF14AMfEClear(const char* cmd);
+extern int CmdHF14AMfEGet(const char* cmd);
+extern int CmdHF14AMfESet(const char* cmd);
+extern int CmdHF14AMfELoad(const char* cmd);
+extern int CmdHF14AMfESave(const char* cmd);
+extern int CmdHF14AMfECFill(const char* cmd);
+extern int CmdHF14AMfEKeyPrn(const char* cmd);
+extern int CmdHF14AMfCSetUID(const char* cmd);
+extern int CmdHF14AMfCSetBlk(const char* cmd);
+extern int CmdHF14AMfCGetBlk(const char* cmd);
+extern int CmdHF14AMfCGetSc(const char* cmd);
+extern int CmdHF14AMfCLoad(const char* cmd);
+extern int CmdHF14AMfCSave(const char* cmd);
 
 #endif

--- a/client/cmdhfmfu.c
+++ b/client/cmdhfmfu.c
@@ -7,7 +7,11 @@
 //-----------------------------------------------------------------------------
 // High frequency MIFARE ULTRALIGHT (C) commands
 //-----------------------------------------------------------------------------
-#include <ctype.h>
+
+#include "proxmark3.h"
+#include "usb_cmd.h"
+#include "cmdmain.h"
+#include "ui.h"
 #include "loclass/des.h"
 #include "cmdhfmfu.h"
 #include "cmdhfmf.h"

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -63,7 +63,7 @@ int CmdLFCommandRead(const char *Cmd)
 {
 	static char dummy[3] = {0x20,0x00,0x00};
 	UsbCommand c = {CMD_MOD_THEN_ACQUIRE_RAW_ADC_SAMPLES_125K};
-	bool errors = FALSE;
+	bool errors = false;
 	//uint8_t divisor = 95; //125khz
 	uint8_t cmdp = 0;
 	while(param_getchar(Cmd, cmdp) != 0x00)
@@ -484,7 +484,7 @@ int CmdLFSetConfig(const char *Cmd)
 	uint8_t bps = 0; // Bits per sample
 	uint8_t decimation = 0; //How many to keep
 	bool averaging = 1; // Defaults to true
-	bool errors = FALSE;
+	bool errors = false;
 	int trigger_threshold =-1;//Means no change
 	uint8_t unsigned_trigg = 0;
 
@@ -700,7 +700,7 @@ int CmdLFfskSim(const char *Cmd)
 	// otherwise will need FChigh, FClow, Clock, and bitstream
 	uint8_t fcHigh=0, fcLow=0, clk=0;
 	uint8_t invert=0;
-	bool errors = FALSE;
+	bool errors = false;
 	char hexData[32] = {0x00}; // store entered hex data
 	uint8_t data[255] = {0x00}; 
 	int dataLen = 0;
@@ -734,24 +734,24 @@ int CmdLFfskSim(const char *Cmd)
 		case 'd':
 			dataLen = param_getstr(Cmd, cmdp+1, hexData);
 			if (dataLen==0) {
-				errors=TRUE; 
+				errors=true; 
 			} else {
 				dataLen = hextobinarray((char *)data, hexData);
 			}   
-			if (dataLen==0) errors=TRUE; 
+			if (dataLen==0) errors=true; 
 			if (errors) PrintAndLog ("Error getting hex data");
 			cmdp+=2;
 			break;
 		default:
 			PrintAndLog("Unknown parameter '%c'", param_getchar(Cmd, cmdp));
-			errors = TRUE;
+			errors = true;
 			break;
 		}
 		if(errors) break;
 	}
 	if(cmdp == 0 && DemodBufferLen == 0)
 	{
-		errors = TRUE;// No args
+		errors = true;// No args
 	}
 
 	//Validations
@@ -802,7 +802,7 @@ int CmdLFaskSim(const char *Cmd)
 	// needs clock, invert, manchester/raw as m or r, separator as s, and bitstream
 	uint8_t encoding = 1, separator = 0;
 	uint8_t clk=0, invert=0;
-	bool errors = FALSE;
+	bool errors = false;
 	char hexData[32] = {0x00}; 
 	uint8_t data[255]= {0x00}; // store entered hex data
 	int dataLen = 0;
@@ -840,24 +840,24 @@ int CmdLFaskSim(const char *Cmd)
 		case 'd':
 			dataLen = param_getstr(Cmd, cmdp+1, hexData);
 			if (dataLen==0) {
-				errors=TRUE; 
+				errors=true; 
 			} else {
 				dataLen = hextobinarray((char *)data, hexData);
 			}
-			if (dataLen==0) errors=TRUE; 
+			if (dataLen==0) errors=true; 
 			if (errors) PrintAndLog ("Error getting hex data, datalen: %d",dataLen);
 				cmdp+=2;
 			break;
 		default:
 			PrintAndLog("Unknown parameter '%c'", param_getchar(Cmd, cmdp));
-			errors = TRUE;
+			errors = true;
 			break;
 		}
 		if(errors) break;
 	}
 	if(cmdp == 0 && DemodBufferLen == 0)
 	{
-		errors = TRUE;// No args
+		errors = true;// No args
 	}
 
 	//Validations
@@ -896,7 +896,7 @@ int CmdLFpskSim(const char *Cmd)
 	//will need carrier, Clock, and bitstream
 	uint8_t carrier=0, clk=0;
 	uint8_t invert=0;
-	bool errors = FALSE;
+	bool errors = false;
 	char hexData[32] = {0x00}; // store entered hex data
 	uint8_t data[255] = {0x00}; 
 	int dataLen = 0;
@@ -935,24 +935,24 @@ int CmdLFpskSim(const char *Cmd)
 		case 'd':
 			dataLen = param_getstr(Cmd, cmdp+1, hexData);
 			if (dataLen==0) {
-				errors=TRUE; 
+				errors=true; 
 			} else {
 				dataLen = hextobinarray((char *)data, hexData);
 			}    
-			if (dataLen==0) errors=TRUE; 
+			if (dataLen==0) errors=true; 
 			if (errors) PrintAndLog ("Error getting hex data");
 			cmdp+=2;
 			break;
 		default:
 			PrintAndLog("Unknown parameter '%c'", param_getchar(Cmd, cmdp));
-			errors = TRUE;
+			errors = true;
 			break;
 		}
 		if (errors) break;
 	}
 	if (cmdp == 0 && DemodBufferLen == 0)
 	{
-		errors = TRUE;// No args
+		errors = true;// No args
 	}
 
 	//Validations
@@ -962,9 +962,9 @@ int CmdLFpskSim(const char *Cmd)
 	}
 	if (dataLen == 0){ //using DemodBuffer
 		PrintAndLog("Getting Clocks");
-		if (clk==0) clk = GetPskClock("", FALSE, FALSE);
+		if (clk==0) clk = GetPskClock("", false, false);
 		PrintAndLog("clk: %d",clk);
-		if (!carrier) carrier = GetPskCarrier("", FALSE, FALSE); 
+		if (!carrier) carrier = GetPskCarrier("", false, false); 
 		PrintAndLog("carrier: %d", carrier);
 	} else {
 		setDemodBuf(data, dataLen, 0);
@@ -1236,18 +1236,18 @@ int CmdLFfind(const char *Cmd)
 		ans=CheckChipType(cmdp);
 		//test unknown tag formats (raw mode)0
 		PrintAndLog("\nChecking for Unknown tags:\n");
-		ans=AutoCorrelate(4000, FALSE, FALSE);
+		ans=AutoCorrelate(4000, false, false);
 		if (ans > 0) PrintAndLog("Possible Auto Correlation of %d repeating samples",ans);
-		ans=GetFskClock("",FALSE,FALSE); 
+		ans=GetFskClock("",false,false); 
 		if (ans != 0){ //fsk
-			ans=FSKrawDemod("",TRUE);
+			ans=FSKrawDemod("",true);
 			if (ans>0) {
 				PrintAndLog("\nUnknown FSK Modulated Tag Found!");
 				return 1;
 			}
 		}
-		bool st = TRUE;
-		ans=ASKDemod_ext("0 0 0",TRUE,FALSE,1,&st);
+		bool st = true;
+		ans=ASKDemod_ext("0 0 0",true,false,1,&st);
 		if (ans>0) {
 			PrintAndLog("\nUnknown ASK Modulated and Manchester encoded Tag Found!");
 			PrintAndLog("\nif it does not look right it could instead be ASK/Biphase - try 'data rawdemod ab'");

--- a/client/cmdlfcotag.c
+++ b/client/cmdlfcotag.c
@@ -7,7 +7,17 @@
 //-----------------------------------------------------------------------------
 // Low frequency COTAG commands
 //-----------------------------------------------------------------------------
-#include "cmdlfcotag.h"  // COTAG function declarations
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "proxmark3.h"
+#include "ui.h"
+#include "cmddata.h"
+#include "data.h"
+#include "cmdlfcotag.h"
+#include "lfdemod.h"
+#include "usb_cmd.h"
+#include "cmdmain.h"
 
 static int CmdHelp(const char *Cmd);
 

--- a/client/cmdlfcotag.h
+++ b/client/cmdlfcotag.h
@@ -11,15 +11,6 @@
 #ifndef CMDLFCOTAG_H__
 #define CMDLFCOTAG_H__
 
-#include "proxmark3.h"// Definitions, USB controls, COTAG_BITS
-#include "util.h"     // FALSE / TRUE
-#include "cmddata.h"  // getSamples
-#include "cmdparser.h"// CmdsParse, CmdsHelp
-#include "cmdmain.h"
-#include "ui.h"       // PrintAndLog
-#include "cmdlf.h"    // Setconfig 
-#include "lfdemod.h"  // manrawdecode, bytebits_tobyteLSBF
-
 #ifndef COTAG_BITS
 #define COTAG_BITS 264
 #endif

--- a/client/cmdlft55xx.c
+++ b/client/cmdlft55xx.c
@@ -30,7 +30,7 @@
 #define REGULAR_READ_MODE_BLOCK 0xFF
 
 // Default configuration
-t55xx_conf_block_t config = { .modulation = DEMOD_ASK, .inverted = FALSE, .offset = 0x00, .block0 = 0x00, .Q5 = FALSE };
+t55xx_conf_block_t config = { .modulation = DEMOD_ASK, .inverted = false, .offset = 0x00, .block0 = 0x00, .Q5 = false };
 
 t55xx_conf_block_t Get_t55xx_Config(){
 	return config;
@@ -194,7 +194,7 @@ int CmdT55xxSetConfig(const char *Cmd) {
 	uint8_t bitRate = 0;
 	uint8_t rates[9] = {8,16,32,40,50,64,100,128,0};
 	uint8_t cmdp = 0;
-	bool errors = FALSE;
+	bool errors = false;
 	while(param_getchar(Cmd, cmdp) != 0x00 && !errors)
 	{
 		tmp = param_getchar(Cmd, cmdp);
@@ -213,7 +213,7 @@ int CmdT55xxSetConfig(const char *Cmd) {
 						break;
 					}
 				}
-				if (i==9) errors = TRUE;
+				if (i==9) errors = true;
 			}
 			cmdp+=2;
 			break;
@@ -253,7 +253,7 @@ int CmdT55xxSetConfig(const char *Cmd) {
 				config.inverted=0;
 			} else {
 				PrintAndLog("Unknown modulation '%s'", modulation);
-				errors = TRUE;
+				errors = true;
 			}
 			break;
 		case 'i':
@@ -268,17 +268,17 @@ int CmdT55xxSetConfig(const char *Cmd) {
 			break;
 		case 'Q':
 		case 'q':		
-			config.Q5 = TRUE;
+			config.Q5 = true;
 			cmdp++;
 			break;
 		case 'S':
 		case 's':		
-			config.ST = TRUE;
+			config.ST = true;
 			cmdp++;
 			break;
 		default:
 			PrintAndLog("Unknown parameter '%c'", param_getchar(Cmd, cmdp));
-			errors = TRUE;
+			errors = true;
 			break;
 		}
 	}
@@ -383,28 +383,28 @@ bool DecodeT55xxBlock(){
 	switch( config.modulation ){
 		case DEMOD_FSK:
 			snprintf(cmdStr, sizeof(buf),"%d %d", bitRate[config.bitrate], config.inverted );
-			ans = FSKrawDemod(cmdStr, FALSE);
+			ans = FSKrawDemod(cmdStr, false);
 			break;
 		case DEMOD_FSK1:
 		case DEMOD_FSK1a:
 			snprintf(cmdStr, sizeof(buf),"%d %d 8 5", bitRate[config.bitrate], config.inverted );
-			ans = FSKrawDemod(cmdStr, FALSE);
+			ans = FSKrawDemod(cmdStr, false);
 			break;
 		case DEMOD_FSK2:
 		case DEMOD_FSK2a:
 			snprintf(cmdStr, sizeof(buf),"%d %d 10 8", bitRate[config.bitrate], config.inverted );
-			ans = FSKrawDemod(cmdStr, FALSE);
+			ans = FSKrawDemod(cmdStr, false);
 			break;
 		case DEMOD_ASK:
 			snprintf(cmdStr, sizeof(buf),"%d %d 1", bitRate[config.bitrate], config.inverted );
-			ans = ASKDemod_ext(cmdStr, FALSE, FALSE, 1, &ST);
+			ans = ASKDemod_ext(cmdStr, false, false, 1, &ST);
 			break;
 		case DEMOD_PSK1:
 			// skip first 160 samples to allow antenna to settle in (psk gets inverted occasionally otherwise)
 			save_restoreGB(1);
 			CmdLtrim("160");
 			snprintf(cmdStr, sizeof(buf),"%d %d 6", bitRate[config.bitrate], config.inverted );
-			ans = PSKDemod(cmdStr, FALSE);
+			ans = PSKDemod(cmdStr, false);
 			//undo trim samples
 			save_restoreGB(0);
 			break;
@@ -414,22 +414,22 @@ bool DecodeT55xxBlock(){
 			save_restoreGB(1);
 			CmdLtrim("160");
 			snprintf(cmdStr, sizeof(buf),"%d 0 6", bitRate[config.bitrate] );
-			ans = PSKDemod(cmdStr, FALSE);
+			ans = PSKDemod(cmdStr, false);
 			psk1TOpsk2(DemodBuffer, DemodBufferLen);
 			//undo trim samples
 			save_restoreGB(0);
 			break;
 		case DEMOD_NRZ:
 			snprintf(cmdStr, sizeof(buf),"%d %d 1", bitRate[config.bitrate], config.inverted );
-			ans = NRZrawDemod(cmdStr, FALSE);
+			ans = NRZrawDemod(cmdStr, false);
 			break;
 		case DEMOD_BI:
 		case DEMOD_BIa:
 			snprintf(cmdStr, sizeof(buf),"0 %d %d 1", bitRate[config.bitrate], config.inverted );
-			ans = ASKbiphaseDemod(cmdStr, FALSE);
+			ans = ASKbiphaseDemod(cmdStr, false);
 			break;
 		default:
-			return FALSE;
+			return false;
 	}
 	return (bool) ans;
 }
@@ -438,13 +438,13 @@ bool DecodeT5555TraceBlock() {
 	DemodBufferLen = 0x00;
 	
 	// According to datasheet. Always: RF/64, not inverted, Manchester
-	return (bool) ASKDemod("64 0 1", FALSE, FALSE, 1);
+	return (bool) ASKDemod("64 0 1", false, false, 1);
 }
 
 int CmdT55xxDetect(const char *Cmd){
-	bool errors = FALSE;
-	bool useGB = FALSE;
-	bool usepwd = FALSE;
+	bool errors = false;
+	bool useGB = false;
+	bool usepwd = false;
 	uint32_t password = 0;
 	uint8_t cmdp = 0;
 
@@ -456,12 +456,12 @@ int CmdT55xxDetect(const char *Cmd){
 		case 'p':
 		case 'P':
 			password = param_get32ex(Cmd, cmdp+1, 0, 16);
-			usepwd = TRUE;
+			usepwd = true;
 			cmdp += 2;
 			break;
 		case '1':
 			// use Graphbuffer data
-			useGB = TRUE;
+			useGB = true;
 			cmdp++;
 			break;
 		default:
@@ -489,87 +489,87 @@ bool tryDetectModulation(){
 	t55xx_conf_block_t tests[15];
 	int bitRate=0;
 	uint8_t fc1 = 0, fc2 = 0, clk=0;
-	if (GetFskClock("", FALSE, FALSE)){ 
-		fskClocks(&fc1, &fc2, &clk, FALSE);
-		if ( FSKrawDemod("0 0", FALSE) && test(DEMOD_FSK, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
+	if (GetFskClock("", false, false)){ 
+		fskClocks(&fc1, &fc2, &clk, false);
+		if ( FSKrawDemod("0 0", false) && test(DEMOD_FSK, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
 			tests[hits].modulation = DEMOD_FSK;
 			if (fc1==8 && fc2 == 5)
 				tests[hits].modulation = DEMOD_FSK1a;
  			else if (fc1==10 && fc2 == 8)
 				tests[hits].modulation = DEMOD_FSK2;
 			tests[hits].bitrate = bitRate;
-			tests[hits].inverted = FALSE;
+			tests[hits].inverted = false;
 			tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
-			tests[hits].ST = FALSE;
+			tests[hits].ST = false;
 			++hits;
 		}
-		if ( FSKrawDemod("0 1", FALSE) && test(DEMOD_FSK, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
+		if ( FSKrawDemod("0 1", false) && test(DEMOD_FSK, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
 			tests[hits].modulation = DEMOD_FSK;
 			if (fc1 == 8 && fc2 == 5)
 				tests[hits].modulation = DEMOD_FSK1;
 			else if (fc1 == 10 && fc2 == 8)
 				tests[hits].modulation = DEMOD_FSK2a;
 			tests[hits].bitrate = bitRate;
-			tests[hits].inverted = TRUE;
+			tests[hits].inverted = true;
 			tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
-			tests[hits].ST = FALSE;
+			tests[hits].ST = false;
 			++hits;
 		}
 	} else {
-		clk = GetAskClock("", FALSE, FALSE);
+		clk = GetAskClock("", false, false);
 		if (clk>0) {
-			tests[hits].ST = TRUE;
-			if ( ASKDemod_ext("0 0 1", FALSE, FALSE, 1, &tests[hits].ST) && test(DEMOD_ASK, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
+			tests[hits].ST = true;
+			if ( ASKDemod_ext("0 0 1", false, false, 1, &tests[hits].ST) && test(DEMOD_ASK, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
 				tests[hits].modulation = DEMOD_ASK;
 				tests[hits].bitrate = bitRate;
-				tests[hits].inverted = FALSE;
+				tests[hits].inverted = false;
 				tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
 				++hits;
 			}
-			tests[hits].ST = TRUE;
-			if ( ASKDemod_ext("0 1 1", FALSE, FALSE, 1, &tests[hits].ST)  && test(DEMOD_ASK, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
+			tests[hits].ST = true;
+			if ( ASKDemod_ext("0 1 1", false, false, 1, &tests[hits].ST)  && test(DEMOD_ASK, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
 				tests[hits].modulation = DEMOD_ASK;
 				tests[hits].bitrate = bitRate;
-				tests[hits].inverted = TRUE;
+				tests[hits].inverted = true;
 				tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
 				++hits;
 			}
-			if ( ASKbiphaseDemod("0 0 0 2", FALSE) && test(DEMOD_BI, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5) ) {
+			if ( ASKbiphaseDemod("0 0 0 2", false) && test(DEMOD_BI, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5) ) {
 				tests[hits].modulation = DEMOD_BI;
 				tests[hits].bitrate = bitRate;
-				tests[hits].inverted = FALSE;
+				tests[hits].inverted = false;
 				tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
-				tests[hits].ST = FALSE;
+				tests[hits].ST = false;
 				++hits;
 			}
-			if ( ASKbiphaseDemod("0 0 1 2", FALSE) && test(DEMOD_BIa, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5) ) {
+			if ( ASKbiphaseDemod("0 0 1 2", false) && test(DEMOD_BIa, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5) ) {
 				tests[hits].modulation = DEMOD_BIa;
 				tests[hits].bitrate = bitRate;
-				tests[hits].inverted = TRUE;
+				tests[hits].inverted = true;
 				tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
-				tests[hits].ST = FALSE;
+				tests[hits].ST = false;
 				++hits;
 			}
 		}
 		//undo trim from ask
 		//save_restoreGB(0);
-		clk = GetNrzClock("", FALSE, FALSE);
+		clk = GetNrzClock("", false, false);
 		if (clk>0) {
-			if ( NRZrawDemod("0 0 1", FALSE)  && test(DEMOD_NRZ, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
+			if ( NRZrawDemod("0 0 1", false)  && test(DEMOD_NRZ, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
 				tests[hits].modulation = DEMOD_NRZ;
 				tests[hits].bitrate = bitRate;
-				tests[hits].inverted = FALSE;
+				tests[hits].inverted = false;
 				tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
-				tests[hits].ST = FALSE;
+				tests[hits].ST = false;
 				++hits;
 			}
 
-			if ( NRZrawDemod("0 1 1", FALSE)  && test(DEMOD_NRZ, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
+			if ( NRZrawDemod("0 1 1", false)  && test(DEMOD_NRZ, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
 				tests[hits].modulation = DEMOD_NRZ;
 				tests[hits].bitrate = bitRate;
-				tests[hits].inverted = TRUE;
+				tests[hits].inverted = true;
 				tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
-				tests[hits].ST = FALSE;
+				tests[hits].ST = false;
 				++hits;
 			}
 		}
@@ -578,45 +578,45 @@ bool tryDetectModulation(){
 		// skip first 160 samples to allow antenna to settle in (psk gets inverted occasionally otherwise)
 		save_restoreGB(1);
 		CmdLtrim("160");
-		clk = GetPskClock("", FALSE, FALSE);
+		clk = GetPskClock("", false, false);
 		if (clk>0) {
-			if ( PSKDemod("0 0 6", FALSE) && test(DEMOD_PSK1, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
+			if ( PSKDemod("0 0 6", false) && test(DEMOD_PSK1, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
 				tests[hits].modulation = DEMOD_PSK1;
 				tests[hits].bitrate = bitRate;
-				tests[hits].inverted = FALSE;
+				tests[hits].inverted = false;
 				tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
-				tests[hits].ST = FALSE;
+				tests[hits].ST = false;
 				++hits;
 			}
-			if ( PSKDemod("0 1 6", FALSE) && test(DEMOD_PSK1, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
+			if ( PSKDemod("0 1 6", false) && test(DEMOD_PSK1, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
 				tests[hits].modulation = DEMOD_PSK1;
 				tests[hits].bitrate = bitRate;
-				tests[hits].inverted = TRUE;
+				tests[hits].inverted = true;
 				tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
-				tests[hits].ST = FALSE;
+				tests[hits].ST = false;
 				++hits;
 			}
 			// PSK2 - needs a call to psk1TOpsk2.
-			if ( PSKDemod("0 0 6", FALSE)) {
+			if ( PSKDemod("0 0 6", false)) {
 				psk1TOpsk2(DemodBuffer, DemodBufferLen);
 				if (test(DEMOD_PSK2, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)){
 					tests[hits].modulation = DEMOD_PSK2;
 					tests[hits].bitrate = bitRate;
-					tests[hits].inverted = FALSE;
+					tests[hits].inverted = false;
 					tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
-					tests[hits].ST = FALSE;
+					tests[hits].ST = false;
 					++hits;
 				}
 			} // inverse waves does not affect this demod
 			// PSK3 - needs a call to psk1TOpsk2.
-			if ( PSKDemod("0 0 6", FALSE)) {
+			if ( PSKDemod("0 0 6", false)) {
 				psk1TOpsk2(DemodBuffer, DemodBufferLen);
 				if (test(DEMOD_PSK3, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)){
 					tests[hits].modulation = DEMOD_PSK3;
 					tests[hits].bitrate = bitRate;
-					tests[hits].inverted = FALSE;
+					tests[hits].inverted = false;
 					tests[hits].block0 = PackBits(tests[hits].offset, 32, DemodBuffer);
-					tests[hits].ST = FALSE;
+					tests[hits].ST = false;
 					++hits;
 				}
 			} // inverse waves does not affect this demod
@@ -633,7 +633,7 @@ bool tryDetectModulation(){
 		config.Q5 = tests[0].Q5;
 		config.ST = tests[0].ST;
 		printConfiguration( config );
-		return TRUE;
+		return true;
 	}
 	
 	if ( hits > 1) {
@@ -643,68 +643,68 @@ bool tryDetectModulation(){
 			printConfiguration( tests[i] );
 		}
 	}
-	return FALSE;
+	return false;
 }
 
 bool testModulation(uint8_t mode, uint8_t modread){
 	switch( mode ){
 		case DEMOD_FSK:
-			if (modread >= DEMOD_FSK1 && modread <= DEMOD_FSK2a) return TRUE;
+			if (modread >= DEMOD_FSK1 && modread <= DEMOD_FSK2a) return true;
 			break;
 		case DEMOD_ASK:
-			if (modread == DEMOD_ASK) return TRUE;
+			if (modread == DEMOD_ASK) return true;
 			break;
 		case DEMOD_PSK1:
-			if (modread == DEMOD_PSK1) return TRUE;
+			if (modread == DEMOD_PSK1) return true;
 			break;
 		case DEMOD_PSK2:
-			if (modread == DEMOD_PSK2) return TRUE;
+			if (modread == DEMOD_PSK2) return true;
 			break;
 		case DEMOD_PSK3:
-			if (modread == DEMOD_PSK3) return TRUE;
+			if (modread == DEMOD_PSK3) return true;
 			break;
 		case DEMOD_NRZ:
-			if (modread == DEMOD_NRZ) return TRUE;
+			if (modread == DEMOD_NRZ) return true;
 			break;
 		case DEMOD_BI:
-			if (modread == DEMOD_BI) return TRUE;
+			if (modread == DEMOD_BI) return true;
 			break;
 		case DEMOD_BIa:
-			if (modread == DEMOD_BIa) return TRUE;
+			if (modread == DEMOD_BIa) return true;
 			break;		
 		default:
-			return FALSE;
+			return false;
 	}
-	return FALSE;
+	return false;
 }
 
 bool testQ5Modulation(uint8_t	mode, uint8_t	modread){
 	switch( mode ){
 		case DEMOD_FSK:
-			if (modread >= 4 && modread <= 5) return TRUE;
+			if (modread >= 4 && modread <= 5) return true;
 			break;
 		case DEMOD_ASK:
-			if (modread == 0) return TRUE;
+			if (modread == 0) return true;
 			break;
 		case DEMOD_PSK1:
-			if (modread == 1) return TRUE;
+			if (modread == 1) return true;
 			break;
 		case DEMOD_PSK2:
-			if (modread == 2) return TRUE;
+			if (modread == 2) return true;
 			break;
 		case DEMOD_PSK3:
-			if (modread == 3) return TRUE;
+			if (modread == 3) return true;
 			break;
 		case DEMOD_NRZ:
-			if (modread == 7) return TRUE;
+			if (modread == 7) return true;
 			break;
 		case DEMOD_BI:
-			if (modread == 6) return TRUE;
+			if (modread == 6) return true;
 			break;
 		default:
-			return FALSE;
+			return false;
 	}
-	return FALSE;
+	return false;
 }
 
 int convertQ5bitRate(uint8_t bitRateRead) {
@@ -718,7 +718,7 @@ int convertQ5bitRate(uint8_t bitRateRead) {
 
 bool testQ5(uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t	clk){
 
-	if ( DemodBufferLen < 64 ) return FALSE;
+	if ( DemodBufferLen < 64 ) return false;
 	uint8_t si = 0;
 	for (uint8_t idx = 28; idx < 64; idx++){
 		si = idx;
@@ -751,9 +751,9 @@ bool testQ5(uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t	clk){
 		if (*fndBitRate < 0) continue;
 		*offset = idx;
 
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 bool testBitRate(uint8_t readRate, uint8_t clk){
@@ -766,7 +766,7 @@ bool testBitRate(uint8_t readRate, uint8_t clk){
 
 bool test(uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t clk, bool *Q5){
 
-	if ( DemodBufferLen < 64 ) return FALSE;
+	if ( DemodBufferLen < 64 ) return false;
 	uint8_t si = 0;
 	for (uint8_t idx = 28; idx < 64; idx++){
 		si = idx;
@@ -788,7 +788,7 @@ bool test(uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t clk, bool *Q5)
 		//uint8_t nml02    = PackBits(si, 2, DemodBuffer); si += 2;
 		
 		//if extended mode
-		bool extMode =( (safer == 0x6 || safer == 0x9) && extend) ? TRUE : FALSE;
+		bool extMode =( (safer == 0x6 || safer == 0x9) && extend) ? true : false;
 
 		if (!extMode){
 			if (xtRate) continue;  //nml01 || nml02 ||  caused issues on noralys tags
@@ -798,14 +798,14 @@ bool test(uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t clk, bool *Q5)
 		if (!testBitRate(bitRate, clk)) continue;
 		*fndBitRate = bitRate;
 		*offset = idx;
-		*Q5 = FALSE;
-		return TRUE;
+		*Q5 = false;
+		return true;
 	}
 	if (testQ5(mode, offset, fndBitRate, clk)) {
-		*Q5 = TRUE;
-		return TRUE;
+		*Q5 = true;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 void printT55xxBlock(const char *blockNum){
@@ -1471,7 +1471,7 @@ int CmdT55xxBruteForce(const char *Cmd) {
 
 			PrintAndLog("Testing %08X", testpwd);
 
-			if ( !AquireData(T55x7_PAGE0, T55x7_CONFIGURATION_BLOCK, TRUE, testpwd)) {
+			if ( !AquireData(T55x7_PAGE0, T55x7_CONFIGURATION_BLOCK, true, testpwd)) {
 				PrintAndLog("Aquireing data from device failed. Quitting");
 				free(keyBlock);
 				return 0;
@@ -1516,7 +1516,7 @@ int CmdT55xxBruteForce(const char *Cmd) {
 			return 0;
 		}
 
-		if (!AquireData(T55x7_PAGE0, T55x7_CONFIGURATION_BLOCK, TRUE, i)) {
+		if (!AquireData(T55x7_PAGE0, T55x7_CONFIGURATION_BLOCK, true, i)) {
 			PrintAndLog("Aquireing data from device failed. Quitting");
 			free(keyBlock);
 			return 0;

--- a/client/cmdmain.h
+++ b/client/cmdmain.h
@@ -11,12 +11,16 @@
 #ifndef CMDMAIN_H__
 #define CMDMAIN_H__
 
+#include <stdint.h>
+#include <stddef.h>
 #include "usb_cmd.h"
 #include "cmdparser.h"
-void UsbCommandReceived(UsbCommand *UC);
-int CommandReceived(char *Cmd);
-bool WaitForResponseTimeout(uint32_t cmd, UsbCommand* response, size_t ms_timeout);
-bool WaitForResponse(uint32_t cmd, UsbCommand* response);
-void clearCommandBuffer();
-command_t* getTopLevelCommandTable();
+
+extern void UsbCommandReceived(UsbCommand *UC);
+extern int CommandReceived(char *Cmd);
+extern bool WaitForResponseTimeout(uint32_t cmd, UsbCommand* response, size_t ms_timeout);
+extern bool WaitForResponse(uint32_t cmd, UsbCommand* response);
+extern void clearCommandBuffer();
+extern command_t* getTopLevelCommandTable();
+
 #endif

--- a/client/mifarehost.h
+++ b/client/mifarehost.h
@@ -8,63 +8,36 @@
 // High frequency ISO14443A commands
 //-----------------------------------------------------------------------------
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include "common.h"
-#include "cmdmain.h"
-#include "ui.h"
+#include <stdint.h>
+#include <stdbool.h>
 #include "data.h"
-#include "util.h"
-#include "nonce2key/nonce2key.h"
-#include "nonce2key/crapto1.h"
-#include "iso14443crc.h"
-
-#define MEM_CHUNK               1000000
-#define NESTED_SECTOR_RETRY     10
 
 // mfCSetBlock work flags
 #define CSETBLOCK_UID 					0x01
 #define CSETBLOCK_WUPC					0x02
 #define CSETBLOCK_HALT					0x04
-#define CSETBLOCK_INIT_FIELD		0x08
-#define CSETBLOCK_RESET_FIELD		0x10
-#define CSETBLOCK_SINGLE_OPER		0x1F
+#define CSETBLOCK_INIT_FIELD			0x08
+#define CSETBLOCK_RESET_FIELD			0x10
+#define CSETBLOCK_SINGLE_OPER			0x1F
 
-// mifare tracer flags
-#define TRACE_IDLE		 					0x00
-#define TRACE_AUTH1		 					0x01
-#define TRACE_AUTH2		 					0x02
-#define TRACE_AUTH_OK	 					0x03
-#define TRACE_READ_DATA 				0x04
-#define TRACE_WRITE_OK					0x05
-#define TRACE_WRITE_DATA				0x06
-
-#define TRACE_ERROR		 					0xFF
-
-typedef struct {
-	uint64_t Key[2];
-	int foundKey[2];
-} sector;
- 
 extern char logHexFileName[FILE_PATH_SIZE];
 
-int mfnested(uint8_t blockNo, uint8_t keyType, uint8_t * key, uint8_t trgBlockNo, uint8_t trgKeyType, uint8_t * ResultKeys, bool calibrate);
-int mfCheckKeys (uint8_t blockNo, uint8_t keyType, bool clear_trace, uint8_t keycnt, uint8_t * keyBlock, uint64_t * key);
+extern int mfnested(uint8_t blockNo, uint8_t keyType, uint8_t * key, uint8_t trgBlockNo, uint8_t trgKeyType, uint8_t * ResultKeys, bool calibrate);
+extern int mfCheckKeys (uint8_t blockNo, uint8_t keyType, bool clear_trace, uint8_t keycnt, uint8_t * keyBlock, uint64_t * key);
 
-int mfEmlGetMem(uint8_t *data, int blockNum, int blocksCount);
-int mfEmlSetMem(uint8_t *data, int blockNum, int blocksCount);
+extern int mfEmlGetMem(uint8_t *data, int blockNum, int blocksCount);
+extern int mfEmlSetMem(uint8_t *data, int blockNum, int blocksCount);
 
-int mfCSetUID(uint8_t *uid, uint8_t *atqa, uint8_t *sak, uint8_t *oldUID, bool wantWipe);
-int mfCSetBlock(uint8_t blockNo, uint8_t *data, uint8_t *uid, bool wantWipe, uint8_t params);
-int mfCGetBlock(uint8_t blockNo, uint8_t *data, uint8_t params);
+extern int mfCSetUID(uint8_t *uid, uint8_t *atqa, uint8_t *sak, uint8_t *oldUID, bool wantWipe);
+extern int mfCSetBlock(uint8_t blockNo, uint8_t *data, uint8_t *uid, bool wantWipe, uint8_t params);
+extern int mfCGetBlock(uint8_t blockNo, uint8_t *data, uint8_t params);
 
-int mfTraceInit(uint8_t *tuid, uint8_t *atqa, uint8_t sak, bool wantSaveToEmlFile);
-int mfTraceDecode(uint8_t *data_src, int len, bool wantSaveToEmlFile);
+extern int mfTraceInit(uint8_t *tuid, uint8_t *atqa, uint8_t sak, bool wantSaveToEmlFile);
+extern int mfTraceDecode(uint8_t *data_src, int len, bool wantSaveToEmlFile);
 
-int isTraceCardEmpty(void);
-int isBlockEmpty(int blockN);
-int isBlockTrailer(int blockN);
-int loadTraceCard(uint8_t *tuid);
-int saveTraceCard(void);
-int tryDecryptWord(uint32_t nt, uint32_t ar_enc, uint32_t at_enc, uint8_t *data, int len);
+extern int isTraceCardEmpty(void);
+extern int isBlockEmpty(int blockN);
+extern int isBlockTrailer(int blockN);
+extern int loadTraceCard(uint8_t *tuid);
+extern int saveTraceCard(void);
+extern int tryDecryptWord(uint32_t nt, uint32_t ar_enc, uint32_t at_enc, uint8_t *data, int len);

--- a/client/nonce2key/nonce2key.c
+++ b/client/nonce2key/nonce2key.c
@@ -10,12 +10,13 @@
 // MIFARE Darkside hack
 //-----------------------------------------------------------------------------
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+#include <time.h>
 
 #include "nonce2key.h"
 #include "mifarehost.h"
 #include "ui.h"
+#include "util.h"
 
 int compar_state(const void * a, const void * b) {
 	// didn't work: (the result is truncated to 32 bits)
@@ -161,7 +162,7 @@ bool mfkey32(nonces_t data, uint64_t *outputkey) {
 	uint32_t nr1_enc = data.nr2; // second encrypted reader challenge
 	uint32_t ar1_enc = data.ar2; // second encrypted reader response
 	clock_t t1 = clock();
-	bool isSuccess = FALSE;
+	bool isSuccess = false;
 	uint8_t counter=0;
 
 	s = lfsr_recovery32(ar0_enc ^ prng_successor(nt, 64), 0);
@@ -208,7 +209,7 @@ bool tryMfk32_moebius(nonces_t data, uint64_t *outputkey) {
 	uint32_t nt1     = data.nonce2; // second tag challenge (nonce)
 	uint32_t nr1_enc = data.nr2; // second encrypted reader challenge
 	uint32_t ar1_enc = data.ar2; // second encrypted reader response	
-	bool isSuccess = FALSE;
+	bool isSuccess = false;
 	int counter = 0;
 	
 	//PrintAndLog("Enter mfkey32_moebius");

--- a/client/util.h
+++ b/client/util.h
@@ -25,8 +25,6 @@
 #ifndef MAX
 # define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #endif
-#define TRUE                        1
-#define FALSE                       0
 #define EVEN                        0
 #define ODD                         1
 

--- a/client/whereami.c
+++ b/client/whereami.c
@@ -261,7 +261,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
       if (!fgets(buffer, sizeof(buffer), maps))
         break;
 
-      if (sscanf(buffer, "%" PRIx64 "-%" PRIx64 " %s %" PRIx64 " %x:%x %u %s\n", &low, &high, perms, &offset, &major, &minor, &inode, path) == 8)
+      if (sscanf(buffer, "%" SCNx64 "-%" SCNx64 " %s %" SCNx64 " %x:%x %u %s\n", &low, &high, perms, &offset, &major, &minor, &inode, path) == 8)
       {
         uint64_t addr = (uint64_t)(uintptr_t)WAI_RETURN_ADDRESS();
         if (low <= addr && addr <= high)


### PR DESCRIPTION
- cleanup some header files and respective #includes
- rearrange functions (definition before first use)
- use SCNxxx instead of PRIxxx macros in scanf()
- use stdbool true/false instead of self defined TRUE/FALSE