### PR TITLE
a few coverity scan bug fixes

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2418,8 +2418,8 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 	//Here, we collect UID,sector,keytype,NT,AR,NR,NT2,AR2,NR2
 	// This will be used in the reader-only attack.
 
-	//allow collecting up to 8 sets of nonces to allow recovery of up to 8 keys
-	#define ATTACK_KEY_COUNT 8 // keep same as define in cmdhfmf.c -> readerAttack()
+	//allow collecting up to 7 sets of nonces to allow recovery of up to 7 keys
+	#define ATTACK_KEY_COUNT 7 // keep same as define in cmdhfmf.c -> readerAttack() (Cannot be more than 7)
 	nonces_t ar_nr_resp[ATTACK_KEY_COUNT*2]; //*2 for 2 separate attack types (nml, moebius)
 	memset(ar_nr_resp, 0x00, sizeof(ar_nr_resp));
 

--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -661,7 +661,7 @@ int CmdHF14ACmdRaw(const char *cmd) {
 						PrintAndLog("Buffer is full, we can't add CRC to your data");
 					break;
 				} else {
-					datalen++
+					datalen++;
 				}
 			}
 			continue;

--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -561,72 +561,72 @@ int CmdHF14ASnoop(const char *Cmd) {
 		if (ctmp == 'r' || ctmp == 'R') param |= 0x02;
 	}
 
