### PR TITLE
fix compile errors on non-Intel CPUs (issue #303)

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -155,7 +155,16 @@ CMDSRCS = 	crapto1/crapto1.c\
 			reveng/poly.c\
 			reveng/getopt.c\
 
-MULTIARCHSRCS = hardnested/hardnested_bf_core.c hardnested/hardnested_bitarray_core.c
+cpu_arch = $(shell uname -m)
+ifneq ($(findstring 86, $(cpu_arch)), )
+	MULTIARCHSRCS = hardnested/hardnested_bf_core.c hardnested/hardnested_bitarray_core.c
+endif
+ifneq ($(findstring 64, $(cpu_arch)), )
+	MULTIARCHSRCS = hardnested/hardnested_bf_core.c hardnested/hardnested_bitarray_core.c
+endif
+ifeq ($(MULTIARCHSRCS), )
+	CMDSRCS += hardnested/hardnested_bf_core.c hardnested/hardnested_bitarray_core.c
+endif
 
 ZLIBSRCS = deflate.c adler32.c trees.c zutil.c inflate.c inffast.c inftrees.c
 ZLIBFLAGS = -DZ_SOLO -DZ_PREFIX -DNO_GZIP -DZLIB_PM3_TUNED 

--- a/client/hardnested/hardnested_bf_core.c
+++ b/client/hardnested/hardnested_bf_core.c
@@ -70,7 +70,7 @@ THE SOFTWARE.
 #define MAX_BITSLICES 128
 #elif defined(__SSE2__)
 #define MAX_BITSLICES 128
-#else // MMX or SSE
+#else // MMX or SSE or NOSIMD
 #define MAX_BITSLICES 64
 #endif
 
@@ -117,6 +117,9 @@ typedef union {
 #elif defined (__MMX__) 
 #define BITSLICE_TEST_NONCES bitslice_test_nonces_MMX
 #define CRACK_STATES_BITSLICED crack_states_bitsliced_MMX
+#else
+#define BITSLICE_TEST_NONCES bitslice_test_nonces_NOSIMD
+#define CRACK_STATES_BITSLICED crack_states_bitsliced_NOSIMD
 #endif
 
 // typedefs and declaration of functions:
@@ -126,6 +129,7 @@ crack_states_bitsliced_t crack_states_bitsliced_AVX2;
 crack_states_bitsliced_t crack_states_bitsliced_AVX;
 crack_states_bitsliced_t crack_states_bitsliced_SSE2;
 crack_states_bitsliced_t crack_states_bitsliced_MMX;
+crack_states_bitsliced_t crack_states_bitsliced_NOSIMD;
 crack_states_bitsliced_t crack_states_bitsliced_dispatch;
 
 typedef void bitslice_test_nonces_t(uint32_t, uint32_t*, uint8_t*);
@@ -134,6 +138,7 @@ bitslice_test_nonces_t bitslice_test_nonces_AVX2;
 bitslice_test_nonces_t bitslice_test_nonces_AVX;
 bitslice_test_nonces_t bitslice_test_nonces_SSE2;
 bitslice_test_nonces_t bitslice_test_nonces_MMX;
+bitslice_test_nonces_t bitslice_test_nonces_NOSIMD;
 bitslice_test_nonces_t bitslice_test_nonces_dispatch;
 
 #ifdef _WIN32
@@ -144,7 +149,6 @@ bitslice_test_nonces_t bitslice_test_nonces_dispatch;
 #define free_bitslice(x) free(x)
 #endif
 
-#if defined (__MMX__)		// (including more sophisticated instruction sets)
 typedef enum {
 	EVEN_STATE = 0,
 	ODD_STATE = 1
@@ -523,7 +527,7 @@ out:
 #endif	
     return key;
 }
-#endif
+
 
 
 #ifndef __MMX__
@@ -534,6 +538,7 @@ bitslice_test_nonces_t *bitslice_test_nonces_function_p = &bitslice_test_nonces_
 
 // determine the available instruction set at runtime and call the correct function
 const uint64_t crack_states_bitsliced_dispatch(uint32_t cuid, uint8_t *best_first_bytes, statelist_t *p, uint32_t *keys_found, uint64_t *num_keys_tested, uint32_t nonces_to_bruteforce, uint8_t *bf_test_nonce_2nd_byte, noncelist_t *nonces) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2) 
 	if (__builtin_cpu_supports("avx512f")) crack_states_bitsliced_function_p = &crack_states_bitsliced_AVX512;
 	else if (__builtin_cpu_supports("avx2")) crack_states_bitsliced_function_p = &crack_states_bitsliced_AVX2;
@@ -543,15 +548,16 @@ const uint64_t crack_states_bitsliced_dispatch(uint32_t cuid, uint8_t *best_firs
 	else if (__builtin_cpu_supports("avx")) crack_states_bitsliced_function_p = &crack_states_bitsliced_AVX;
 	else if (__builtin_cpu_supports("sse2")) crack_states_bitsliced_function_p = &crack_states_bitsliced_SSE2;
 	else if (__builtin_cpu_supports("mmx")) crack_states_bitsliced_function_p = &crack_states_bitsliced_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		crack_states_bitsliced_function_p = &crack_states_bitsliced_NOSIMD;
+
     // call the most optimized function for this CPU
     return (*crack_states_bitsliced_function_p)(cuid, best_first_bytes, p, keys_found, num_keys_tested, nonces_to_bruteforce, bf_test_nonce_2nd_byte, nonces);
 }
 
 void bitslice_test_nonces_dispatch(uint32_t nonces_to_bruteforce, uint32_t *bf_test_nonce, uint8_t *bf_test_nonce_par) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) bitslice_test_nonces_function_p = &bitslice_test_nonces_AVX512;
 	else if (__builtin_cpu_supports("avx2")) bitslice_test_nonces_function_p = &bitslice_test_nonces_AVX2;
