### PR TITLE
fixing the crash on exit (issue #284)

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -20,7 +20,7 @@ LDLIBS = -L/opt/local/lib -L/usr/local/lib -lreadline -lpthread -lm
 LUALIB = ../liblua/liblua.a
 LDFLAGS = $(COMMON_FLAGS)
 CFLAGS = -std=c99 -D_ISOC99_SOURCE -I. -I../include -I../common -I../zlib -I/opt/local/include -I../liblua -Wall $(COMMON_FLAGS) -g -O3
-CXXFLAGS = -Wall -O3
+CXXFLAGS = -I../include -Wall -O3
 
 LUAPLATFORM = generic
 platform = $(shell uname)

--- a/client/proxgui.h
+++ b/client/proxgui.h
@@ -19,7 +19,7 @@ void ShowGraphWindow(void);
 void HideGraphWindow(void);
 void RepaintGraphWindow(void);
 void MainGraphics(void);
-void InitGraphics(int argc, char **argv);
+void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present);
 void ExitGraphics(void);
 
 #define MAX_GRAPH_TRACE_LEN (40000*8)

--- a/client/proxguiqt.cpp
+++ b/client/proxguiqt.cpp
@@ -84,6 +84,7 @@ void ProxGuiQT::_HideGraphWindow(void)
 void ProxGuiQT::_Exit(void) {
 	delete this;
 }
+
 void ProxGuiQT::MainLoop()
 {
 	plotapp = new QApplication(argc, argv);
@@ -110,7 +111,7 @@ ProxGuiQT::~ProxGuiQT(void)
 	//}
 	if (plotapp) {
 		plotapp->quit();
-		delete plotapp;
+		// delete plotapp;
 		plotapp = NULL;
 	}
 }

--- a/client/proxguiqt.h
+++ b/client/proxguiqt.h
@@ -118,4 +118,17 @@ class ProxGuiQT : public QObject
 		void HideGraphWindowSignal(void);
 		void ExitSignal(void);
 };
+
+
+class WorkerThread : public QThread {
+	Q_OBJECT;
+public:
+	WorkerThread(char*, bool);
+	~WorkerThread();
+	void run();
+private:
+	char *script_cmds_file = NULL;
+	bool usb_present = false;
+};
+
 #endif // PROXGUI_QT

--- a/client/proxmark3.h
+++ b/client/proxmark3.h
@@ -16,8 +16,17 @@
 
 #define PROXPROMPT "proxmark3> "
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void SendCommand(UsbCommand *c);
 const char *get_my_executable_path(void);
 const char *get_my_executable_directory(void);
+void main_loop(char *script_cmds_file, bool usb_present);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Using a `QThread` instead of a `pthread` to run the `main_loop()`. I am still not confident if the cleanup (deleting objects) is OK. However, this happens just before exiting `main()` anyway. Should fix #284.  