### PR TITLE
Update hfsnoop.c

### DIFF
--- a/armsrc/hfsnoop.c
+++ b/armsrc/hfsnoop.c
@@ -2,6 +2,7 @@
 #include "apps.h"
 #include "BigBuf.h"
 #include "util.h"
+#include "usb_cdc.h"	// for usb_poll_validate_length
 
 static void RAMFUNC optimizedSnoop(void);
 


### PR DESCRIPTION
fix:  missed a include for usb_poll_validate_length