@@ -561,10 +567,10 @@ void bitslice_test_nonces_dispatch(uint32_t nonces_to_bruteforce, uint32_t *bf_t
 	else if (__builtin_cpu_supports("avx")) bitslice_test_nonces_function_p = &bitslice_test_nonces_AVX;
 	else if (__builtin_cpu_supports("sse2")) bitslice_test_nonces_function_p = &bitslice_test_nonces_SSE2;
 	else if (__builtin_cpu_supports("mmx")) bitslice_test_nonces_function_p = &bitslice_test_nonces_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		bitslice_test_nonces_function_p = &bitslice_test_nonces_NOSIMD;
+
     // call the most optimized function for this CPU
     (*bitslice_test_nonces_function_p)(nonces_to_bruteforce, bf_test_nonce, bf_test_nonce_par);
 }

--- a/client/hardnested/hardnested_bitarray_core.c
+++ b/client/hardnested/hardnested_bitarray_core.c
@@ -23,16 +23,6 @@
 #include <stdlib.h>
 #include <malloc.h>
 
-// #include <stdint.h>
-// #include <stdbool.h>
-// #include <stdlib.h>
-// #include <stdio.h>
-// #include <malloc.h>
-// #include <string.h>
-// #include "crapto1/crapto1.h"
-// #include "parity.h"
-
-
 // this needs to be compiled several times for each instruction set. 
 // For each instruction set, define a dedicated function name:
 #if defined (__AVX512F__)
@@ -105,36 +95,50 @@
 #define COUNT_BITARRAY_AND2 count_bitarray_AND2_MMX
 #define COUNT_BITARRAY_AND3 count_bitarray_AND3_MMX
 #define COUNT_BITARRAY_AND4 count_bitarray_AND4_MMX
+#else
+#define MALLOC_BITARRAY malloc_bitarray_NOSIMD
+#define FREE_BITARRAY free_bitarray_NOSIMD
+#define BITCOUNT bitcount_NOSIMD
+#define COUNT_STATES count_states_NOSIMD
+#define BITARRAY_AND bitarray_AND_NOSIMD
+#define BITARRAY_LOW20_AND bitarray_low20_AND_NOSIMD
+#define COUNT_BITARRAY_AND count_bitarray_AND_NOSIMD
+#define COUNT_BITARRAY_LOW20_AND count_bitarray_low20_AND_NOSIMD
+#define BITARRAY_AND4 bitarray_AND4_NOSIMD
+#define BITARRAY_OR bitarray_OR_NOSIMD
+#define COUNT_BITARRAY_AND2 count_bitarray_AND2_NOSIMD
+#define COUNT_BITARRAY_AND3 count_bitarray_AND3_NOSIMD
+#define COUNT_BITARRAY_AND4 count_bitarray_AND4_NOSIMD
 #endif
 
 
 // typedefs and declaration of functions:
 typedef uint32_t* malloc_bitarray_t(uint32_t);
