### PR TITLE
Iceman1001 patch 5

### DIFF
--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -26,6 +26,7 @@
 #include "cmdmain.h"
 #include "mifare.h"
 #include "cmdhfmfu.h"
+#include "mifarehost.h"
 
 static int CmdHelp(const char *Cmd);
 static void waitCmd(uint8_t iLen);

--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -170,9 +170,10 @@ int CmdHF14AReader(const char *Cmd)
 	PrintAndLog("ATQA : %02x %02x", card.atqa[1], card.atqa[0]);
 	PrintAndLog(" SAK : %02x [%d]", card.sak, resp.arg[0]);
 
+	bool isMifareClassic = true;
 	switch (card.sak) {
 		case 0x00: 
-
+			isMifareClassic = false;
 			//***************************************test****************
 			// disconnect
 			c.arg[0] = 0;
@@ -420,6 +421,13 @@ int CmdHF14AReader(const char *Cmd)
 	c.arg[2] = 0;
 	SendCommand(&c);
 
+	if (isMifareClassic) {		
+		if ( detect_classic_prng() )
+			PrintAndLog("Prng detection: WEAK (darkside)");
+		else
+			PrintAndLog("Prng detection: HARDEND (hardnested)");		
+	}
+	
 	return select_status;
 }
 

--- a/client/mifarehost.c
+++ b/client/mifarehost.c
@@ -820,3 +820,33 @@ int tryDecryptWord(uint32_t nt, uint32_t ar_enc, uint32_t at_enc, uint8_t *data,
 	crypto1_destroy(traceCrypto1);
 	return 0;
 }
+/* Detect Tag Prng, 
+* function performs a partial AUTH,  where it tries to authenticate against block0, key A, but only collects tag nonce.
+* the tag nonce is check to see if it has a predictable PRNG.
+* @returns 
+*	TRUE if tag uses WEAK prng (ie Darkside attack possible)
+*   FALSE is tag uses HARDEND prng (ie hardnested attack possible, with known key)
+*/
+bool detect_classic_prng(){
+
+	UsbCommand resp, respA;	
+	uint8_t cmd[] = {MIFARE_AUTH_KEYA, 0x00};
+	uint32_t flags = ISO14A_CONNECT | ISO14A_RAW | ISO14A_APPEND_CRC;
+	
+	UsbCommand cAuth = {CMD_READER_ISO_14443a, {flags, sizeof(cmd), 0}};
+	memcpy(cAuth.d.asBytes, cmd, sizeof(cmd));
+
+	clearCommandBuffer();
+	SendCommand(&cAuth);
+	WaitForResponse(CMD_ACK, &resp);
+	WaitForResponse(CMD_ACK, &respA);
+		
+	// if select tag failed.
+	if ( resp.arg[0] == 0 ) {
+		printf("Error:  selecting tag failed,  can't detect prng\n");
+		return false;
+	}
+
+	uint32_t nonce = bytes_to_num(respA.d.asBytes, respA.arg[0]);
+	return validate_prng_nonce(nonce);
+}

--- a/client/mifarehost.c
+++ b/client/mifarehost.c
@@ -22,6 +22,8 @@
 #include "ui.h"
 #include "util.h"
 #include "iso14443crc.h"
+#include "mifare.h"	// for ISO14A_CONNECT etc
+#include "protocols.h"	// for MIFARE_AUTH_KEYA
 
 // mifare tracer flags used in mfTraceDecode()
 #define TRACE_IDLE		 				0x00

--- a/client/mifarehost.h
+++ b/client/mifarehost.h
@@ -45,5 +45,5 @@ extern int isBlockTrailer(int blockN);
 extern int loadTraceCard(uint8_t *tuid);
 extern int saveTraceCard(void);
 extern int tryDecryptWord(uint32_t nt, uint32_t ar_enc, uint32_t at_enc, uint8_t *data, int len);
-
+extern bool detect_classic_prng();
 #endif

--- a/common/crapto1/crapto1.c
+++ b/common/crapto1/crapto1.c
@@ -425,6 +425,17 @@ int nonce_distance(uint32_t from, uint32_t to)
 	}
 	return (65535 + dist[to >> 16] - dist[from >> 16]) % 65535;
 }
+/** validate_prng_nonce
+ * Determine if nonce is deterministic. ie: Suspectable to Darkside attack.
+ * returns
+ *   true = weak prng
+ *   false = hardend prng
+ */
+bool validate_prng_nonce(uint32_t nonce) {
+	// init prng table:
+	nonce_distance(nonce, nonce);
+	return ((65535 - dist[nonce >> 16] + dist[nonce & 0xffff]) % 65535) == 16;
+}
 
 
 static uint32_t fastfwd[2][8] = {

--- a/common/crapto1/crapto1.h
+++ b/common/crapto1/crapto1.h
@@ -48,6 +48,7 @@ uint8_t lfsr_rollback_bit(struct Crypto1State* s, uint32_t in, int fb);
 uint8_t lfsr_rollback_byte(struct Crypto1State* s, uint32_t in, int fb);
 uint32_t lfsr_rollback_word(struct Crypto1State* s, uint32_t in, int fb);
 int nonce_distance(uint32_t from, uint32_t to);
+extern bool validate_prng_nonce(uint32_t nonce);
 #define FOREACH_VALID_NONCE(N, FILTER, FSIZE)\
 	uint32_t __n = 0,__M = 0, N = 0;\
 	int __i;\


### PR DESCRIPTION
ADD:  'hf 14a reader' - added Mifare Classic PRNG detection.
It detects if found Mifare Classic tag has a weak or hardend PRNG. Thanks to @doegox for implementing it in nfc-tools/mfoc  Its a beauty :)