-  UsbCommand c = {CMD_SNOOP_ISO_14443a, {param, 0, 0}};
-  SendCommand(&c);
-  return 0;
+	UsbCommand c = {CMD_SNOOP_ISO_14443a, {param, 0, 0}};
+	SendCommand(&c);
+	return 0;
 }
 
 
 int CmdHF14ACmdRaw(const char *cmd) {
-    UsbCommand c = {CMD_READER_ISO_14443a, {0, 0, 0}};
-    bool reply=1;
-    bool crc = false;
-    bool power = false;
-    bool active = false;
-    bool active_select = false;
-    uint16_t numbits = 0;
+	UsbCommand c = {CMD_READER_ISO_14443a, {0, 0, 0}};
+	bool reply=1;
+	bool crc = false;
+	bool power = false;
+	bool active = false;
+	bool active_select = false;
+	uint16_t numbits = 0;
 	bool bTimeout = false;
 	uint32_t timeout = 0;
 	bool topazmode = false;
-    char buf[5]="";
-    int i = 0;
-    uint8_t data[USB_CMD_DATA_SIZE];
+	char buf[5]="";
+	int i = 0;
+	uint8_t data[USB_CMD_DATA_SIZE];
 	uint16_t datalen = 0;
 	uint32_t temp;
 
-    if (strlen(cmd)<2) {
-        PrintAndLog("Usage: hf 14a raw [-r] [-c] [-p] [-f] [-b] [-t] <number of bits> <0A 0B 0C ... hex>");
-        PrintAndLog("       -r    do not read response");
-        PrintAndLog("       -c    calculate and append CRC");
-        PrintAndLog("       -p    leave the signal field ON after receive");
-        PrintAndLog("       -a    active signal field ON without select");
-        PrintAndLog("       -s    active signal field ON with select");
-        PrintAndLog("       -b    number of bits to send. Useful for send partial byte");
+	if (strlen(cmd)<2) {
+		PrintAndLog("Usage: hf 14a raw [-r] [-c] [-p] [-f] [-b] [-t] <number of bits> <0A 0B 0C ... hex>");
+		PrintAndLog("       -r    do not read response");
+		PrintAndLog("       -c    calculate and append CRC");
+		PrintAndLog("       -p    leave the signal field ON after receive");
+		PrintAndLog("       -a    active signal field ON without select");
+		PrintAndLog("       -s    active signal field ON with select");
+		PrintAndLog("       -b    number of bits to send. Useful for send partial byte");
 		PrintAndLog("       -t    timeout in ms");
 		PrintAndLog("       -T    use Topaz protocol to send command");
-        return 0;
-    }
+		return 0;
+	}
 
-	
-    // strip
-    while (*cmd==' ' || *cmd=='\t') cmd++;
 
-    while (cmd[i]!='\0') {
-        if (cmd[i]==' ' || cmd[i]=='\t') { i++; continue; }
-        if (cmd[i]=='-') {
-            switch (cmd[i+1]) {
-                case 'r': 
-                    reply = false;
-                    break;
-                case 'c':
-                    crc = true;
-                    break;
-                case 'p':
-                    power = true;
-                    break;
-                case 'a':
-                    active = true;
-                    break;
-                case 's':
-                    active_select = true;
-                    break;
-                case 'b': 
-                    sscanf(cmd+i+2,"%d",&temp);
-                    numbits = temp & 0xFFFF;
-                    i+=3;
-                    while(cmd[i]!=' ' && cmd[i]!='\0') { i++; }
-                    i-=2;
-                    break;
+	// strip
+	while (*cmd==' ' || *cmd=='\t') cmd++;
+
+	while (cmd[i]!='\0') {
+		if (cmd[i]==' ' || cmd[i]=='\t') { i++; continue; }
+		if (cmd[i]=='-') {
+			switch (cmd[i+1]) {
+				case 'r': 
+					reply = false;
+					break;
+				case 'c':
+					crc = true;
+					break;
+				case 'p':
+					power = true;
+					break;
+				case 'a':
+					active = true;
+					break;
+				case 's':
+					active_select = true;
+					break;
+				case 'b': 
+					sscanf(cmd+i+2,"%d",&temp);
+					numbits = temp & 0xFFFF;
+					i+=3;
+					while(cmd[i]!=' ' && cmd[i]!='\0') { i++; }
+					i-=2;
+					break;
 				case 't':
 					bTimeout = true;
 					sscanf(cmd+i+2,"%d",&temp);
@@ -635,93 +635,95 @@ int CmdHF14ACmdRaw(const char *cmd) {
 					while(cmd[i]!=' ' && cmd[i]!='\0') { i++; }
 					i-=2;
 					break;
-                case 'T':
+				case 'T':
 					topazmode = true;
 					break;
-                default:
-                    PrintAndLog("Invalid option");
-                    return 0;
-            }
-            i+=2;
-            continue;
-        }
-        if ((cmd[i]>='0' && cmd[i]<='9') ||
-            (cmd[i]>='a' && cmd[i]<='f') ||
-            (cmd[i]>='A' && cmd[i]<='F') ) {
-            buf[strlen(buf)+1]=0;
-            buf[strlen(buf)]=cmd[i];
-            i++;
+				default:
+					PrintAndLog("Invalid option");
+					return 0;
+			}
+			i+=2;
+			continue;
+		}
+		if ((cmd[i]>='0' && cmd[i]<='9') ||
+		    (cmd[i]>='a' && cmd[i]<='f') ||
+		    (cmd[i]>='A' && cmd[i]<='F') ) {
+			buf[strlen(buf)+1]=0;
+			buf[strlen(buf)]=cmd[i];
+			i++;
 
-            if (strlen(buf)>=2) {
-                sscanf(buf,"%x",&temp);
-                data[datalen]=(uint8_t)(temp & 0xff);
-                *buf=0;
-				if (++datalen>sizeof(data)){
+			if (strlen(buf)>=2) {
+				sscanf(buf,"%x",&temp);
+				data[datalen]=(uint8_t)(temp & 0xff);
+				*buf=0;
+				if (datalen > sizeof(data)-1) {
 					if (crc)
 						PrintAndLog("Buffer is full, we can't add CRC to your data");
 					break;
+				} else {
+					datalen++
 				}
-            }
-            continue;
-        }
-        PrintAndLog("Invalid char on input");
-        return 0;
-    }
+			}
+			continue;
+		}
+		PrintAndLog("Invalid char on input");
+		return 0;
+	}
 
-    if(crc && datalen>0 && datalen<sizeof(data)-2)
-    {
-        uint8_t first, second;
+	if(crc && datalen>0 && datalen<sizeof(data)-2)
+	{
+		uint8_t first, second;
 		if (topazmode) {
 			ComputeCrc14443(CRC_14443_B, data, datalen, &first, &second);
 		} else {
 			ComputeCrc14443(CRC_14443_A, data, datalen, &first, &second);
 		}
-        data[datalen++] = first;
-        data[datalen++] = second;
-    }
+		data[datalen++] = first;
+		data[datalen++] = second;
+	}
 
-    if(active || active_select)
-    {
-        c.arg[0] |= ISO14A_CONNECT;
-        if(active)
-            c.arg[0] |= ISO14A_NO_SELECT;
-    }
+	if(active || active_select)
+	{
+		c.arg[0] |= ISO14A_CONNECT;
+		if(active)
+			c.arg[0] |= ISO14A_NO_SELECT;
+	}
 
 	if(bTimeout){
-	    #define MAX_TIMEOUT 40542464 	// = (2^32-1) * (8*16) / 13560000Hz * 1000ms/s
-        c.arg[0] |= ISO14A_SET_TIMEOUT;
-        if(timeout > MAX_TIMEOUT) {
-            timeout = MAX_TIMEOUT;
-            PrintAndLog("Set timeout to 40542 seconds (11.26 hours). The max we can wait for response");
-        }
+		#define MAX_TIMEOUT 40542464 	// = (2^32-1) * (8*16) / 13560000Hz * 1000ms/s
+		c.arg[0] |= ISO14A_SET_TIMEOUT;
+		if(timeout > MAX_TIMEOUT) {
+			timeout = MAX_TIMEOUT;
+			PrintAndLog("Set timeout to 40542 seconds (11.26 hours). The max we can wait for response");
+		}
 		c.arg[2] = 13560000 / 1000 / (8*16) * timeout; // timeout in ETUs (time to transfer 1 bit, approx. 9.4 us)
 	}
 
-    if(power) {
-        c.arg[0] |= ISO14A_NO_DISCONNECT;
-    }
+	if(power) {
+		c.arg[0] |= ISO14A_NO_DISCONNECT;
+	}
 
 	if(datalen > 0) {
-        c.arg[0] |= ISO14A_RAW;
-    }
+		c.arg[0] |= ISO14A_RAW;
+	}
 
 	if(topazmode) {
 		c.arg[0] |= ISO14A_TOPAZMODE;
-    }
-		
-	// Max buffer is USB_CMD_DATA_SIZE
-    c.arg[1] = (datalen & 0xFFFF) | (numbits << 16);
-    memcpy(c.d.asBytes,data,datalen);
+	}
 
-    SendCommand(&c);
+	// Max buffer is USB_CMD_DATA_SIZE (512)
+	c.arg[1] = (datalen & 0xFFFF) | ((uint32_t)numbits << 16);
+	memcpy(c.d.asBytes,data,datalen);
 
-    if (reply) {
-        if(active_select)
-            waitCmd(1);
-        if(datalen>0)
-            waitCmd(0);
-    } // if reply
-    return 0;
+	SendCommand(&c);
+
+	if (reply) {
+		if(active_select)
+			waitCmd(1);
+		if(datalen>0)
+			waitCmd(0);
+	} // if reply
+	return 0;
 }
 
 

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -970,6 +970,7 @@ int CmdHF14AMfChk(const char *Cmd)
 		break;
 	default:
 		PrintAndLog("Key type must be A , B or ?");