-malloc_bitarray_t malloc_bitarray_AVX512, malloc_bitarray_AVX2, malloc_bitarray_AVX, malloc_bitarray_SSE2, malloc_bitarray_MMX, malloc_bitarray_dispatch;
+malloc_bitarray_t malloc_bitarray_AVX512, malloc_bitarray_AVX2, malloc_bitarray_AVX, malloc_bitarray_SSE2, malloc_bitarray_MMX, malloc_bitarray_NOSIMD, malloc_bitarray_dispatch;
 typedef void free_bitarray_t(uint32_t*);
-free_bitarray_t free_bitarray_AVX512, free_bitarray_AVX2, free_bitarray_AVX, free_bitarray_SSE2, free_bitarray_MMX, free_bitarray_dispatch;
+free_bitarray_t free_bitarray_AVX512, free_bitarray_AVX2, free_bitarray_AVX, free_bitarray_SSE2, free_bitarray_MMX, free_bitarray_NOSIMD, free_bitarray_dispatch;
 typedef uint32_t bitcount_t(uint32_t);
-bitcount_t bitcount_AVX512, bitcount_AVX2, bitcount_AVX, bitcount_SSE2, bitcount_MMX, bitcount_dispatch;
+bitcount_t bitcount_AVX512, bitcount_AVX2, bitcount_AVX, bitcount_SSE2, bitcount_MMX, bitcount_NOSIMD, bitcount_dispatch;
 typedef uint32_t count_states_t(uint32_t*);
-count_states_t count_states_AVX512, count_states_AVX2, count_states_AVX, count_states_SSE2, count_states_MMX, count_states_dispatch;
+count_states_t count_states_AVX512, count_states_AVX2, count_states_AVX, count_states_SSE2, count_states_MMX, count_states_NOSIMD, count_states_dispatch;
 typedef void bitarray_AND_t(uint32_t[], uint32_t[]);
-bitarray_AND_t bitarray_AND_AVX512, bitarray_AND_AVX2, bitarray_AND_AVX, bitarray_AND_SSE2, bitarray_AND_MMX, bitarray_AND_dispatch;
+bitarray_AND_t bitarray_AND_AVX512, bitarray_AND_AVX2, bitarray_AND_AVX, bitarray_AND_SSE2, bitarray_AND_MMX, bitarray_AND_NOSIMD, bitarray_AND_dispatch;
 typedef void bitarray_low20_AND_t(uint32_t*, uint32_t*);
-bitarray_low20_AND_t bitarray_low20_AND_AVX512, bitarray_low20_AND_AVX2, bitarray_low20_AND_AVX, bitarray_low20_AND_SSE2, bitarray_low20_AND_MMX, bitarray_low20_AND_dispatch;
+bitarray_low20_AND_t bitarray_low20_AND_AVX512, bitarray_low20_AND_AVX2, bitarray_low20_AND_AVX, bitarray_low20_AND_SSE2, bitarray_low20_AND_MMX, bitarray_low20_AND_NOSIMD, bitarray_low20_AND_dispatch;
 typedef uint32_t count_bitarray_AND_t(uint32_t*, uint32_t*);
-count_bitarray_AND_t count_bitarray_AND_AVX512, count_bitarray_AND_AVX2, count_bitarray_AND_AVX, count_bitarray_AND_SSE2, count_bitarray_AND_MMX, count_bitarray_AND_dispatch;
+count_bitarray_AND_t count_bitarray_AND_AVX512, count_bitarray_AND_AVX2, count_bitarray_AND_AVX, count_bitarray_AND_SSE2, count_bitarray_AND_MMX, count_bitarray_AND_NOSIMD, count_bitarray_AND_dispatch;
 typedef uint32_t count_bitarray_low20_AND_t(uint32_t*, uint32_t*);
-count_bitarray_low20_AND_t count_bitarray_low20_AND_AVX512, count_bitarray_low20_AND_AVX2, count_bitarray_low20_AND_AVX, count_bitarray_low20_AND_SSE2, count_bitarray_low20_AND_MMX, count_bitarray_low20_AND_dispatch;
+count_bitarray_low20_AND_t count_bitarray_low20_AND_AVX512, count_bitarray_low20_AND_AVX2, count_bitarray_low20_AND_AVX, count_bitarray_low20_AND_SSE2, count_bitarray_low20_AND_MMX, count_bitarray_low20_AND_NOSIMD, count_bitarray_low20_AND_dispatch;
 typedef void bitarray_AND4_t(uint32_t*, uint32_t*, uint32_t*, uint32_t*);
