### PR TITLE
Add needed header files to proxguiqt

### DIFF
--- a/client/proxguiqt.h
+++ b/client/proxguiqt.h
@@ -11,6 +11,9 @@
 #ifndef PROXGUI_QT
 #define PROXGUI_QT
 
+#include <stdint.h>
+#include <string.h>
+
 #include <QApplication>
 #include <QPushButton>
 #include <QObject>


### PR DESCRIPTION
Fixes compile errors due to missing typedefs.