+		free(keyBlock);
 		return 1;
 	};
 	

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -1120,7 +1120,8 @@ int CmdHF14AMfChk(const char *Cmd)
 }
 
 void readerAttack(nonces_t ar_resp[], bool setEmulatorMem, bool doStandardAttack) {
-	#define ATTACK_KEY_COUNT 8 // keep same as define in iso14443a.c -> Mifare1ksim()
+	#define ATTACK_KEY_COUNT 7 // keep same as define in iso14443a.c -> Mifare1ksim()
+	                           // cannot be more than 7 or it will overrun c.d.asBytes(512)
 	uint64_t key = 0;
 	typedef struct {
 			uint64_t keyA;

--- a/client/cmdhfmfu.c
+++ b/client/cmdhfmfu.c
@@ -1474,7 +1474,7 @@ int CmdHF14AMfucAuth(const char *Cmd){
 	//Change key to user defined one
 	if (cmdp == 'k' || cmdp == 'K'){
 		keyNo = param_get8(Cmd, 1);
-		if(keyNo > KEYS_3DES_COUNT) 
+		if(keyNo > KEYS_3DES_COUNT-1) 
 			errors = true;
 	}
 

--- a/client/cmdlfpresco.c
+++ b/client/cmdlfpresco.c
@@ -68,8 +68,8 @@ int GetWiegandFromPresco(const char *Cmd, uint32_t *sitecode, uint32_t *usercode
 				*fullcode = param_get32ex(Cmd, cmdp+1, 0, 10);
 				cmdp+=2;
 				break;
-			case 'P':
-			case 'p':
+			case 'D':
+			case 'd':
 				//param get string int param_getstr(const char *line, int paramnum, char * str)
 				stringlen = param_getstr(Cmd, cmdp+1, id);
 				if (stringlen < 2) return -1;

--- a/client/cmdlfpresco.c
+++ b/client/cmdlfpresco.c
@@ -91,7 +91,7 @@ int GetWiegandFromPresco(const char *Cmd, uint32_t *sitecode, uint32_t *usercode
 	if(cmdp == 0) errors = 1;
 
 	//Validations
-	if(errors) return -1;
+	if(errors || stringlen == 0) return -1;
 
 	if (!hex) {
 		for (int index =0; index < strlen(id); ++index) {

--- a/client/cmdlfpresco.c
+++ b/client/cmdlfpresco.c
@@ -91,7 +91,7 @@ int GetWiegandFromPresco(const char *Cmd, uint32_t *sitecode, uint32_t *usercode
 	if(cmdp == 0) errors = 1;
 
 	//Validations
-	if(errors || stringlen == 0) return -1;
+	if(errors || (stringlen == 0 && !hex) ) return -1;
 
 	if (!hex) {
 		for (int index =0; index < strlen(id); ++index) {

--- a/client/proxguiqt.h
+++ b/client/proxguiqt.h
@@ -128,7 +128,7 @@ public:
 	void run();
 private:
 	char *script_cmds_file = NULL;
-	bool usb_present = false;
+	bool usb_present;
 };
 
 #endif // PROXGUI_QT


### PR DESCRIPTION
1. mf reader attack could overload the usb packet buffer if 8 keys were found. (dropped to 7)
2. mfu authentication could take a keynumber larger than possible in buffer - fixed
3. 14a raw cmd could overloads uint16_t numbits  line 715 to signed int then to uint64_t  could cause issues. 
4. cmdhfmf line 973 exits without freeing key calloc.
5. couple bugs fixed in cmdlfpresco.c