### PR TITLE
various lf bug fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added option c to 'hf list' (mark CRC bytes) (piwi)
 
 ### Changed
+- `lf t5 wakeup` has been adjusted to not need the p in front of the pwd arg.
 - `data psknexwatchdemod` has been moved to `lf nexwatch demod` (reads from graphbuffer)
 - `data fskparadoxdemod` has been moved to `lf paradox demod` (reads from graphbuffer)
 - `data fdxdemod` has been moved to `lf fdx demod` (reads from graphbuffer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 ## [unreleased][unreleased]
 
 ### Added
+- Added experimental testmode write option for t55xx (danger) (marshmellow)
+- Added t55xx p1detect to `lf search` chip detections (marshmellow)
+- Added lf t55xx p1detect, detect page 1 of a t55xx tag based on E015 mfg code (marshmellow)
 - Added lf noralsy demod, read, clone, sim commands (iceman)
 - Added lf jablotron demod, read, clone, sim commands (iceman)
 - Added lf nexwatch read   - reads a nexwatch tag from the antenna
@@ -54,6 +57,8 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added option c to 'hf list' (mark CRC bytes) (piwi)
 
 ### Changed
+- adjusted lf t5 chip timings to use WaitUS. and adjusted the readblock timings
+    appears to have more consistent results with more antennas.
 - `lf t5 wakeup` has been adjusted to not need the p in front of the pwd arg.
 - `data psknexwatchdemod` has been moved to `lf nexwatch demod` (reads from graphbuffer)
 - `data fskparadoxdemod` has been moved to `lf paradox demod` (reads from graphbuffer)

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1096,7 +1096,7 @@ void CmdIOdemodFSK(int findone, int *high, int *low, int ledcontrol)
 void TurnReadLFOn(int delay) {
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_LF_ADC | FPGA_LF_ADC_READER_FIELD);
 	// Give it a bit of time for the resonant antenna to settle.
-	SpinDelayUs(delay); //155*8 //50*8
+	WaitUS(delay); //155*8 //50*8
 }
 
 // Write one bit to card
@@ -1106,7 +1106,7 @@ void T55xxWriteBit(int bit) {
 	else
 		TurnReadLFOn(WRITE_1);
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
-	SpinDelayUs(WRITE_GAP);
+	WaitUS(WRITE_GAP);
 }
 
 // Send T5577 reset command then read stream (see if we can identify the start of the stream)
