### PR TITLE
bug:  hf mf chk - wrong size

### DIFF
--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -906,7 +906,7 @@ int CmdHF14AMfChk(const char *Cmd)
 	char filename[FILE_PATH_SIZE]={0};
 	char buf[13];
 	uint8_t *keyBlock = NULL, *p;
-	uint8_t stKeyBlock = 20;
+	uint16_t stKeyBlock = 20;
 	
 	int i, res;
 	int	keycnt = 0;


### PR DESCRIPTION
bug:  'hf mf chk' - size of keycounter variable is too small for dictionary files larger than 256rows.