-bitarray_AND4_t bitarray_AND4_AVX512, bitarray_AND4_AVX2, bitarray_AND4_AVX, bitarray_AND4_SSE2, bitarray_AND4_MMX, bitarray_AND4_dispatch;
+bitarray_AND4_t bitarray_AND4_AVX512, bitarray_AND4_AVX2, bitarray_AND4_AVX, bitarray_AND4_SSE2, bitarray_AND4_MMX, bitarray_AND4_NOSIMD, bitarray_AND4_dispatch;
 typedef void bitarray_OR_t(uint32_t[], uint32_t[]);
-bitarray_OR_t bitarray_OR_AVX512, bitarray_OR_AVX2, bitarray_OR_AVX, bitarray_OR_SSE2, bitarray_OR_MMX, bitarray_OR_dispatch;
+bitarray_OR_t bitarray_OR_AVX512, bitarray_OR_AVX2, bitarray_OR_AVX, bitarray_OR_SSE2, bitarray_OR_MMX, bitarray_OR_NOSIMD, bitarray_OR_dispatch;
 typedef uint32_t count_bitarray_AND2_t(uint32_t*, uint32_t*);
-count_bitarray_AND2_t count_bitarray_AND2_AVX512, count_bitarray_AND2_AVX2, count_bitarray_AND2_AVX, count_bitarray_AND2_SSE2, count_bitarray_AND2_MMX, count_bitarray_AND2_dispatch;
+count_bitarray_AND2_t count_bitarray_AND2_AVX512, count_bitarray_AND2_AVX2, count_bitarray_AND2_AVX, count_bitarray_AND2_SSE2, count_bitarray_AND2_MMX, count_bitarray_AND2_NOSIMD, count_bitarray_AND2_dispatch;
 typedef uint32_t count_bitarray_AND3_t(uint32_t*, uint32_t*, uint32_t*);
-count_bitarray_AND3_t count_bitarray_AND3_AVX512, count_bitarray_AND3_AVX2, count_bitarray_AND3_AVX, count_bitarray_AND3_SSE2, count_bitarray_AND3_MMX, count_bitarray_AND3_dispatch;
+count_bitarray_AND3_t count_bitarray_AND3_AVX512, count_bitarray_AND3_AVX2, count_bitarray_AND3_AVX, count_bitarray_AND3_SSE2, count_bitarray_AND3_MMX, count_bitarray_AND3_NOSIMD, count_bitarray_AND3_dispatch;
 typedef uint32_t count_bitarray_AND4_t(uint32_t*, uint32_t*, uint32_t*, uint32_t*);
-count_bitarray_AND4_t count_bitarray_AND4_AVX512, count_bitarray_AND4_AVX2, count_bitarray_AND4_AVX, count_bitarray_AND4_SSE2, count_bitarray_AND4_MMX, count_bitarray_AND4_dispatch;
+count_bitarray_AND4_t count_bitarray_AND4_AVX512, count_bitarray_AND4_AVX2, count_bitarray_AND4_AVX, count_bitarray_AND4_SSE2, count_bitarray_AND4_MMX, count_bitarray_AND4_NOSIMD, count_bitarray_AND4_dispatch;
 
 
 inline uint32_t *MALLOC_BITARRAY(uint32_t x)
@@ -285,6 +289,7 @@ inline uint32_t COUNT_BITARRAY_AND4(uint32_t *restrict A, uint32_t *restrict B, 
 	return count;
 }
 
+
 #ifndef __MMX__
 
 // pointers to functions:
@@ -304,6 +309,7 @@ count_bitarray_AND4_t *count_bitarray_AND4_function_p = &count_bitarray_AND4_dis
 
 // determine the available instruction set at runtime and call the correct function
 uint32_t *malloc_bitarray_dispatch(uint32_t x) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) malloc_bitarray_function_p = &malloc_bitarray_AVX512;
 	else if (__builtin_cpu_supports("avx2")) malloc_bitarray_function_p = &malloc_bitarray_AVX2;
