### PR TITLE
Fixed compile error in MinGW

### DIFF
--- a/client/util.c
+++ b/client/util.c
@@ -639,9 +639,8 @@ uint64_t msclock() {
     // WORKAROUND FOR MinGW (some versions - use if normal code does not compile)
     // It has no _ftime_s and needs explicit inclusion of timeb.h
     #include <sys/timeb.h>
-    #define _ftime_s _ftime
     struct _timeb t;
-    _ftime_s(&t);
+    _ftime(&t);
     return 1000 * t.time + t.millitm;
     
     // NORMAL CODE (use _ftime_s)

--- a/client/util.c
+++ b/client/util.c
@@ -634,13 +634,23 @@ void msleep(uint32_t n) {
 // a milliseconds timer for performance measurement
 uint64_t msclock() {
 #if defined(_WIN32)
-#include <sys/types.h>
-	struct _timeb t;
-	if (_ftime_s(&t)) {
-		return 0;
-	} else {
-		return 1000 * t.time + t.millitm;
-	}
+    #include <sys/types.h>
+    
+    // WORKAROUND FOR MinGW (some versions - use if normal code does not compile)
+    // It has no _ftime_s and needs explicit inclusion of timeb.h
+    #include <sys/timeb.h>
+    #define _ftime_s _ftime
+    struct _timeb t;
+    _ftime_s(&t);
+    return 1000 * t.time + t.millitm;
+    
+    // NORMAL CODE (use _ftime_s)
+	//struct _timeb t;
+    //if (_ftime_s(&t)) {
+	//	return 0;
+	//} else {
+	//	return 1000 * t.time + t.millitm;
+	//}
 #else
 	struct timespec t;
 	clock_gettime(CLOCK_MONOTONIC, &t);


### PR DESCRIPTION
Some versions of MinGW miss some definitions. In order to be able to
compile I redefined a function and added an explicit include. It is only
a quick workaround, as other people also seemed to have the same
problem. It should be checked whether a better solution is possible.