### PR TITLE
reenable build in old proxspace environment

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -20,7 +20,7 @@ LDLIBS = -L/opt/local/lib -L/usr/local/lib -lreadline -lpthread -lm
 LUALIB = ../liblua/liblua.a
 LDFLAGS = $(COMMON_FLAGS)
 CFLAGS = -std=c99 -D_ISOC99_SOURCE -I. -I../include -I../common -I../zlib -I/opt/local/include -I../liblua -Wall $(COMMON_FLAGS) -g -O3
-CXXFLAGS = -std=c++11 -fPIC -Wall -O3
+CXXFLAGS = -Wall -O3
 
 LUAPLATFORM = generic
 platform = $(shell uname)
@@ -41,8 +41,9 @@ QTINCLUDES = $(shell pkg-config --cflags Qt5Core Qt5Widgets 2>/dev/null)
 QTLDLIBS = $(shell pkg-config --libs Qt5Core Qt5Widgets 2>/dev/null)
 MOC = $(shell pkg-config --variable=host_bins Qt5Core)/moc
 UIC = $(shell pkg-config --variable=host_bins Qt5Core)/uic
+CXXFLAGS += -std=c++11 -fPIC
 ifeq ($(QTINCLUDES), )
-# if Qt5 not found Check for correctly configured Qt4	
+# if Qt5 not found check for correctly configured Qt4	
 	QTINCLUDES = $(shell pkg-config --cflags QtCore QtGui 2>/dev/null)
 	QTLDLIBS = $(shell pkg-config --libs QtCore QtGui 2>/dev/null)
 	MOC = $(shell pkg-config --variable=moc_location QtCore)

--- a/client/Makefile
+++ b/client/Makefile
@@ -41,13 +41,14 @@ QTINCLUDES = $(shell pkg-config --cflags Qt5Core Qt5Widgets 2>/dev/null)
 QTLDLIBS = $(shell pkg-config --libs Qt5Core Qt5Widgets 2>/dev/null)
 MOC = $(shell pkg-config --variable=host_bins Qt5Core)/moc
 UIC = $(shell pkg-config --variable=host_bins Qt5Core)/uic
-CXXFLAGS += -std=c++11 -fPIC
 ifeq ($(QTINCLUDES), )
 # if Qt5 not found check for correctly configured Qt4	
 	QTINCLUDES = $(shell pkg-config --cflags QtCore QtGui 2>/dev/null)
 	QTLDLIBS = $(shell pkg-config --libs QtCore QtGui 2>/dev/null)
 	MOC = $(shell pkg-config --variable=moc_location QtCore)
 	UIC = $(shell pkg-config --variable=uic_location QtCore)
+else
+	CXXFLAGS += -std=c++11 -fPIC
 endif
 ifeq ($(QTINCLUDES), )
 # if both pkg-config commands failed, search in common places
@@ -57,6 +58,7 @@ ifeq ($(QTINCLUDES), )
 		ifneq ($(wildcard $(QTDIR)/include/QtWidgets),)
 			QTINCLUDES += -I$(QTDIR)/include/QtWidgets
 			QTLDLIBS = -L$(QTDIR)/lib -lQt5Widgets -lQt5Gui -lQt5Core
+			CXXFLAGS += -std=c++11 -fPIC
 		endif
 		MOC = $(QTDIR)/bin/moc
 		UIC = $(QTDIR)/bin/uic


### PR DESCRIPTION
(use -std=c++11 and -fPIC options for Qt5 only)

Note: the latest graphwork changes in addition require ProxSpace/qt/4.6.2/bin/uic.exe which is not included in the old proxspace environment. If someone could add it please...