@@ -313,15 +319,16 @@ uint32_t *malloc_bitarray_dispatch(uint32_t x) {
 	else if (__builtin_cpu_supports("avx")) malloc_bitarray_function_p = &malloc_bitarray_AVX;
 	else if (__builtin_cpu_supports("sse2")) malloc_bitarray_function_p = &malloc_bitarray_SSE2;
 	else if (__builtin_cpu_supports("mmx")) malloc_bitarray_function_p = &malloc_bitarray_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif		
+		malloc_bitarray_function_p = &malloc_bitarray_NOSIMD;
+
     // call the most optimized function for this CPU
     return (*malloc_bitarray_function_p)(x);
 }
 
 void free_bitarray_dispatch(uint32_t *x) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) free_bitarray_function_p = &free_bitarray_AVX512;
 	else if (__builtin_cpu_supports("avx2")) free_bitarray_function_p = &free_bitarray_AVX2;
@@ -331,15 +338,16 @@ void free_bitarray_dispatch(uint32_t *x) {
 	else if (__builtin_cpu_supports("avx")) free_bitarray_function_p = &free_bitarray_AVX;
 	else if (__builtin_cpu_supports("sse2")) free_bitarray_function_p = &free_bitarray_SSE2;
 	else if (__builtin_cpu_supports("mmx")) free_bitarray_function_p = &free_bitarray_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else 
+#endif
+		free_bitarray_function_p = &free_bitarray_NOSIMD;
+
     // call the most optimized function for this CPU
     (*free_bitarray_function_p)(x);
 }
 
 uint32_t bitcount_dispatch(uint32_t a) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) bitcount_function_p = &bitcount_AVX512;
 	else if (__builtin_cpu_supports("avx2")) bitcount_function_p = &bitcount_AVX2;
@@ -349,15 +357,16 @@ uint32_t bitcount_dispatch(uint32_t a) {
 	else if (__builtin_cpu_supports("avx")) bitcount_function_p = &bitcount_AVX;
 	else if (__builtin_cpu_supports("sse2")) bitcount_function_p = &bitcount_SSE2;
 	else if (__builtin_cpu_supports("mmx")) bitcount_function_p = &bitcount_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		bitcount_function_p = &bitcount_NOSIMD;
+
     // call the most optimized function for this CPU
     return (*bitcount_function_p)(a);
 }
 
 uint32_t count_states_dispatch(uint32_t *bitarray) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) count_states_function_p = &count_states_AVX512;
 	else if (__builtin_cpu_supports("avx2")) count_states_function_p = &count_states_AVX2;
@@ -367,15 +376,16 @@ uint32_t count_states_dispatch(uint32_t *bitarray) {
 	else if (__builtin_cpu_supports("avx")) count_states_function_p = &count_states_AVX;
 	else if (__builtin_cpu_supports("sse2")) count_states_function_p = &count_states_SSE2;
 	else if (__builtin_cpu_supports("mmx")) count_states_function_p = &count_states_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else 
+#endif
+		count_states_function_p = &count_states_NOSIMD;
+
     // call the most optimized function for this CPU
     return (*count_states_function_p)(bitarray);
 }
 
 void bitarray_AND_dispatch(uint32_t *A, uint32_t *B) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) bitarray_AND_function_p = &bitarray_AND_AVX512;
 	else if (__builtin_cpu_supports("avx2")) bitarray_AND_function_p = &bitarray_AND_AVX2;
@@ -385,15 +395,16 @@ void bitarray_AND_dispatch(uint32_t *A, uint32_t *B) {
 	else if (__builtin_cpu_supports("avx")) bitarray_AND_function_p = &bitarray_AND_AVX;
 	else if (__builtin_cpu_supports("sse2")) bitarray_AND_function_p = &bitarray_AND_SSE2;
 	else if (__builtin_cpu_supports("mmx")) bitarray_AND_function_p = &bitarray_AND_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		bitarray_AND_function_p = &bitarray_AND_NOSIMD;
+
     // call the most optimized function for this CPU
     (*bitarray_AND_function_p)(A,B);
 }
 
 void bitarray_low20_AND_dispatch(uint32_t *A, uint32_t *B) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) bitarray_low20_AND_function_p = &bitarray_low20_AND_AVX512;
 	else if (__builtin_cpu_supports("avx2")) bitarray_low20_AND_function_p = &bitarray_low20_AND_AVX2;