@@ -1117,16 +1117,18 @@ void T55xxResetRead(void) {
 
 	// Set up FPGA, 125kHz
 	LFSetupFPGAForADC(95, true);
-
+	StartTicks();
+	// make sure tag is fully powered up...
+	WaitMS(5);
+	
 	// Trigger T55x7 in mode.
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
-	SpinDelayUs(START_GAP);
+	WaitUS(START_GAP);
 
 	// reset tag - op code 00
 	T55xxWriteBit(0);
 	T55xxWriteBit(0);
 
-	// Turn field on to read the response
 	TurnReadLFOn(READ_GAP);
 
 	// Acquisition
@@ -1143,18 +1145,22 @@ void T55xxWriteBlockExt(uint32_t Data, uint32_t Block, uint32_t Pwd, uint8_t arg
 	LED_A_ON();
 	bool PwdMode = arg & 0x1;
 	uint8_t Page = (arg & 0x2)>>1;
+	bool testMode = arg & 0x4;
 	uint32_t i = 0;
 
 	// Set up FPGA, 125kHz
 	LFSetupFPGAForADC(95, true);
-
+	StartTicks();
+	// make sure tag is fully powered up...
+	WaitMS(5);
 	// Trigger T55x7 in mode.
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
-	SpinDelayUs(START_GAP);
+	WaitUS(START_GAP);
 
-	// Opcode 10
-	T55xxWriteBit(1);
-	T55xxWriteBit(Page); //Page 0
+	if (testMode) Dbprintf("TestMODE");
+	// Std Opcode 10
+	T55xxWriteBit(testMode ? 0 : 1);
+	T55xxWriteBit(testMode ? 1 : Page); //Page 0
 	if (PwdMode){
 		// Send Pwd
 		for (i = 0x80000000; i != 0; i >>= 1)
@@ -1173,11 +1179,31 @@ void T55xxWriteBlockExt(uint32_t Data, uint32_t Block, uint32_t Pwd, uint8_t arg
 
 	// Perform write (nominal is 5.6 ms for T55x7 and 18ms for E5550,
 	// so wait a little more)
-	TurnReadLFOn(20 * 1000);
+
+	// "there is a clock delay before programming" 
+	//  - programming takes ~5.6ms for t5577 ~18ms for E5550
+	//  so we should wait 1 clock + 5.6ms then read response? 
+	//  but we need to know we are dealing with t55x7 vs e5550 (or q5) marshmellow...
+	if (testMode) {
+		// Turn field on to read the response
+		TurnReadLFOn(READ_GAP);
+
+		// Acquisition
+		// Now do the acquisition
+		// Now do the acquisition
+		DoPartialAcquisition(20, true, 12000);
+
+		//doT55x7Acquisition(12000);
+	} else {
+		TurnReadLFOn(20 * 1000);
+	}
 		//could attempt to do a read to confirm write took
 		// as the tag should repeat back the new block 
 		// until it is reset, but to confirm it we would 
-		// need to know the current block 0 config mode
+		// need to know the current block 0 config mode for
+		// modulation clock an other details to demod the response...
+		// response should be (for t55x7) a 0 bit then (ST if on) 
+		// block data written in on repeat until reset. 
 
 	// turn field off
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
@@ -1206,10 +1232,12 @@ void T55xxReadBlock(uint16_t arg0, uint8_t Block, uint32_t Pwd) {
 
 	// Set up FPGA, 125kHz to power up the tag
 	LFSetupFPGAForADC(95, true);
-
+	StartTicks();
+	// make sure tag is fully powered up...
+	WaitMS(5);
 	// Trigger T55x7 Direct Access Mode with start gap
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
-	SpinDelayUs(START_GAP);
+	WaitUS(START_GAP);
 
 	// Opcode 1[page]
 	T55xxWriteBit(1);
@@ -1229,10 +1257,13 @@ void T55xxReadBlock(uint16_t arg0, uint8_t Block, uint32_t Pwd) {
 			T55xxWriteBit(Block & i);		
 
 	// Turn field on to read the response
-	TurnReadLFOn(READ_GAP);
+	TurnReadLFOn(135*8);
 
 	// Acquisition
-	doT55x7Acquisition(12000);
+	// Now do the acquisition
+	DoPartialAcquisition(0, true, 12000);
+
+	//	doT55x7Acquisition(12000);
 
 	// Turn the field off
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
@@ -1246,10 +1277,13 @@ void T55xxWakeUp(uint32_t Pwd){
 	
 	// Set up FPGA, 125kHz
 	LFSetupFPGAForADC(95, true);
+	StartTicks();
+	// make sure tag is fully powered up...
+	WaitMS(5);
 	
 	// Trigger T55x7 Direct Access Mode
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
-	SpinDelayUs(START_GAP);
+	WaitUS(START_GAP);
 	
 	// Opcode 10
 	T55xxWriteBit(1);
@@ -1367,7 +1401,7 @@ void CopyIndala224toT55x7(uint32_t uid1, uint32_t uid2, uint32_t uid3, uint32_t 
 // clone viking tag to T55xx
 void CopyVikingtoT55xx(uint32_t block1, uint32_t block2, uint8_t Q5) {
 	uint32_t data[] = {T55x7_BITRATE_RF_32 | T55x7_MODULATION_MANCHESTER | (2 << T55x7_MAXBLOCK_SHIFT), block1, block2};
-	if (Q5) data[0] = ( ((32-2)>>1) << T5555_BITRATE_SHIFT) | T5555_MODULATION_MANCHESTER | 2 << T5555_MAXBLOCK_SHIFT;
+	if (Q5) data[0] = T5555_SET_BITRATE(32) | T5555_MODULATION_MANCHESTER | 2 << T5555_MAXBLOCK_SHIFT;
 	// Program the data blocks for supplied ID and the block 0 config
 	WriteT55xx(data, 0, 3);
 	LED_D_OFF();
@@ -1451,8 +1485,7 @@ void WriteEM410x(uint32_t card, uint32_t id_hi, uint32_t id_lo) {
 		}
 		data[0] = clock | T55x7_MODULATION_MANCHESTER | (2 << T55x7_MAXBLOCK_SHIFT);
 	} else { //t5555 (Q5)
-		clock = (clock-2)>>1;  //n = (RF-2)/2
-		data[0] = (clock << T5555_BITRATE_SHIFT) | T5555_MODULATION_MANCHESTER | (2 << T5555_MAXBLOCK_SHIFT);
+		data[0] = T5555_SET_BITRATE(clock) | T5555_MODULATION_MANCHESTER | (2 << T5555_MAXBLOCK_SHIFT);
 	}
 
 	WriteT55xx(data, 0, 3);

--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1222,7 +1222,7 @@ void T55xxReadBlock(uint16_t arg0, uint8_t Block, uint32_t Pwd) {
 	bool PwdMode = arg0 & 0x1;
 	uint8_t Page = (arg0 & 0x2) >> 1;
 	uint32_t i = 0;
-	bool RegReadMode = (Block == 0xFF);
+	bool RegReadMode = (Block == 0xFF);//regular read mode
 
 	//clear buffer now so it does not interfere with timing later
 	BigBuf_Clear_ext(false);
@@ -1257,7 +1257,9 @@ void T55xxReadBlock(uint16_t arg0, uint8_t Block, uint32_t Pwd) {
 			T55xxWriteBit(Block & i);		
 
 	// Turn field on to read the response
-	TurnReadLFOn(135*8);
+	// 137*8 seems to get to the start of data pretty well... 
+	//  but we want to go past the start and let the repeating data settle in...
+	TurnReadLFOn(210*8); 
 
 	// Acquisition
 	// Now do the acquisition

--- a/client/cmddata.h
+++ b/client/cmddata.h
@@ -22,6 +22,7 @@ command_t * CmdDataCommands();
 int CmdData(const char *Cmd);
 void printDemodBuff(void);
 void setDemodBuf(uint8_t *buff, size_t size, size_t startIdx);
+void save_restoreDB(uint8_t saveOpt);// option '1' to save DemodBuffer any other to restore
 int CmdPrintDemodBuff(const char *Cmd);
 int Cmdaskrawdemod(const char *Cmd);
 int Cmdaskmandemod(const char *Cmd);
@@ -68,6 +69,8 @@ int getSamples(const char *Cmd, bool silent);
 extern uint8_t DemodBuffer[MAX_DEMOD_BUF_LEN];
 extern size_t DemodBufferLen;
 extern uint8_t g_debugMode;
+//extern size_t g_demodStartIdx;
+//extern uint8_t g_demodClock;
 #define BIGBUF_SIZE 40000
 
 #endif

--- a/client/cmdlfnoralsy.c
+++ b/client/cmdlfnoralsy.c
@@ -111,7 +111,7 @@ int NoralsyDemod_AM(uint8_t *dest, size_t *size) {
 int CmdNoralsyDemod(const char *Cmd) {
 
 	//ASK / Manchester
-	bool st = false;
+	bool st = true;
 	if (!ASKDemod_ext("32 0 0", false, false, 1, &st)) {
 		if (g_debugMode) PrintAndLog("DEBUG: Error - Noralsy: ASK/Manchester Demod failed");
 		return 0;

--- a/client/cmdlft55xx.c
+++ b/client/cmdlft55xx.c
@@ -570,7 +570,7 @@ bool tryDetectModulation(){
 			}
 		}
 		clk = GetNrzClock("", false, false);
-		if (clk>0) {
+		if (clk>8) { //clock of rf/8 is likely a false positive, so don't use it.
 			if ( NRZrawDemod("0 0 1", false)  && test(DEMOD_NRZ, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
 				tests[hits].modulation = DEMOD_NRZ;
 				tests[hits].bitrate = bitRate;

--- a/client/cmdlft55xx.c
+++ b/client/cmdlft55xx.c
@@ -24,6 +24,7 @@
 #include "data.h"
 #include "lfdemod.h"
 #include "cmdhf14a.h" //for getTagInfo
+#include "protocols.h"
 
 #define T55x7_CONFIGURATION_BLOCK 0x00
 #define T55x7_PAGE0 0x00
@@ -78,12 +79,13 @@ int usage_t55xx_read(){
 	return 0;
 }
 int usage_t55xx_write(){
-	PrintAndLog("Usage:  lf t55xx write [b <block>] [d <data>] [p <password>] [1]");
+	PrintAndLog("Usage:  lf t55xx write [b <block>] [d <data>] [p <password>] [1] [t]");
 	PrintAndLog("Options:");
 	PrintAndLog("     b <block>    - block number to write. Between 0-7");
 	PrintAndLog("     d <data>     - 4 bytes of data to write (8 hex characters)");
 	PrintAndLog("     p <password> - OPTIONAL password 4bytes (8 hex characters)");
 	PrintAndLog("     1            - OPTIONAL write Page 1 instead of Page 0");
+	PrintAndLog("     t            - OPTIONAL test mode write - ****DANGER****");	
 	PrintAndLog("");
 	PrintAndLog("Examples:");
 	PrintAndLog("      lf t55xx write b 3 d 11223344            - write 11223344 to block 3");
@@ -138,15 +140,28 @@ int usage_t55xx_detect(){
 	PrintAndLog("");
 	return 0;
 }
+int usage_t55xx_detectP1(){
+	PrintAndLog("Usage:  lf t55xx page1detect [1] [p <password>]");
+	PrintAndLog("Options:");
+	PrintAndLog("     1             - if set, use Graphbuffer otherwise read data from tag.");
+	PrintAndLog("     p <password>  - OPTIONAL password (8 hex characters)");
+	PrintAndLog("");
+	PrintAndLog("Examples:");
+	PrintAndLog("      lf t55xx page1detect");
+	PrintAndLog("      lf t55xx page1detect 1");
+	PrintAndLog("      lf t55xx page1detect p 11223344");
+	PrintAndLog("");
+	return 0;
+}
 int usage_t55xx_wakup(){
-	PrintAndLog("Usage:  lf t55xx wakeup [h] p <password>");
+	PrintAndLog("Usage:  lf t55xx wakeup [h] <password>");
 	PrintAndLog("This commands send the Answer-On-Request command and leaves the readerfield ON afterwards.");
 	PrintAndLog("Options:");
 	PrintAndLog("     h             - this help");
-	PrintAndLog("     p <password>  - password 4bytes (8 hex symbols)");
+	PrintAndLog("     <password>  - [required] password 4bytes (8 hex symbols)");
 	PrintAndLog("");
 	PrintAndLog("Examples:");
-		PrintAndLog("      lf t55xx wakeup p 11223344  - send wakeup password");
+		PrintAndLog("      lf t55xx wakeup 11223344  - send wakeup password");
 	return 0;
 }
 int usage_t55xx_bruteforce(){
@@ -490,9 +505,10 @@ bool tryDetectModulation(){
 	uint8_t hits = 0;
 	t55xx_conf_block_t tests[15];
 	int bitRate=0;
-	uint8_t fc1 = 0, fc2 = 0, clk=0;
-	if (GetFskClock("", false, false)){ 
-		fskClocks(&fc1, &fc2, &clk, false);
+	uint8_t fc1 = 0, fc2 = 0, ans = 0;
+	int clk=0;
+	ans = fskClocks(&fc1, &fc2, (uint8_t *)&clk, false);
+	if (ans && ((fc1==10 && fc2==8) || (fc1==8 && fc2==5))) {
 		if ( FSKrawDemod("0 0", false) && test(DEMOD_FSK, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
 			tests[hits].modulation = DEMOD_FSK;
 			if (fc1==8 && fc2 == 5)
@@ -553,8 +569,6 @@ bool tryDetectModulation(){
 				++hits;
 			}
 		}
-		//undo trim from ask
-		//save_restoreGB(0);
 		clk = GetNrzClock("", false, false);
 		if (clk>0) {
 			if ( NRZrawDemod("0 0 1", false)  && test(DEMOD_NRZ, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
@@ -576,12 +590,12 @@ bool tryDetectModulation(){
 			}
 		}
 		
-		// allow undo
-		// skip first 160 samples to allow antenna to settle in (psk gets inverted occasionally otherwise)
-		save_restoreGB(1);
-		CmdLtrim("160");
 		clk = GetPskClock("", false, false);
 		if (clk>0) {
+			// allow undo
+			save_restoreGB(1);
+			// skip first 160 samples to allow antenna to settle in (psk gets inverted occasionally otherwise)
+			CmdLtrim("160");
 			if ( PSKDemod("0 0 6", false) && test(DEMOD_PSK1, &tests[hits].offset, &bitRate, clk, &tests[hits].Q5)) {
 				tests[hits].modulation = DEMOD_PSK1;
 				tests[hits].bitrate = bitRate;
@@ -622,9 +636,9 @@ bool tryDetectModulation(){
 					++hits;
 				}
 			} // inverse waves does not affect this demod
+			//undo trim samples
+			save_restoreGB(0);
 		}
-		//undo trim samples
-		save_restoreGB(0);
 	}	
 	if ( hits == 1) {
 		config.modulation = tests[0].modulation;
@@ -780,9 +794,7 @@ bool test(uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t clk, bool *Q5)
 		// moved test to here, since this gets most faults first.
 		if ( resv > 0x00) continue;
 
-		uint8_t xtRate   = PackBits(si, 3, DemodBuffer); si += 3;     //extended mode part of rate
-		int bitRate      = PackBits(si, 3, DemodBuffer); si += 3;     //bit rate
-		if (bitRate > 7) continue;
+		int bitRate      = PackBits(si, 6, DemodBuffer); si += 6;     //bit rate (includes extended mode part of rate)
 		uint8_t extend   = PackBits(si, 1, DemodBuffer); si += 1;     //bit 15 extended mode
 		uint8_t modread  = PackBits(si, 5, DemodBuffer); si += 5+2+1; 
 		//uint8_t pskcr   = PackBits(si, 2, DemodBuffer); si += 2+1;  //could check psk cr
@@ -792,12 +804,14 @@ bool test(uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t clk, bool *Q5)
 		//if extended mode
 		bool extMode =( (safer == 0x6 || safer == 0x9) && extend) ? true : false;
 
-		if (!extMode){
-			if (xtRate) continue;  //nml01 || nml02 ||  caused issues on noralys tags
+		if (!extMode) {
+			if (bitRate > 7) continue;
+			if (!testBitRate(bitRate, clk)) continue;
+		} else { //extended mode bitrate = same function to calc bitrate as em4x05
+			if (EM4x05_GET_BITRATE(bitRate) != clk) continue;
 		}
 		//test modulation
 		if (!testModulation(mode, modread)) continue;
-		if (!testBitRate(bitRate, clk)) continue;
 		*fndBitRate = bitRate;
 		*offset = idx;
 		*Q5 = false;
@@ -854,7 +868,7 @@ int special(const char *Cmd) {
 int printConfiguration( t55xx_conf_block_t b){
 	PrintAndLog("Chip Type  : %s", (b.Q5) ? "T5555(Q5)" : "T55x7");
 	PrintAndLog("Modulation : %s", GetSelectedModulationStr(b.modulation) );
-	PrintAndLog("Bit Rate   : %s", GetBitRateStr(b.bitrate) );
+	PrintAndLog("Bit Rate   : %s", GetBitRateStr(b.bitrate, (b.block0 & T55x7_X_MODE)) );
 	PrintAndLog("Inverted   : %s", (b.inverted) ? "Yes" : "No" );
 	PrintAndLog("Offset     : %d", b.offset);
 	PrintAndLog("Seq. Term. : %s", (b.ST) ? "Yes" : "No" );
@@ -865,26 +879,11 @@ int printConfiguration( t55xx_conf_block_t b){
 
 int CmdT55xxWakeUp(const char *Cmd) {
 	uint32_t password = 0;
-	uint8_t cmdp = 0;
-	bool errors = true;
-	while(param_getchar(Cmd, cmdp) != 0x00) {
-		switch(param_getchar(Cmd, cmdp)) {
-		case 'h':
-		case 'H':
-			return usage_t55xx_wakup();
-		case 'p':
-		case 'P':
-			password = param_get32ex(Cmd, cmdp+1, 0xFFFFFFFF, 16);
-			cmdp += 2;
-			errors = false;
-			break;
-		default:
-			PrintAndLog("Unknown parameter '%c'", param_getchar(Cmd, cmdp));
-			errors = true;
-			break;
-		}
-	}
-	if (errors) return usage_t55xx_wakup();
+	if ( strlen(Cmd) <= 0 ) return usage_t55xx_wakup();
+	char cmdp = param_getchar(Cmd, 0);
+	if ( cmdp == 'h' || cmdp == 'H') return usage_t55xx_wakup();
+
+	password = param_get32ex(Cmd, 0, 0, 16);
 
 	UsbCommand c = {CMD_T55XX_WAKEUP, {password, 0, 0}};
 	clearCommandBuffer();
@@ -900,6 +899,7 @@ int CmdT55xxWriteBlock(const char *Cmd) {
 	bool usepwd = false;
 	bool page1 = false;	
 	bool gotdata = false;
+	bool testMode = false;
 	bool errors = false;
 	uint8_t cmdp = 0;
 	while(param_getchar(Cmd, cmdp) != 0x00 && !errors) {
@@ -924,6 +924,11 @@ int CmdT55xxWriteBlock(const char *Cmd) {
 			usepwd = true;
 			cmdp += 2;
 			break;
+		case 't':
+		case 'T':
+			testMode = true;
+			cmdp++;
+			break;
 		case '1':
 			page1 = true;
 			cmdp++;
@@ -944,6 +949,7 @@ int CmdT55xxWriteBlock(const char *Cmd) {
 	UsbCommand c = {CMD_T55XX_WRITE_BLOCK, {data, block, 0}};
 	UsbCommand resp;
  	c.d.asBytes[0] = (page1) ? 0x2 : 0; 
+ 	c.d.asBytes[0] |= (testMode) ? 0x4 : 0; 
 
 	char pwdStr[16] = {0};
 	snprintf(pwdStr, sizeof(pwdStr), "pwd: 0x%08X", password);
@@ -1168,7 +1174,7 @@ int CmdT55xxInfo(const char *Cmd){
 	PrintAndLog("-------------------------------------------------------------");
 	PrintAndLog(" Safer key                 : %s", GetSaferStr(safer));
 	PrintAndLog(" reserved                  : %d", resv);
-	PrintAndLog(" Data bit rate             : %s", GetBitRateStr(dbr));
+	PrintAndLog(" Data bit rate             : %s", GetBitRateStr(dbr, extend));
 	PrintAndLog(" eXtended mode             : %s", (extend) ? "Yes - Warning":"No");
 	PrintAndLog(" Modulation                : %s", GetModulationStr(datamod));
 	PrintAndLog(" PSK clock frequency       : %d", pskcf);
@@ -1195,7 +1201,7 @@ int CmdT55xxDump(const char *Cmd){
 	bool override = false;
 	if ( cmdp == 'h' || cmdp == 'H') return usage_t55xx_dump();
 
-	bool usepwd = ( strlen(Cmd) > 0);	
+	bool usepwd = ( strlen(Cmd) > 0);
 	if ( usepwd ){
 		password = param_get32ex(Cmd, 0, 0, 16);
 		if (param_getchar(Cmd, 1) =='o' )
@@ -1234,20 +1240,24 @@ int AquireData( uint8_t page, uint8_t block, bool pwdmode, uint32_t password ){
 	return 1;
 }
 
-char * GetBitRateStr(uint32_t id) {
+char * GetBitRateStr(uint32_t id, bool xmode) {
 	static char buf[25];
 
 	char *retStr = buf;
-	switch (id) {
-		case 0:   snprintf(retStr,sizeof(buf),"%d - RF/8",id);   break;
-		case 1:   snprintf(retStr,sizeof(buf),"%d - RF/16",id);  break;
-		case 2:   snprintf(retStr,sizeof(buf),"%d - RF/32",id);  break;
-		case 3:   snprintf(retStr,sizeof(buf),"%d - RF/40",id);  break;
-		case 4:   snprintf(retStr,sizeof(buf),"%d - RF/50",id);  break;
-		case 5:   snprintf(retStr,sizeof(buf),"%d - RF/64",id);  break;
-		case 6:   snprintf(retStr,sizeof(buf),"%d - RF/100",id); break;
-		case 7:   snprintf(retStr,sizeof(buf),"%d - RF/128",id); break;
-		default:  snprintf(retStr,sizeof(buf),"%d - (Unknown)",id); break;
+	if (xmode) { //xmode bitrate calc is same as em4x05 calc
+		snprintf(retStr,sizeof(buf),"%d - RF/%d", id, EM4x05_GET_BITRATE(id));
+	} else {
+		switch (id) {
+			case 0:   snprintf(retStr,sizeof(buf),"%d - RF/8",id);   break;
+			case 1:   snprintf(retStr,sizeof(buf),"%d - RF/16",id);  break;
+			case 2:   snprintf(retStr,sizeof(buf),"%d - RF/32",id);  break;
+			case 3:   snprintf(retStr,sizeof(buf),"%d - RF/40",id);  break;
+			case 4:   snprintf(retStr,sizeof(buf),"%d - RF/50",id);  break;
+			case 5:   snprintf(retStr,sizeof(buf),"%d - RF/64",id);  break;
+			case 6:   snprintf(retStr,sizeof(buf),"%d - RF/100",id); break;
+			case 7:   snprintf(retStr,sizeof(buf),"%d - RF/128",id); break;
+			default:  snprintf(retStr,sizeof(buf),"%d - (Unknown)",id); break;
+		}		
 	}
 	return buf;
 }
@@ -1540,11 +1550,160 @@ int CmdT55xxBruteForce(const char *Cmd) {
 	return 0;
 }
 
+// note length of data returned is different for different chips.  
+//   some return all page 1 (64 bits) and others return just that block (32 bits) 
+//   unfortunately the 64 bits makes this more likely to get a false positive...
+bool tryDetectP1(bool getData) {
+	uint8_t preamble[] = {1,1,1,0,0,0,0,0,0,0,0,1,0,1,0,1};
+	size_t startIdx = 0;
+	uint8_t fc1 = 0, fc2 = 0, ans = 0;
+	int clk = 0;
+	bool st = true;
+
+	if ( getData ) {
+		if ( !AquireData(T55x7_PAGE1, 1, false, 0) )
+			return false;
+	}
+
+	// try fsk clock detect. if successful it cannot be any other type of modulation...  (in theory...)
+	ans = fskClocks(&fc1, &fc2, (uint8_t *)&clk, false);
+	if (ans && ((fc1==10 && fc2==8) || (fc1==8 && fc2==5))) {
+		if ( FSKrawDemod("0 0", false) && 
+			  preambleSearchEx(DemodBuffer,preamble,sizeof(preamble),&DemodBufferLen,&startIdx,false) && 
+			  (DemodBufferLen == 32 || DemodBufferLen == 64) ) {
+			return true;
+		}
+		if ( FSKrawDemod("0 1", false) && 
+			  preambleSearchEx(DemodBuffer,preamble,sizeof(preamble),&DemodBufferLen,&startIdx,false) && 
+			  (DemodBufferLen == 32 || DemodBufferLen == 64) ) {
+			return true;
+		}
+		return false;
+	}
+
+	// try psk clock detect. if successful it cannot be any other type of modulation... (in theory...)
+	clk = GetPskClock("", false, false);
+	if (clk>0) {
+		// allow undo
+		// save_restoreGB(1);
+		// skip first 160 samples to allow antenna to settle in (psk gets inverted occasionally otherwise)
+		//CmdLtrim("160");
+		if ( PSKDemod("0 0 6", false) &&
+			  preambleSearchEx(DemodBuffer,preamble,sizeof(preamble),&DemodBufferLen,&startIdx,false) && 
+			  (DemodBufferLen == 32 || DemodBufferLen == 64) ) {
+			//save_restoreGB(0);
+			return true;
+		}
+		if ( PSKDemod("0 1 6", false) &&
+			  preambleSearchEx(DemodBuffer,preamble,sizeof(preamble),&DemodBufferLen,&startIdx,false) && 
+			  (DemodBufferLen == 32 || DemodBufferLen == 64) ) {
+			//save_restoreGB(0);
+			return true;
+		}
+		// PSK2 - needs a call to psk1TOpsk2.
+		if ( PSKDemod("0 0 6", false)) {
+			psk1TOpsk2(DemodBuffer, DemodBufferLen);
+			if (preambleSearchEx(DemodBuffer,preamble,sizeof(preamble),&DemodBufferLen,&startIdx,false) && 
+				  (DemodBufferLen == 32 || DemodBufferLen == 64) ) {
+				//save_restoreGB(0);
+				return true;
+			}
+		} // inverse waves does not affect PSK2 demod
+		//undo trim samples
+		//save_restoreGB(0); 
+		// no other modulation clocks = 2 or 4 so quit searching
+		if (fc1 != 8) return false;
+	}
+
+	// try ask clock detect.  it could be another type even if successful.
+	clk = GetAskClock("", false, false);
+	if (clk>0) {
+		if ( ASKDemod_ext("0 0 1", false, false, 1, &st) &&
+			  preambleSearchEx(DemodBuffer,preamble,sizeof(preamble),&DemodBufferLen,&startIdx,false) && 
+			  (DemodBufferLen == 32 || DemodBufferLen == 64) ) {
+			return true;
+		}
+		st = true;
+		if ( ASKDemod_ext("0 1 1", false, false, 1, &st)  &&
+			  preambleSearchEx(DemodBuffer,preamble,sizeof(preamble),&DemodBufferLen,&startIdx,false) && 
+			  (DemodBufferLen == 32 || DemodBufferLen == 64) ) {
+			return true;
+		}
+		if ( ASKbiphaseDemod("0 0 0 2", false) &&
+			  preambleSearchEx(DemodBuffer,preamble,sizeof(preamble),&DemodBufferLen,&startIdx,false) && 
+			  (DemodBufferLen == 32 || DemodBufferLen == 64) ) {
+			return true;
+		}
+		if ( ASKbiphaseDemod("0 0 1 2", false) &&
+			  preambleSearchEx(DemodBuffer,preamble,sizeof(preamble),&DemodBufferLen,&startIdx,false) && 
+			  (DemodBufferLen == 32 || DemodBufferLen == 64) ) {
+			return true;
+		}
+	}
+
+	// try NRZ clock detect.  it could be another type even if successful.
+	clk = GetNrzClock("", false, false); //has the most false positives :(
+	if (clk>0) {
+		if ( NRZrawDemod("0 0 1", false)  &&
+			  preambleSearchEx(DemodBuffer,preamble,sizeof(preamble),&DemodBufferLen,&startIdx,false) && 
+			  (DemodBufferLen == 32 || DemodBufferLen == 64) ) {
+			return true;
+		}
+		if ( NRZrawDemod("0 1 1", false)  &&
+			  preambleSearchEx(DemodBuffer,preamble,sizeof(preamble),&DemodBufferLen,&startIdx,false) && 
+			  (DemodBufferLen == 32 || DemodBufferLen == 64) ) {
+			return true;
+		}
+	}
+	return false;
+}
+//  does this need to be a callable command?
+int CmdT55xxDetectPage1(const char *Cmd){
+	bool errors = false;
+	bool useGB = false;
+	bool usepwd = false;
+	uint32_t password = 0;
+	uint8_t cmdp = 0;
+
+	while(param_getchar(Cmd, cmdp) != 0x00 && !errors) {
+		switch(param_getchar(Cmd, cmdp)) {
+		case 'h':
+		case 'H':
+			return usage_t55xx_detectP1();
+		case 'p':
+		case 'P':
+			password = param_get32ex(Cmd, cmdp+1, 0, 16);
+			usepwd = true;
+			cmdp += 2;
+			break;
+		case '1':
+			// use Graphbuffer data
+			useGB = true;
+			cmdp++;
+			break;
+		default:
+			PrintAndLog("Unknown parameter '%c'", param_getchar(Cmd, cmdp));
+			errors = true;
+			break;
+		}
+	}
+	if (errors) return usage_t55xx_detectP1();
+
+	if ( !useGB ) {
+		if ( !AquireData(T55x7_PAGE1, 1, usepwd, password) )
+			return false;
+	}
+	bool success = tryDetectP1(false);
+	if (success) PrintAndLog("T55xx chip found!");
+	return success;
+}
+
 static command_t CommandTable[] = {
   {"help",      CmdHelp,           1, "This help"},
 	{"bruteforce",CmdT55xxBruteForce,0, "<start password> <end password> [i <*.dic>] Simple bruteforce attack to find password"},
   {"config",    CmdT55xxSetConfig, 1, "Set/Get T55XX configuration (modulation, inverted, offset, rate)"},
   {"detect",    CmdT55xxDetect,    1, "[1] Try detecting the tag modulation from reading the configuration block."},
+  {"p1detect",  CmdT55xxDetectPage1,1, "[1] Try detecting if this is a t55xx tag by reading page 1"},
   {"read",      CmdT55xxReadBlock, 0, "b <block> p [password] [o] [1] -- Read T55xx block data. Optional [p password], [override], [page1]"},
   {"resetread", CmdResetRead,      0, "Send Reset Cmd then lf read the stream to attempt to identify the start of it (needs a demod and/or plot after)"},
   {"write",     CmdT55xxWriteBlock,0, "b <block> d <data> p [password] [1] -- Write T55xx block data. Optional [p password], [page1]"},

--- a/client/cmdlft55xx.c
+++ b/client/cmdlft55xx.c
@@ -141,15 +141,16 @@ int usage_t55xx_detect(){
 	return 0;
 }
 int usage_t55xx_detectP1(){
-	PrintAndLog("Usage:  lf t55xx page1detect [1] [p <password>]");
+	PrintAndLog("Command: Detect Page 1 of a t55xx chip");
+	PrintAndLog("Usage:  lf t55xx p1detect [1] [p <password>]");
 	PrintAndLog("Options:");
 	PrintAndLog("     1             - if set, use Graphbuffer otherwise read data from tag.");
 	PrintAndLog("     p <password>  - OPTIONAL password (8 hex characters)");
 	PrintAndLog("");
 	PrintAndLog("Examples:");
-	PrintAndLog("      lf t55xx page1detect");
-	PrintAndLog("      lf t55xx page1detect 1");
-	PrintAndLog("      lf t55xx page1detect p 11223344");
+	PrintAndLog("      lf t55xx p1detect");
+	PrintAndLog("      lf t55xx p1detect 1");
+	PrintAndLog("      lf t55xx p1detect p 11223344");
 	PrintAndLog("");
 	return 0;
 }

--- a/client/cmdlft55xx.h
+++ b/client/cmdlft55xx.h
@@ -36,18 +36,18 @@ typedef struct {
 
 typedef struct {
 	enum {
-		DEMOD_NRZ  = 0x00,    
+		DEMOD_NRZ  = 0x00,
 		DEMOD_PSK1 = 0x01,
 		DEMOD_PSK2 = 0x02,
 		DEMOD_PSK3 = 0x03,
-		DEMOD_FSK1  = 0x04,     
-		DEMOD_FSK1a = 0x05,     
-		DEMOD_FSK2  = 0x06,     
+		DEMOD_FSK1  = 0x04,
+		DEMOD_FSK1a = 0x05,
+		DEMOD_FSK2  = 0x06,
 		DEMOD_FSK2a = 0x07, 
 		DEMOD_FSK   = 0xF0, //generic FSK (auto detect FCs)    
 		DEMOD_ASK  = 0x08,
 		DEMOD_BI   = 0x10,
-		DEMOD_BIa  = 0x18,		
+		DEMOD_BIa  = 0x18
 	}  modulation;
 	bool inverted;
 	uint8_t offset;
@@ -60,27 +60,27 @@ typedef struct {
 		RF_50 = 0x04,
 		RF_64 = 0x05,
 		RF_100 = 0x06,
-		RF_128 = 0x07,
+		RF_128 = 0x07
 	} bitrate;
 	bool Q5;
 	bool ST;
 } t55xx_conf_block_t;
-t55xx_conf_block_t Get_t55xx_Config();
+
+t55xx_conf_block_t Get_t55xx_Config(void);
 void Set_t55xx_Config(t55xx_conf_block_t conf);
 
+extern int CmdLFT55XX(const char *Cmd);
+extern int CmdT55xxBruteForce(const char *Cmd);
+extern int CmdT55xxSetConfig(const char *Cmd);
+extern int CmdT55xxReadBlock(const char *Cmd);
+extern int CmdT55xxWriteBlock(const char *Cmd);
+extern int CmdT55xxReadTrace(const char *Cmd);
+extern int CmdT55xxInfo(const char *Cmd);
+extern int CmdT55xxDetect(const char *Cmd);
+extern int CmdResetRead(const char *Cmd);
+extern int CmdT55xxWipe(const char *Cmd);
 
-int CmdLFT55XX(const char *Cmd);
-int CmdT55xxBruteForce(const char *Cmd);
-int CmdT55xxSetConfig(const char *Cmd);
-int CmdT55xxReadBlock(const char *Cmd);
-int CmdT55xxWriteBlock(const char *Cmd);
-int CmdT55xxReadTrace(const char *Cmd);
-int CmdT55xxInfo(const char *Cmd);
-int CmdT55xxDetect(const char *Cmd);
-int CmdResetRead(const char *Cmd);
-int CmdT55xxWipe(const char *Cmd);
-
-char * GetBitRateStr(uint32_t id);
+char * GetBitRateStr(uint32_t id, bool xmode);
 char * GetSaferStr(uint32_t id);
 char * GetModulationStr( uint32_t id);
 char * GetModelStrFromCID(uint32_t cid);
@@ -90,8 +90,9 @@ void printT5xxHeader(uint8_t page);
 void printT55xxBlock(const char *demodStr);
 int printConfiguration( t55xx_conf_block_t b);
 
-bool DecodeT55xxBlock();
-bool tryDetectModulation();
+bool DecodeT55xxBlock(void);
+bool tryDetectModulation(void);
+extern bool tryDetectP1(bool getData);
 bool test(uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t clk, bool *Q5);
 int special(const char *Cmd);
 int AquireData( uint8_t page, uint8_t block, bool pwdmode, uint32_t password );

--- a/client/graph.c
+++ b/client/graph.c
@@ -166,11 +166,12 @@ uint8_t GetPskCarrier(const char str[], bool printAns, bool verbose)
 			PrintAndLog("Failed to copy from graphbuffer");
 		return 0;
 	}
-	//uint8_t countPSK_FC(uint8_t *BitStream, size_t size)
-
-	carrier = countFC(grph,size,0);
+	uint16_t fc = countFC(grph,size,0);
+	carrier = fc & 0xFF;
+	if (carrier != 2 && carrier != 4 && carrier != 8) return 0;
+	if ((fc>>8) == 10 && carrier == 8) return 0;
 	// Only print this message if we're not looping something
-	if (printAns){
+	if (printAns) {
 		PrintAndLog("Auto-detected PSK carrier rate: %d", carrier);
 	}
 	return carrier;
@@ -193,7 +194,9 @@ int GetPskClock(const char str[], bool printAns, bool verbose)
 			PrintAndLog("Failed to copy from graphbuffer");
 		return -1;
 	}
-	clock = DetectPSKClock(grph,size,0);
+	size_t firstPhaseShiftLoc = 0;
+	uint8_t curPhase = 0, fc = 0;
+	clock = DetectPSKClock(grph, size, 0, &firstPhaseShiftLoc, &curPhase, &fc);
 	// Only print this message if we're not looping something
 	if (printAns){
 		PrintAndLog("Auto-detected clock rate: %d", clock);

--- a/client/graph.c
+++ b/client/graph.c
@@ -150,7 +150,7 @@ int GetAskClock(const char str[], bool printAns, bool verbose)
 		start = DetectASKClock(grph, size, &clock, 20);
 	}
 	// Only print this message if we're not looping something
-	if (printAns) {
+	if (printAns || g_debugMode) {
 		PrintAndLog("Auto-detected clock rate: %d, Best Starting Position: %d", clock, start);
 	}
 	return clock;

--- a/client/util.c
+++ b/client/util.c
@@ -169,7 +169,7 @@ char *sprint_bin_break(const uint8_t *data, const size_t len, const uint8_t brea
 
 	size_t in_index = 0;
 	// loop through the out_index to make sure we don't go too far
-	for (size_t out_index=0; out_index < max_len-1; out_index++) {
+	for (size_t out_index=0; out_index < max_len; out_index++) {
 		// set character - (should be binary but verify it isn't more than 1 digit)
 		if (data[in_index]<10)
 			sprintf(tmp++, "%u", (unsigned int) data[in_index]);

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -548,7 +548,7 @@ int DetectNRZClock(uint8_t dest[], size_t size, int clock, size_t *clockStartIdx
 
 	//get high and low peak
 	int peak, low;
-	if (getHiLo(dest, loopCnt, &peak, &low, 85, 85) < 1) return 0;
+	if (getHiLo(dest, loopCnt, &peak, &low, 90, 90) < 1) return 0;
 
 	int lowestTransition = DetectStrongNRZClk(dest, size-20, peak, low);
 	size_t ii;
@@ -958,6 +958,8 @@ uint8_t	detectFSKClk(uint8_t *BitStream, size_t size, uint8_t fcHigh, uint8_t fc
 
 // look for Sequence Terminator - should be pulses of clk*(1 or 2), clk*2, clk*(1.5 or 2), by idx we mean graph position index...
 bool findST(int *stStopLoc, int *stStartIdx, int lowToLowWaveLen[], int highToLowWaveLen[], int clk, int tol, int buffSize, size_t *i) {
+	if (buffSize < *i+4) return false;
+
 	for (; *i < buffSize - 4; *i+=1) {
 		*stStartIdx += lowToLowWaveLen[*i]; //caution part of this wave may be data and part may be ST....  to be accounted for in main function for now...
 		if (lowToLowWaveLen[*i] >= clk*1-tol && lowToLowWaveLen[*i] <= (clk*2)+tol && highToLowWaveLen[*i] < clk+tol) {           //1 to 2 clocks depending on 2 bits prior

--- a/common/lfdemod.h
+++ b/common/lfdemod.h
@@ -30,8 +30,7 @@ extern uint8_t  DetectCleanAskWave(uint8_t dest[], size_t size, uint8_t high, ui
 extern uint8_t  detectFSKClk(uint8_t *BitStream, size_t size, uint8_t fcHigh, uint8_t fcLow);
 extern uint8_t  detectFSKClk_ext(uint8_t *BitStream, size_t size, uint8_t fcHigh, uint8_t fcLow, int *firstClockEdge);
 extern int      DetectNRZClock(uint8_t dest[], size_t size, int clock, size_t *clockStartIdx);
-extern int      DetectPSKClock(uint8_t dest[], size_t size, int clock);
-extern int      DetectPSKClock_ext(uint8_t dest[], size_t size, int clock, int *firstPhaseShift);
+extern int      DetectPSKClock(uint8_t dest[], size_t size, int clock, size_t *firstPhaseShift, uint8_t *curPhase, uint8_t *fc);
 extern int      DetectStrongAskClock(uint8_t dest[], size_t size, int high, int low, int *clock);
 extern bool     DetectST(uint8_t buffer[], size_t *size, int *foundclock);
 extern bool     DetectST_ext(uint8_t buffer[], size_t *size, int *foundclock, size_t *ststart, size_t *stend);
@@ -42,7 +41,7 @@ extern uint32_t manchesterEncode2Bytes(uint16_t datain);
 extern int      ManchesterEncode(uint8_t *BitStream, size_t size);
 extern int      manrawdecode(uint8_t *BitStream, size_t *size, uint8_t invert, uint8_t *alignPos);
 extern int      nrzRawDemod(uint8_t *dest, size_t *size, int *clk, int *invert, int *startIdx);
-extern uint8_t  parityTest(uint32_t bits, uint8_t bitLen, uint8_t pType);
+extern bool     parityTest(uint32_t bits, uint8_t bitLen, uint8_t pType);
 extern uint8_t  preambleSearch(uint8_t *BitStream, uint8_t *preamble, size_t pLen, size_t *size, size_t *startIdx);
 extern bool     preambleSearchEx(uint8_t *BitStream, uint8_t *preamble, size_t pLen, size_t *size, size_t *startIdx, bool findone);
 extern int      pskRawDemod(uint8_t dest[], size_t *size, int *clock, int *invert);

--- a/common/protocols.h
+++ b/common/protocols.h
@@ -238,6 +238,7 @@ void getMemConfig(uint8_t mem_cfg, uint8_t chip_cfg, uint8_t *max_blk, uint8_t *
 #define T55x7_MODULATION_MANCHESTER 0x00008000
 #define T55x7_MODULATION_BIPHASE    0x00010000
 #define T55x7_MODULATION_DIPHASE    0x00018000
+#define T55x7_X_MODE                0x00020000
 #define T55x7_BITRATE_RF_8          0
 #define T55x7_BITRATE_RF_16         0x00040000
 #define T55x7_BITRATE_RF_32         0x00080000


### PR DESCRIPTION
fixes #267 
also fixes a bug in noralsy demod.
improves lf sequence terminator(ST) detection
improves lf t55xx detection and reading.
fixes a bug in sprint_bin_break (didn't print last bit)
fixes a bug in lf indala demod corrupting the end of the ID sometimes
improves psk and nrz detection / demodulation
added t55xx page 1 detection and added it to the lf search chip detection. (based on mfg code E015)
added experimental t55xx testmode write command. (careful.  can and will overwrite entire tag no matter the selected block)