### PR TITLE
Upgrade crapto1 library to v3.3

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -9,7 +9,7 @@ include ../common/Makefile.common
 CC=gcc
 CXX=g++
 #COMMON_FLAGS = -m32
-VPATH = ../common ../zlib ../tools
+VPATH = ../common ../zlib
 OBJDIR = obj
 
 LDLIBS = -L/opt/local/lib -L/usr/local/lib -lreadline -lpthread -lm

--- a/client/nonce2key/nonce2key.c
+++ b/client/nonce2key/nonce2key.c
@@ -72,8 +72,8 @@ int nonce2key(uint32_t uid, uint32_t nt, uint32_t nr, uint64_t par_info, uint64_
     printf("%01x|\n", par[i][7]);
   }
   
-	if (par_info==0)
-		PrintAndLog("parity is all zero,try special attack!just wait for few more seconds...");
+	if (par_info == 0)
+		PrintAndLog("Parity is all zero, trying special attack! Just wait for few more seconds...");
   
 	state = lfsr_common_prefix(nr, rr, ks3x, par);
 	state_s = (int64_t*)state;
@@ -82,7 +82,7 @@ int nonce2key(uint32_t uid, uint32_t nt, uint32_t nr, uint64_t par_info, uint64_
     //sprintf(filename, "nt_%08x_%d.txt", nt, nr);
     //printf("name %s\n", filename);
 	//FILE* fp = fopen(filename,"w");
-	for (i = 0; (state) && ((state + i)->odd != -1); i++)
+	for (i = 0; (state) && *(state_s + i); i++)
 	{
 		lfsr_rollback_word(state+i, uid^nt, 0);
 		crypto1_get_lfsr(state + i, &key_recovered);
@@ -98,9 +98,8 @@ int nonce2key(uint32_t uid, uint32_t nt, uint32_t nr, uint64_t par_info, uint64_
 	*(state_s + i) = -1;
 	
 	//Create the intersection:
-	if (par_info == 0 )
-		if ( last_keylist != NULL)
-		{
+	if (par_info == 0 ) {
+		if (last_keylist != NULL) {
 			int64_t *p1, *p2, *p3;
 			p1 = p3 = last_keylist; 
 			p2 = state_s;
@@ -115,12 +114,11 @@ int nonce2key(uint32_t uid, uint32_t nt, uint32_t nr, uint64_t par_info, uint64_
 					while (compar_state(p1, p2) == 1) ++p2;
 				}
 			}
-			key_count = p3 - last_keylist;;
-		}
-		else
+			key_count = p3 - last_keylist;
+		} else {
 			key_count = 0;
-	else
-	{
+		}
+	} else {
 		last_keylist = state_s;
 		key_count = i;
 	}
@@ -138,7 +136,7 @@ int nonce2key(uint32_t uid, uint32_t nt, uint32_t nr, uint64_t par_info, uint64_
 			*key = key64;
 			free(last_keylist);
 			last_keylist = NULL;
-			if (par_info ==0)
+			if (par_info == 0)
 				free(state);
 			return 0;
 		}

--- a/common/crapto1/crapto1.h
+++ b/common/crapto1/crapto1.h
@@ -15,7 +15,7 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
     MA  02110-1301, US$
 
-    Copyright (C) 2008-2008 bla <blapost@gmail.com>
+    Copyright (C) 2008-2014 bla <blapost@gmail.com>
 */
 #ifndef CRAPTO1_INCLUDED
 #define CRAPTO1_INCLUDED
@@ -44,9 +44,9 @@ struct Crypto1State*
 lfsr_common_prefix(uint32_t pfx, uint32_t rr, uint8_t ks[8], uint8_t par[8][8]);
 
 
-void lfsr_rollback_bit(struct Crypto1State* s, uint32_t in, int fb);
-void lfsr_rollback_byte(struct Crypto1State* s, uint32_t in, int fb);
-void lfsr_rollback_word(struct Crypto1State* s, uint32_t in, int fb);
+uint8_t lfsr_rollback_bit(struct Crypto1State* s, uint32_t in, int fb);
+uint8_t lfsr_rollback_byte(struct Crypto1State* s, uint32_t in, int fb);
+uint32_t lfsr_rollback_word(struct Crypto1State* s, uint32_t in, int fb);
 int nonce_distance(uint32_t from, uint32_t to);
 #define FOREACH_VALID_NONCE(N, FILTER, FSIZE)\
 	uint32_t __n = 0,__M = 0, N = 0;\

--- a/common/crapto1/crypto1.c
+++ b/common/crapto1/crypto1.c
@@ -23,33 +23,34 @@
 #define SWAPENDIAN(x)\
 	(x = (x >> 8 & 0xff00ff) | (x & 0xff00ff) << 8, x = x >> 16 | x << 16)
 
-#if defined(__arm__)
+#if defined(__arm__) && !defined(__linux__) && !defined(_WIN32)			// bare metal ARM lacks malloc()/free()
 void crypto1_create(struct Crypto1State *s, uint64_t key)
 {
-#else
-struct Crypto1State * crypto1_create(uint64_t key)
-{
-	struct Crypto1State *s = malloc(sizeof(*s));
-#endif
 	int i;
 
 	for(i = 47;s && i > 0; i -= 2) {
 		s->odd  = s->odd  << 1 | BIT(key, (i - 1) ^ 7);
 		s->even = s->even << 1 | BIT(key, i ^ 7);
 	}
-#if defined(__arm__)	
 	return;
-#else
-	return s;
-#endif
 }
-#if defined(__arm__)
 void crypto1_destroy(struct Crypto1State *state)
 {
 	state->odd = 0;
 	state->even = 0;
 }
 #else
+struct Crypto1State * crypto1_create(uint64_t key)
+{
+	struct Crypto1State *s = malloc(sizeof(*s));
+	int i;
+
+	for(i = 47;s && i > 0; i -= 2) {
+		s->odd  = s->odd  << 1 | BIT(key, (i - 1) ^ 7);
+		s->even = s->even << 1 | BIT(key, i ^ 7);
+	}
+	return s;
+}
 void crypto1_destroy(struct Crypto1State *state)
 {
 	free(state);
@@ -65,8 +66,7 @@ void crypto1_get_lfsr(struct Crypto1State *state, uint64_t *lfsr)
 }
 uint8_t crypto1_bit(struct Crypto1State *s, uint8_t in, int is_encrypted)
 {
-	uint32_t feedin;
-	uint32_t tmp;
+	uint32_t feedin, t;
 	uint8_t ret = filter(s->odd);
 
 	feedin  = ret & !!is_encrypted;
@@ -75,9 +75,7 @@ uint8_t crypto1_bit(struct Crypto1State *s, uint8_t in, int is_encrypted)
 	feedin ^= LF_POLY_EVEN & s->even;
 	s->even = s->even << 1 | parity(feedin);
 
-	tmp = s->odd;
-	s->odd = s->even;
-	s->even = tmp;
+	t = s->odd, s->odd = s->even, s->even = t;
 
 	return ret;
 }
@@ -94,8 +92,8 @@ uint32_t crypto1_word(struct Crypto1State *s, uint32_t in, int is_encrypted)
 {
 	uint32_t i, ret = 0;
 
-	for (i = 0; i < 4; ++i, in <<= 8)
-		ret = ret << 8 | crypto1_byte(s, in >> 24, is_encrypted);
+	for (i = 0; i < 32; ++i)
+		ret |= crypto1_bit(s, BEBIT(in, i), is_encrypted) << (i ^ 24);
 
 	return ret;
 }

--- a/tools/mfkey/Makefile
+++ b/tools/mfkey/Makefile
@@ -1,17 +1,20 @@
+VPATH = ../../common/crapto1
 CC = gcc
 LD = gcc
-CFLAGS = -Wall -Winline -O4
+CFLAGS = -I../../common -Wall -O4
 LDFLAGS =
 
-OBJS = crapto1.o crypto1.o
-HEADERS = 
-EXES = mfkey64 mfkey32
-LIBS =
-	
-all: $(OBJS) $(EXES) $(LIBS)
+OBJS = crypto1.o crapto1.o
+EXES = mfkey32 mfkey64
+WINEXES = $(patsubst %, %.exe, $(EXES))
 
-% : %.c $(OBJS)
-	$(LD) $(CFLAGS) -o $@ $< $(OBJS) $(LDFLAGS)
+all: $(OBJS) $(EXES)
+
+%.o : %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+% : %.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS) $<
 
 clean: 
-	rm -f $(OBJS) $(EXES) $(LIBS) 
+	rm -f $(OBJS) $(EXES) $(WINEXES)

--- a/tools/mfkey/mfkey32.c
+++ b/tools/mfkey/mfkey32.c
@@ -1,5 +1,5 @@
 #include <inttypes.h>
-#include "crapto1.h"
+#include "crapto1/crapto1.h"
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/tools/mfkey/mfkey64.c
+++ b/tools/mfkey/mfkey64.c
@@ -1,5 +1,5 @@
 #include <inttypes.h>
-#include "crapto1.h"
+#include "crapto1/crapto1.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -34,7 +34,7 @@ int main (int argc, char *argv[]) {
   for (int i = 0; i < encc; i++) {
     enclen[i] = strlen(argv[i + 6]) / 2;
     for (int i2 = 0; i2 < enclen[i]; i2++) {
-      sscanf(argv[i+6] + i2*2,"%2x", (uint8_t*)&enc[i][i2]);
+      sscanf(argv[i+6] + i2*2,"%2x", (unsigned int *)&enc[i][i2]);
     }
   }
   printf("Recovering key for:\n");

--- a/tools/nonce2key/Makefile
+++ b/tools/nonce2key/Makefile
@@ -1,22 +1,21 @@
+VPATH = ../../common/crapto1
 CC = gcc
 LD = gcc
-CFLAGS = -Wall -O4 -c
+CFLAGS = -I../../common -Wall -O4
 LDFLAGS =
 
 OBJS = crypto1.o crapto1.o
 HEADERS = crapto1.h
 EXES = nonce2key
+WINEXES = $(patsubst %, %.exe, $(EXES))
 
 all: $(OBJS) $(EXES)
 
 %.o : %.c
-	$(CC) $(CFLAGS) -o $@ $<
+	$(CC) $(CFLAGS) -c -o $@ $<
 
 % : %.c
-	$(LD) $(LDFLAGS) -o $@ $(OBJS) $<
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS) $<
 
-crypto1test: libnfc $(OBJS)
-	$(LD) $(LDFLAGS) -o crypto1test crypto1test.c $(OBJS)
- 
 clean: 
-	rm -f $(OBJS) $(EXES)
+	rm -f $(OBJS) $(EXES) $(WINEXES)

--- a/tools/nonce2key/nonce2key.c
+++ b/tools/nonce2key/nonce2key.c
@@ -1,13 +1,13 @@
-#include "crapto1.h"
+#include "crapto1/crapto1.h"
 #include <inttypes.h>
 #include <stdio.h>
 typedef unsigned char byte_t;
 
 int main(const int argc, const char* argv[]) {
   struct Crypto1State *state;
-  uint32_t pos, uid, nt, nr, rr, nr_diff, ks1, ks2;
+  uint32_t pos, uid, nt, nr, rr, nr_diff;
   byte_t bt, i, ks3x[8], par[8][8];
-  uint64_t key, key_recovered;
+  uint64_t key_recovered;
   uint64_t par_info;
   uint64_t ks_info;
   nr = rr = 0;


### PR DESCRIPTION
- fix standalone tools mfkey32, mfkey64 and nonce2key to use common crapto1 library
- fix compiler warnings in tools/mfkey/mfkey64.c and tools/nonce2key/nonce2key.c
- allow crapto1.c to compile on ARM hosts
- add @iceman1001's readme.txt to tools/mfkey