@@ -403,15 +414,16 @@ void bitarray_low20_AND_dispatch(uint32_t *A, uint32_t *B) {
 	else if (__builtin_cpu_supports("avx")) bitarray_low20_AND_function_p = &bitarray_low20_AND_AVX;
 	else if (__builtin_cpu_supports("sse2")) bitarray_low20_AND_function_p = &bitarray_low20_AND_SSE2;
 	else if (__builtin_cpu_supports("mmx")) bitarray_low20_AND_function_p = &bitarray_low20_AND_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		bitarray_low20_AND_function_p = &bitarray_low20_AND_NOSIMD;
+
     // call the most optimized function for this CPU
     (*bitarray_low20_AND_function_p)(A, B);
 }
 
 uint32_t count_bitarray_AND_dispatch(uint32_t *A, uint32_t *B) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) count_bitarray_AND_function_p = &count_bitarray_AND_AVX512;
 	else if (__builtin_cpu_supports("avx2")) count_bitarray_AND_function_p = &count_bitarray_AND_AVX2;
@@ -421,15 +433,16 @@ uint32_t count_bitarray_AND_dispatch(uint32_t *A, uint32_t *B) {
 	else if (__builtin_cpu_supports("avx")) count_bitarray_AND_function_p = &count_bitarray_AND_AVX;
 	else if (__builtin_cpu_supports("sse2")) count_bitarray_AND_function_p = &count_bitarray_AND_SSE2;
 	else if (__builtin_cpu_supports("mmx")) count_bitarray_AND_function_p = &count_bitarray_AND_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		count_bitarray_AND_function_p = &count_bitarray_AND_NOSIMD;
+
     // call the most optimized function for this CPU
     return (*count_bitarray_AND_function_p)(A, B);
 }
 
 uint32_t count_bitarray_low20_AND_dispatch(uint32_t *A, uint32_t *B) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) count_bitarray_low20_AND_function_p = &count_bitarray_low20_AND_AVX512;
 	else if (__builtin_cpu_supports("avx2")) count_bitarray_low20_AND_function_p = &count_bitarray_low20_AND_AVX2;
@@ -439,15 +452,16 @@ uint32_t count_bitarray_low20_AND_dispatch(uint32_t *A, uint32_t *B) {
 	else if (__builtin_cpu_supports("avx")) count_bitarray_low20_AND_function_p = &count_bitarray_low20_AND_AVX;
 	else if (__builtin_cpu_supports("sse2")) count_bitarray_low20_AND_function_p = &count_bitarray_low20_AND_SSE2;
 	else if (__builtin_cpu_supports("mmx")) count_bitarray_low20_AND_function_p = &count_bitarray_low20_AND_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		count_bitarray_low20_AND_function_p = &count_bitarray_low20_AND_NOSIMD;
+
     // call the most optimized function for this CPU
     return (*count_bitarray_low20_AND_function_p)(A, B);
 }
 
 void bitarray_AND4_dispatch(uint32_t *A, uint32_t *B, uint32_t *C, uint32_t *D) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) bitarray_AND4_function_p = &bitarray_AND4_AVX512;
 	else if (__builtin_cpu_supports("avx2")) bitarray_AND4_function_p = &bitarray_AND4_AVX2;
@@ -457,15 +471,16 @@ void bitarray_AND4_dispatch(uint32_t *A, uint32_t *B, uint32_t *C, uint32_t *D) 
 	else if (__builtin_cpu_supports("avx")) bitarray_AND4_function_p = &bitarray_AND4_AVX;
 	else if (__builtin_cpu_supports("sse2")) bitarray_AND4_function_p = &bitarray_AND4_SSE2;
 	else if (__builtin_cpu_supports("mmx")) bitarray_AND4_function_p = &bitarray_AND4_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		bitarray_AND4_function_p = &bitarray_AND4_NOSIMD;
+
     // call the most optimized function for this CPU
     (*bitarray_AND4_function_p)(A, B, C, D);
 }
 
 void bitarray_OR_dispatch(uint32_t *A, uint32_t *B) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) bitarray_OR_function_p = &bitarray_OR_AVX512;
 	else if (__builtin_cpu_supports("avx2")) bitarray_OR_function_p = &bitarray_OR_AVX2;
