### PR TITLE
fix mfkey tools (issue #247)

### DIFF
--- a/tools/mfkey/Makefile
+++ b/tools/mfkey/Makefile
@@ -1,7 +1,7 @@
 VPATH = ../../common/crapto1 ../../client
 CC = gcc
 LD = gcc
-CFLAGS = -I../../common -I../../client -Wall -O4
+CFLAGS = -std=c99 -D_ISOC99_SOURCE -I../../common -I../../client -Wall -O3
 LDFLAGS =
 
 OBJS = crypto1.o crapto1.o util.o mfkey.o

--- a/tools/mfkey/mfkey64.c
+++ b/tools/mfkey/mfkey64.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <strings.h>
+#include <string.h>
 #include <inttypes.h>
 #include "crapto1/crapto1.h"
 #include "util.h"


### PR DESCRIPTION
- add -std=c99 -D_ISOC99_SOURCE to compiler flags
- fix: include <string.h> instead of <strings.h> in mfkey64.c