### PR TITLE
OSX: Disable GNU readline-specific hack when libedit is used (fixes #110)

### DIFF
--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -109,7 +109,7 @@ Tested on OSX 10.10 Yosemite
 1 - Install Xcode and Xcode Command Line Tools
 
 2 - Install Homebrew and dependencies
-    brew install readline libusb p7zip libusb-compat wget qt5 pkgconfig
+    brew install libusb p7zip libusb-compat wget qt5 pkgconfig
 
 3 - Install DevKitARM for OSX
     Option 1:
@@ -121,8 +121,8 @@ Tested on OSX 10.10 Yosemite
 
 4 - Edit proxmark3/client/Makefile adding path to readline and qt5
 
-    LDLIBS = -L/usr/local/opt/readline/lib -L/usr/local/opt/qt5/lib -L/opt/local/lib -L/usr/local/lib ../liblua/liblua.a -lreadline -lpthread -lm
-    CFLAGS = -std=c99 -I/usr/local/opt/qt5/include -I/usr/local/opt/readline/include -I. -I../include -I../common -I../zlib -I/opt/local/include -I../liblua -Wall $(COMMON_FLAGS) -g -O4
+    LDLIBS = -L/usr/local/opt/qt5/lib -L/opt/local/lib -L/usr/local/lib ../liblua/liblua.a -lreadline -lpthread -lm
+    CFLAGS = -std=c99 -I/usr/local/opt/qt5/include -I. -I../include -I../common -I../zlib -I/opt/local/include -I../liblua -Wall $(COMMON_FLAGS) -g -O4
 
     If your old brew intallation use /usr/local/Cellar/ path replace /usr/local/opt/readline/lib with your actuall readline and qt5 path. See homebrew manuals.
 

--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -3,7 +3,7 @@ The project compiles on Linux, Mac OS X and Windows (MinGW/MSYS).
 it requires:
 - gcc >= 4.4
 - libpthread
-- libreadline
+- GNU libreadline or BSD libedit (editline)
 - libusb
 - perl
 - an ARM cross-compiler to compile the firmware
@@ -119,12 +119,10 @@ Tested on OSX 10.10 Yosemite
         brew tap nitsky/stm32
         brew install arm-none-eabi-gcc
 
-4 - Edit proxmark3/client/Makefile adding path to readline and qt5
+4 - Edit proxmark3/client/Makefile adding path qt5
 
     LDLIBS = -L/usr/local/opt/qt5/lib -L/opt/local/lib -L/usr/local/lib ../liblua/liblua.a -lreadline -lpthread -lm
     CFLAGS = -std=c99 -I/usr/local/opt/qt5/include -I. -I../include -I../common -I../zlib -I/opt/local/include -I../liblua -Wall $(COMMON_FLAGS) -g -O4
-
-    If your old brew intallation use /usr/local/Cellar/ path replace /usr/local/opt/readline/lib with your actuall readline and qt5 path. See homebrew manuals.
 
 5 - Set Environment
 

--- a/client/ui.c
+++ b/client/ui.c
@@ -48,7 +48,9 @@ void PrintAndLog(char *fmt, ...)
 			logging=0;
 		}
 	}
-	
+
+#ifdef RL_STATE_READCMD
+	// We are using GNU readline.
 	int need_hack = (rl_readline_state & RL_STATE_READCMD) > 0;
 
 	if (need_hack) {
@@ -58,6 +60,10 @@ void PrintAndLog(char *fmt, ...)
 		rl_replace_line("", 0);
 		rl_redisplay();
 	}
+#else
+	// We are using libedit (OSX), which doesn't support this flag.
+	int need_hack = 0;
+#endif
 	
 	va_start(argptr, fmt);
 	va_copy(argptr2, argptr);


### PR DESCRIPTION
This fixes up an issue with building the proxmark3 client on OSX, and allows it to build pretty much out of the box (only Xcode and arm toolchain needed) if you don't need GUI support, without installing GNU readline and doing the whole [pivoting dance](https://github.com/Proxmark/proxmark3/issues/110#issuecomment-171015752).

OSX comes with [libedit](http://thrysoee.dk/editline/) instead, which is mostly compatible and shadows GNU readline's header files.  Once built, the imports of `proxmark3` without the GUI look like (on a OSX 10.12 system):

```
$ objdump -dylibs-used -macho proxmark3
proxmark3:
	/usr/lib/libedit.3.dylib (compatibility version 2.0.0, current version 3.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.50.2)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.5.0)
```

This is a somewhat better fix for #110, and will allow readline to be removed from the dependency list of the Homebrew package.