@@ -475,15 +490,16 @@ void bitarray_OR_dispatch(uint32_t *A, uint32_t *B) {
 	else if (__builtin_cpu_supports("avx")) bitarray_OR_function_p = &bitarray_OR_AVX;
 	else if (__builtin_cpu_supports("sse2")) bitarray_OR_function_p = &bitarray_OR_SSE2;
 	else if (__builtin_cpu_supports("mmx")) bitarray_OR_function_p = &bitarray_OR_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		bitarray_OR_function_p = &bitarray_OR_NOSIMD;
+
     // call the most optimized function for this CPU
     (*bitarray_OR_function_p)(A,B);
 }
 
 uint32_t count_bitarray_AND2_dispatch(uint32_t *A, uint32_t *B) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) count_bitarray_AND2_function_p = &count_bitarray_AND2_AVX512;
 	else if (__builtin_cpu_supports("avx2")) count_bitarray_AND2_function_p = &count_bitarray_AND2_AVX2;
@@ -493,15 +509,16 @@ uint32_t count_bitarray_AND2_dispatch(uint32_t *A, uint32_t *B) {
 	else if (__builtin_cpu_supports("avx")) count_bitarray_AND2_function_p = &count_bitarray_AND2_AVX;
 	else if (__builtin_cpu_supports("sse2")) count_bitarray_AND2_function_p = &count_bitarray_AND2_SSE2;
 	else if (__builtin_cpu_supports("mmx")) count_bitarray_AND2_function_p = &count_bitarray_AND2_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		count_bitarray_AND2_function_p = &count_bitarray_AND2_NOSIMD;
+
     // call the most optimized function for this CPU
     return (*count_bitarray_AND2_function_p)(A, B);
 }
 
 uint32_t count_bitarray_AND3_dispatch(uint32_t *A, uint32_t *B, uint32_t *C) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) count_bitarray_AND3_function_p = &count_bitarray_AND3_AVX512;
 	else if (__builtin_cpu_supports("avx2")) count_bitarray_AND3_function_p = &count_bitarray_AND3_AVX2;
@@ -511,15 +528,16 @@ uint32_t count_bitarray_AND3_dispatch(uint32_t *A, uint32_t *B, uint32_t *C) {
 	else if (__builtin_cpu_supports("avx")) count_bitarray_AND3_function_p = &count_bitarray_AND3_AVX;
 	else if (__builtin_cpu_supports("sse2")) count_bitarray_AND3_function_p = &count_bitarray_AND3_SSE2;
 	else if (__builtin_cpu_supports("mmx")) count_bitarray_AND3_function_p = &count_bitarray_AND3_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		count_bitarray_AND3_function_p = &count_bitarray_AND3_NOSIMD;
+
     // call the most optimized function for this CPU
     return (*count_bitarray_AND3_function_p)(A, B, C);
 }
 
 uint32_t count_bitarray_AND4_dispatch(uint32_t *A, uint32_t *B, uint32_t *C, uint32_t *D) {
+#if defined (__i386__) || defined (__x86_64__)	
 	#if (__GNUC__ >= 5) && (__GNUC__ > 5 || __GNUC_MINOR__ > 2)
 	if (__builtin_cpu_supports("avx512f")) count_bitarray_AND4_function_p = &count_bitarray_AND4_AVX512;
 	else if (__builtin_cpu_supports("avx2")) count_bitarray_AND4_function_p = &count_bitarray_AND4_AVX2;
@@ -529,10 +547,10 @@ uint32_t count_bitarray_AND4_dispatch(uint32_t *A, uint32_t *B, uint32_t *C, uin
 	else if (__builtin_cpu_supports("avx")) count_bitarray_AND4_function_p = &count_bitarray_AND4_AVX;
 	else if (__builtin_cpu_supports("sse2")) count_bitarray_AND4_function_p = &count_bitarray_AND4_SSE2;
 	else if (__builtin_cpu_supports("mmx")) count_bitarray_AND4_function_p = &count_bitarray_AND4_MMX;
-    else {
-        printf("\nFatal: you need at least a CPU with MMX instruction set support. Aborting...\n");
-        exit(5);
-    }
+    else
+#endif
+		count_bitarray_AND4_function_p = &count_bitarray_AND4_NOSIMD;
+
     // call the most optimized function for this CPU
     return (*count_bitarray_AND4_function_p)(A, B, C, D);
 }


### PR DESCRIPTION
fix compile errors on non-Intel CPUs (issue #303):
- client/Makefile: don't compile for different SIMD instruction sets if non-Intel
- hardnested cores: provide non-SIMD versions of core functions