### PR TITLE
Removing global context around pm3 connectivity (work in progress)

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -21,7 +21,7 @@ LDLIBS = -L/opt/local/lib -L/usr/local/lib -lreadline -lpthread -lm
 LUALIB = ../liblua/liblua.a
 LDFLAGS = $(ENV_LDFLAGS)
 CFLAGS = $(ENV_CFLAGS) -std=c99 -D_ISOC99_SOURCE -I. -I../include -I../common -I../zlib -I../uart -I/opt/local/include -I../liblua -Wall -g -O3
-CXXFLAGS = -I../include -Wall -O3
+CXXFLAGS = -I../include -I../uart -Wall -O3
 
 LUAPLATFORM = generic
 platform = $(shell uname)
@@ -82,7 +82,10 @@ POSTCOMPILE = $(MV) -f $(OBJDIR)/$*.Td $(OBJDIR)/$*.d
 CORESRCS = 	uart_posix.c \
 			uart_win32.c \
 			util.c \
-			util_posix.c
+			util_posix.c \
+			comms.c \
+			data.c \
+			ui.c
 
 CMDSRCS = 	crapto1/crapto1.c\
 			crapto1/crypto1.c\
@@ -102,9 +105,7 @@ CMDSRCS = 	crapto1/crapto1.c\
 			crc64.c \
 			iso14443crc.c \
 			iso15693tools.c \
-			data.c \
 			graph.c \
-			ui.c \
 			cmddata.c \
 			lfdemod.c \
 			cmdhf.c \
@@ -175,6 +176,7 @@ ZLIBFLAGS = -DZ_SOLO -DZ_PREFIX -DNO_GZIP -DZLIB_PM3_TUNED
 #-DDEBUG -Dverbose=1
 
 QTGUISRCS = proxgui.cpp proxguiqt.cpp proxguiqt.moc.cpp guidummy.cpp
+NOGUISRCS = guidummy.cpp
 
 COREOBJS = $(CORESRCS:%.c=$(OBJDIR)/%.o)
 CMDOBJS = $(CMDSRCS:%.c=$(OBJDIR)/%.o)

--- a/client/cmdcrc.c
+++ b/client/cmdcrc.c
@@ -62,7 +62,7 @@ int split(char *str, char *arr[MAX_ARGS]){
 	return wordCnt;
 }
 
-int CmdCrc(const char *Cmd)
+int CmdCrc(pm3_connection* conn, const char *Cmd)
 {
 	char name[] = {"reveng "};
 	char Cmd2[50 + 7];
@@ -72,7 +72,7 @@ int CmdCrc(const char *Cmd)
 	int argc = split(Cmd2, argv);
 
 	if (argc == 3 && memcmp(argv[1],"-g",2)==0) {
-		CmdrevengSearch(argv[2]);
+		CmdrevengSearch(conn, argv[2]);
 	} else {
 		reveng_main(argc, argv);
 	}
@@ -269,7 +269,7 @@ int GetModels(char *Models[], int *count, uint8_t *width){
 }
 
 //test call to GetModels
-int CmdrevengTest(const char *Cmd){
+int CmdrevengTest(pm3_connection* conn, const char *Cmd){
 	char *Models[80];
 	int count = 0;
 	uint8_t widtharr[80] = {0};
@@ -427,7 +427,7 @@ int RunModel(char *inModel, char *inHexStr, bool reverse, char endian, char *res
 }
 
 //test call to RunModel
-int CmdrevengTestC(const char *Cmd){
+int CmdrevengTestC(pm3_connection* conn, const char *Cmd){
 	int cmdp = 0;
 	char inModel[30] = {0x00};
 	char inHexStr[30] = {0x00};
@@ -462,7 +462,7 @@ char *SwapEndianStr(const char *inStr, const size_t len, const uint8_t blockSize
 }
 
 // takes hex string in and searches for a matching result (hex string must include checksum)
-int CmdrevengSearch(const char *Cmd){
+int CmdrevengSearch(pm3_connection* conn, const char *Cmd){
 	char inHexStr[50] = {0x00};
 	int dataLen = param_getstr(Cmd, 0, inHexStr);
 	if (dataLen < 4) return 0;

--- a/client/cmdcrc.h
+++ b/client/cmdcrc.h
@@ -11,10 +11,12 @@
 #ifndef CMDCRC_H__
 #define CMDCRC_H__
 
-int CmdCrc(const char *Cmd);
-int CmdrevengTest(const char *Cmd);
-int CmdrevengTestC(const char *Cmd);
-int CmdrevengSearch(const char *Cmd);
+#include "comms.h"
+
+int CmdCrc(pm3_connection* conn, const char *Cmd);
+int CmdrevengTest(pm3_connection* conn, const char *Cmd);
+int CmdrevengTestC(pm3_connection* conn, const char *Cmd);
+int CmdrevengSearch(pm3_connection* conn, const char *Cmd);
 int GetModels(char *Models[], int *count, uint8_t *width);
 int RunModel(char *inModel, char *inHexStr, bool reverse, char endian, char *result);
 #endif

--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -25,6 +25,8 @@
 #include "loclass/cipherutils.h" // for decimating samples in getsamples
 #include "cmdlfem4x.h"// for em410x demod
 
+uint8_t g_debugMode=0;
+
 static int CmdHelp(pm3_connection* conn, const char *Cmd);
 
 //set the demod buffer with given array of binary (one bit per byte)

--- a/client/cmddata.h
+++ b/client/cmddata.h
@@ -19,62 +19,56 @@
 
 command_t * CmdDataCommands();
 
-int CmdData(const char *Cmd);
-void printDemodBuff(void);
-void setDemodBuf(uint8_t *buff, size_t size, size_t startIdx);
-bool getDemodBuf(uint8_t *buff, size_t *size);
-void save_restoreDB(uint8_t saveOpt);// option '1' to save DemodBuffer any other to restore
-int CmdPrintDemodBuff(const char *Cmd);
-int Cmdaskrawdemod(const char *Cmd);
-int Cmdaskmandemod(const char *Cmd);
-int AutoCorrelate(const int *in, int *out, size_t len, int window, bool SaveGrph, bool verbose);
-int CmdAutoCorr(const char *Cmd);
-int CmdBiphaseDecodeRaw(const char *Cmd);
-int CmdBitsamples(const char *Cmd);
-int CmdBuffClear(const char *Cmd);
-int CmdDec(const char *Cmd);
-int CmdDetectClockRate(const char *Cmd);
-int CmdFSKrawdemod(const char *Cmd);
-int CmdPSK1rawDemod(const char *Cmd);
-int CmdPSK2rawDemod(const char *Cmd);
-int CmdGrid(const char *Cmd);
-int CmdGetBitStream(const char *Cmd);
-int CmdHexsamples(const char *Cmd);
-int CmdHide(const char *Cmd);
-int CmdHpf(const char *Cmd);
-int CmdLoad(const char *Cmd);
-int CmdLtrim(const char *Cmd);
-int CmdRtrim(const char *Cmd);
-int Cmdmandecoderaw(const char *Cmd);
-int CmdNorm(const char *Cmd);
-int CmdNRZrawDemod(const char *Cmd);
-int CmdPlot(const char *Cmd);
-int CmdPrintDemodBuff(const char *Cmd);
-int CmdRawDemod(const char *Cmd);
-int CmdSamples(const char *Cmd);
-int CmdTuneSamples(const char *Cmd);
-int CmdSave(const char *Cmd);
-int CmdScale(const char *Cmd);
-int CmdDirectionalThreshold(const char *Cmd);
-int CmdZerocrossings(const char *Cmd);
-int ASKbiphaseDemod(const char *Cmd, bool verbose);
-int ASKDemod(const char *Cmd, bool verbose, bool emSearch, uint8_t askType);
-int ASKDemod_ext(const char *Cmd, bool verbose, bool emSearch, uint8_t askType, bool *stCheck);
-int FSKrawDemod(const char *Cmd, bool verbose);
-int PSKDemod(const char *Cmd, bool verbose);
-int NRZrawDemod(const char *Cmd, bool verbose);
-int getSamples(int n, bool silent);
-void setClockGrid(int clk, int offset);
+int CmdData(pm3_connection* conn, const char *Cmd);
+void printDemodBuff(pm3_connection* conn);
+void setDemodBuf(pm3_connection* conn, uint8_t *buff, size_t size, size_t startIdx);
+bool getDemodBuf(pm3_connection* conn, uint8_t *buff, size_t *size);
+// option '1' to save DemodBuffer any other to restore
+void save_restoreDB(pm3_connection* conn, uint8_t saveOpt);
+
+int CmdPrintDemodBuff(pm3_connection* conn, const char *Cmd);
+int Cmdaskrawdemod(pm3_connection* conn, const char *Cmd);
+int Cmdaskmandemod(pm3_connection* conn, const char *Cmd);
+int AutoCorrelate(pm3_connection* conn, const int *in, int *out, size_t len, int window, bool SaveGrph, bool verbose);
+int CmdAutoCorr(pm3_connection* conn, const char *Cmd);
+int CmdBiphaseDecodeRaw(pm3_connection* conn, const char *Cmd);
+int CmdBitsamples(pm3_connection* conn, const char *Cmd);
+int CmdBuffClear(pm3_connection* conn, const char *Cmd);
+int CmdDec(pm3_connection* conn, const char *Cmd);
+int CmdDetectClockRate(pm3_connection* conn, const char *Cmd);
+int CmdFSKrawdemod(pm3_connection* conn, const char *Cmd);
+int CmdPSK1rawDemod(pm3_connection* conn, const char *Cmd);
+int CmdPSK2rawDemod(pm3_connection* conn, const char *Cmd);
+int CmdGrid(pm3_connection* conn, const char *Cmd);
+int CmdGetBitStream(pm3_connection* conn, const char *Cmd);
+int CmdHexsamples(pm3_connection* conn, const char *Cmd);
+int CmdHide(pm3_connection* conn, const char *Cmd);
+int CmdHpf(pm3_connection* conn, const char *Cmd);
+int CmdLoad(pm3_connection* conn, const char *Cmd);
+int CmdLtrim(pm3_connection* conn, const char *Cmd);
+int CmdRtrim(pm3_connection* conn, const char *Cmd);
+int Cmdmandecoderaw(pm3_connection* conn, const char *Cmd);
+int CmdNorm(pm3_connection* conn, const char *Cmd);
+int CmdNRZrawDemod(pm3_connection* conn, const char *Cmd);
+int CmdPlot(pm3_connection* conn, const char *Cmd);
+int CmdPrintDemodBuff(pm3_connection* conn, const char *Cmd);
+int CmdRawDemod(pm3_connection* conn, const char *Cmd);
+int CmdSamples(pm3_connection* conn, const char *Cmd);
+int CmdTuneSamples(pm3_connection* conn, const char *Cmd);
+int CmdSave(pm3_connection* conn, const char *Cmd);
+int CmdScale(pm3_connection* conn, const char *Cmd);
+int CmdDirectionalThreshold(pm3_connection* conn, const char *Cmd);
+int CmdZerocrossings(pm3_connection* conn, const char *Cmd);
+int ASKbiphaseDemod(pm3_connection* conn, const char *Cmd, bool verbose);
+int ASKDemod(pm3_connection* conn, const char *Cmd, bool verbose, bool emSearch, uint8_t askType);
+int ASKDemod_ext(pm3_connection* conn, const char *Cmd, bool verbose, bool emSearch, uint8_t askType, bool *stCheck);
+int FSKrawDemod(pm3_connection* conn, const char *Cmd, bool verbose);
+int PSKDemod(pm3_connection* conn, const char *Cmd, bool verbose);
+int NRZrawDemod(pm3_connection* conn, const char *Cmd, bool verbose);
+int getSamples(pm3_connection* conn, int n, bool silent);
+void setClockGrid(pm3_connection* conn, int clk, int offset);
 int directionalThreshold(const int* in, int *out, size_t len, int8_t up, int8_t down);
 extern int AskEdgeDetect(const int *in, int *out, int len, int threshold);
 //int autoCorr(const int* in, int *out, size_t len, int window);
-
-#define MAX_DEMOD_BUF_LEN (1024*128)
-extern uint8_t DemodBuffer[MAX_DEMOD_BUF_LEN];
-extern size_t DemodBufferLen;
-extern int g_DemodStartIdx;
-extern int g_DemodClock;
-extern uint8_t g_debugMode;
-#define BIGBUF_SIZE 40000
 
 #endif

--- a/client/cmdhf.c
+++ b/client/cmdhf.c
@@ -31,12 +31,12 @@
 #include "cmdhftopaz.h"
 #include "protocols.h"
 
-static int CmdHelp(const char *Cmd);
+static int CmdHelp(pm3_connection* conn, const char *Cmd);
 
-int CmdHFTune(const char *Cmd)
+int CmdHFTune(pm3_connection* conn, const char *Cmd)
 {
   UsbCommand c={CMD_MEASURE_ANTENNA_TUNING_HF};
-  SendCommand(&c);
+  SendCommand(conn, &c);
   return 0;
 }
 
@@ -557,7 +557,7 @@ uint16_t printTraceLine(uint16_t tracepos, uint16_t traceLen, uint8_t *trace, ui
 }
 
 
-int CmdHFList(const char *Cmd)
+int CmdHFList(pm3_connection* conn, const char *Cmd)
 {
 	bool showWaitCycles = false;
 	bool markCRCBytes = false;
@@ -627,8 +627,8 @@ int CmdHFList(const char *Cmd)
 
 	// Query for the size of the trace
 	UsbCommand response;
-	GetFromBigBuf(trace, USB_CMD_DATA_SIZE, 0);
-	WaitForResponse(CMD_ACK, &response);
+	GetFromBigBuf(conn, trace, USB_CMD_DATA_SIZE, 0);
+	WaitForResponse(conn, CMD_ACK, &response);
 	uint16_t traceLen = response.arg[2];
 	if (traceLen > USB_CMD_DATA_SIZE) {
 		uint8_t *p = realloc(trace, traceLen);
@@ -638,8 +638,8 @@ int CmdHFList(const char *Cmd)
 			return 2;
 		}
 		trace = p;
-		GetFromBigBuf(trace, traceLen, 0);
-		WaitForResponse(CMD_ACK, NULL);
+		GetFromBigBuf(conn, trace, traceLen, 0);
+		WaitForResponse(conn, CMD_ACK, NULL);
 	}
 	
 	PrintAndLog("Recorded Activity (TraceLen = %d bytes)", traceLen);
@@ -660,26 +660,27 @@ int CmdHFList(const char *Cmd)
 	return 0;
 }
 
-int CmdHFSearch(const char *Cmd){
+int CmdHFSearch(pm3_connection* conn, const char *Cmd){
 	int ans = 0;
 	PrintAndLog("");
-	ans = CmdHF14AReader("s");
+	ans = CmdHF14AReader(conn, "s");
 	if (ans > 0) {
 		PrintAndLog("\nValid ISO14443A Tag Found - Quiting Search\n");
 		return ans;
 	}
-	ans = HFiClassReader("", false, false);
+	ans = HFiClassReader(conn, "", false, false);
 	if (ans) {
 		PrintAndLog("\nValid iClass Tag (or PicoPass Tag) Found - Quiting Search\n");
 		return ans;
 	}
-	ans = HF15Reader("", false);
+	ans = HF15Reader(conn, "", false);
 	if (ans) {
 		PrintAndLog("\nValid ISO15693 Tag Found - Quiting Search\n");
 		return ans;
 	}
+
 	//14b is longest test currently (and rarest chip type) ... put last
-	ans = HF14BInfo(false);
+	ans = HF14BInfo(conn, false);
 	if (ans) {
 		PrintAndLog("\nValid ISO14443B Tag Found - Quiting Search\n");
 		return ans;
@@ -688,11 +689,11 @@ int CmdHFSearch(const char *Cmd){
 	return 0;
 }
 
-int CmdHFSnoop(const char *Cmd)
+int CmdHFSnoop(pm3_connection* conn, const char *Cmd)
 {
 	char * pEnd;
 	UsbCommand c = {CMD_HF_SNIFFER, {strtol(Cmd, &pEnd,0),strtol(pEnd, &pEnd,0),0}};
-	SendCommand(&c);
+	SendCommand(conn, &c);
 	return 0;
 }
 
@@ -715,14 +716,14 @@ static command_t CommandTable[] =
 	{NULL,		NULL,			0, NULL}
 };
 
-int CmdHF(const char *Cmd)
+int CmdHF(pm3_connection* conn, const char *Cmd)
 {
-  CmdsParse(CommandTable, Cmd);
+  CmdsParse(conn, CommandTable, Cmd);
   return 0; 
 }
 
-int CmdHelp(const char *Cmd)
+int CmdHelp(pm3_connection* conn, const char *Cmd)
 {
-  CmdsHelp(CommandTable);
+  CmdsHelp(conn, CommandTable);
   return 0;
 }

--- a/client/cmdhf.h
+++ b/client/cmdhf.h
@@ -11,7 +11,7 @@
 #ifndef CMDHF_H__
 #define CMDHF_H__
 
-int CmdHF(const char *Cmd);
-int CmdHFTune(const char *Cmd);
-int CmdHFList(const char *Cmd);
+int CmdHF(pm3_connection* conn, const char *Cmd);
+int CmdHFTune(pm3_connection* conn, const char *Cmd);
+int CmdHFList(pm3_connection* conn, const char *Cmd);
 #endif

--- a/client/cmdhf14a.h
+++ b/client/cmdhf14a.h
@@ -14,12 +14,12 @@
 
 #include <stdint.h>
 
-int CmdHF14A(const char *Cmd);
-int CmdHF14AList(const char *Cmd);
-int CmdHF14AMifare(const char *Cmd);
-int CmdHF14AReader(const char *Cmd);
-int CmdHF14ASim(const char *Cmd);
-int CmdHF14ASnoop(const char *Cmd);
+int CmdHF14A(pm3_connection* conn, const char *Cmd);
+int CmdHF14AList(pm3_connection* conn, const char *Cmd);
+int CmdHF14AMifare(pm3_connection* conn, const char *Cmd);
+int CmdHF14AReader(pm3_connection* conn, const char *Cmd);
+int CmdHF14ASim(pm3_connection* conn, const char *Cmd);
+int CmdHF14ASnoop(pm3_connection* conn, const char *Cmd);
 char* getTagInfo(uint8_t uid);
 
 #endif

--- a/client/cmdhf14b.h
+++ b/client/cmdhf14b.h
@@ -11,14 +11,14 @@
 #ifndef CMDHF14B_H__
 #define CMDHF14B_H__
 
-int CmdHF14B(const char *Cmd);
-int CmdHF14BList(const char *Cmd);
-int CmdHF14BInfo(const char *Cmd);
-int CmdHF14BSim(const char *Cmd);
-int CmdHF14BSnoop(const char *Cmd);
-int CmdSri512Read(const char *Cmd);
-int CmdSrix4kRead(const char *Cmd);
-int CmdHF14BWrite( const char *cmd);
-int HF14BInfo(bool verbose);
+int CmdHF14B(pm3_connection* conn, const char *Cmd);
+int CmdHF14BList(pm3_connection* conn, const char *Cmd);
+int CmdHF14BInfo(pm3_connection* conn, const char *Cmd);
+int CmdHF14BSim(pm3_connection* conn, const char *Cmd);
+int CmdHF14BSnoop(pm3_connection* conn, const char *Cmd);
+int CmdSri512Read(pm3_connection* conn, const char *Cmd);
+int CmdSrix4kRead(pm3_connection* conn, const char *Cmd);
+int CmdHF14BWrite(pm3_connection* conn, const char *cmd);
+int HF14BInfo(pm3_connection* conn, bool verbose);
 
 #endif

--- a/client/cmdhf15.h
+++ b/client/cmdhf15.h
@@ -11,16 +11,16 @@
 #ifndef CMDHF15_H__
 #define CMDHF15_H__
 
-int CmdHF15(const char *Cmd);
+int CmdHF15(pm3_connection* conn, const char *Cmd);
 
-int CmdHF15Demod(const char *Cmd);
-int CmdHF15Read(const char *Cmd);
-int HF15Reader(const char *Cmd, bool verbose);
-int CmdHF15Reader(const char *Cmd);
-int CmdHF15Sim(const char *Cmd);
-int CmdHF15Record(const char *Cmd);
-int CmdHF15Cmd(const char*Cmd);
-int CmdHF15CmdHelp(const char*Cmd);
-int CmdHF15Help(const char*Cmd);
+int CmdHF15Demod(pm3_connection* conn, const char *Cmd);
+int CmdHF15Read(pm3_connection* conn, const char *Cmd);
+int HF15Reader(pm3_connection* conn, const char *Cmd, bool verbose);
+int CmdHF15Reader(pm3_connection* conn, const char *Cmd);
+int CmdHF15Sim(pm3_connection* conn, const char *Cmd);
+int CmdHF15Record(pm3_connection* conn, const char *Cmd);
+int CmdHF15Cmd(pm3_connection* conn, const char*Cmd);
+int CmdHF15CmdHelp(pm3_connection* conn, const char*Cmd);
+int CmdHF15Help(pm3_connection* conn, const char*Cmd);
 
 #endif

--- a/client/cmdhfepa.h
+++ b/client/cmdhfepa.h
@@ -10,9 +10,10 @@
 
 #ifndef CMDHFEPA_H__
 #define CMDHFEPA_H__
+#include "comms.h"
 
-int CmdHFEPA(const char *Cmd);
+int CmdHFEPA(pm3_connection* conn, const char *Cmd);
 
-int CmdHFEPACollectPACENonces(const char *Cmd);
+int CmdHFEPACollectPACENonces(pm3_connection* conn, const char *Cmd);
 
 #endif // CMDHFEPA_H__

--- a/client/cmdhficlass.h
+++ b/client/cmdhficlass.h
@@ -12,28 +12,28 @@
 #ifndef CMDHFICLASS_H__
 #define CMDHFICLASS_H__
 
-int CmdHFiClass(const char *Cmd);
+int CmdHFiClass(pm3_connection* conn, const char *Cmd);
 
-int CmdHFiClassCalcNewKey(const char *Cmd);
-int CmdHFiClassCloneTag(const char *Cmd);
-int CmdHFiClassDecrypt(const char *Cmd);
-int CmdHFiClassEncryptBlk(const char *Cmd);
-int CmdHFiClassELoad(const char *Cmd);
-int CmdHFiClassList(const char *Cmd);
-int HFiClassReader(const char *Cmd, bool loop, bool verbose);
-int CmdHFiClassReader(const char *Cmd);
-int CmdHFiClassReader_Dump(const char *Cmd);
-int CmdHFiClassReader_Replay(const char *Cmd);
-int CmdHFiClassReadKeyFile(const char *filename);
-int CmdHFiClassReadTagFile(const char *Cmd);
-int CmdHFiClass_ReadBlock(const char *Cmd);
-int CmdHFiClass_TestMac(const char *Cmd);
-int CmdHFiClassManageKeys(const char *Cmd);
-int CmdHFiClass_loclass(const char *Cmd);
-int CmdHFiClassSnoop(const char *Cmd);
-int CmdHFiClassSim(const char *Cmd);
-int CmdHFiClassWriteKeyFile(const char *Cmd);
-int CmdHFiClass_WriteBlock(const char *Cmd);
+int CmdHFiClassCalcNewKey(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassCloneTag(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassDecrypt(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassEncryptBlk(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassELoad(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassList(pm3_connection* conn, const char *Cmd);
+int HFiClassReader(pm3_connection* conn, const char *Cmd, bool loop, bool verbose);
+int CmdHFiClassReader(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassReader_Dump(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassReader_Replay(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassReadKeyFile(pm3_connection* conn, const char *filename);
+int CmdHFiClassReadTagFile(pm3_connection* conn, const char *Cmd);
+int CmdHFiClass_ReadBlock(pm3_connection* conn, const char *Cmd);
+int CmdHFiClass_TestMac(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassManageKeys(pm3_connection* conn, const char *Cmd);
+int CmdHFiClass_loclass(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassSnoop(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassSim(pm3_connection* conn, const char *Cmd);
+int CmdHFiClassWriteKeyFile(pm3_connection* conn, const char *Cmd);
+int CmdHFiClass_WriteBlock(pm3_connection* conn, const char *Cmd);
 void printIclassDumpContents(uint8_t *iclass_dump, uint8_t startblock, uint8_t endblock, size_t filesize);
 void HFiClassCalcDivKey(uint8_t	*CSN, uint8_t	*KEY, uint8_t *div_key, bool elite);
 #endif

--- a/client/cmdhflegic.h
+++ b/client/cmdhflegic.h
@@ -11,14 +11,16 @@
 #ifndef CMDHFLEGIC_H__
 #define CMDHFLEGIC_H__
 
-int CmdHFLegic(const char *Cmd);
+#include "comms.h"
 
-int CmdLegicRFRead(const char *Cmd);
-int CmdLegicDecode(const char *Cmd);
-int CmdLegicLoad(const char *Cmd);
-int CmdLegicSave(const char *Cmd);
-int CmdLegicRfSim(const char *Cmd);
-int CmdLegicRfWrite(const char *Cmd);
-int CmdLegicRfFill(const char *Cmd);
+int CmdHFLegic(pm3_connection* conn, const char *Cmd);
+
+int CmdLegicRFRead(pm3_connection* conn, const char *Cmd);
+int CmdLegicDecode(pm3_connection* conn, const char *Cmd);
+int CmdLegicLoad(pm3_connection* conn, const char *Cmd);
+int CmdLegicSave(pm3_connection* conn, const char *Cmd);
+int CmdLegicRfSim(pm3_connection* conn, const char *Cmd);
+int CmdLegicRfWrite(pm3_connection* conn, const char *Cmd);
+int CmdLegicRfFill(pm3_connection* conn, const char *Cmd);
 
 #endif

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -22,19 +22,20 @@
 #include "util_posix.h"
 #include "usb_cmd.h"
 #include "ui.h"
+#include "mifaredefault.h"
 #include "mifarehost.h"
 #include "mifare.h"
 #include "mfkey.h"
 
 #define NESTED_SECTOR_RETRY     10			// how often we try mfested() until we give up
 
-static int CmdHelp(const char *Cmd);
+static int CmdHelp(pm3_connection* conn, const char *Cmd);
 
-int CmdHF14AMifare(const char *Cmd)
+int CmdHF14AMifare(pm3_connection* conn, const char *Cmd)
 {
 	int isOK = 0;
 	uint64_t key = 0;
-	isOK = mfDarkside(&key);
+	isOK = mfDarkside(conn, &key);
 	switch (isOK) {
 		case -1 : PrintAndLog("Button pressed. Aborted."); return 1;
 		case -2 : PrintAndLog("Card is not vulnerable to Darkside attack (doesn't send NACK on authentication requests)."); return 1;
@@ -50,7 +51,7 @@ int CmdHF14AMifare(const char *Cmd)
 }
 
 
-int CmdHF14AMfWrBl(const char *Cmd)
+int CmdHF14AMfWrBl(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t blockNo = 0;
 	uint8_t keyType = 0;
@@ -86,10 +87,10 @@ int CmdHF14AMfWrBl(const char *Cmd)
   UsbCommand c = {CMD_MIFARE_WRITEBL, {blockNo, keyType, 0}};
 	memcpy(c.d.asBytes, key, 6);
 	memcpy(c.d.asBytes + 10, bldata, 16);
-  SendCommand(&c);
+  SendCommand(conn, &c);
 
 	UsbCommand resp;
-	if (WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
+	if (WaitForResponseTimeout(conn, CMD_ACK,&resp,1500)) {
 		uint8_t isOK  = resp.arg[0] & 0xff;
 		PrintAndLog("isOk:%02x", isOK);
 	} else {
@@ -99,7 +100,7 @@ int CmdHF14AMfWrBl(const char *Cmd)
 	return 0;
 }
 
-int CmdHF14AMfRdBl(const char *Cmd)
+int CmdHF14AMfRdBl(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t blockNo = 0;
 	uint8_t keyType = 0;
@@ -129,10 +130,10 @@ int CmdHF14AMfRdBl(const char *Cmd)
 
   UsbCommand c = {CMD_MIFARE_READBL, {blockNo, keyType, 0}};
 	memcpy(c.d.asBytes, key, 6);
-  SendCommand(&c);
+  SendCommand(conn, &c);
 
 	UsbCommand resp;
-	if (WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
+	if (WaitForResponseTimeout(conn, CMD_ACK,&resp,1500)) {
 		uint8_t isOK  = resp.arg[0] & 0xff;
 		uint8_t *data = resp.d.asBytes;
 
@@ -147,7 +148,7 @@ int CmdHF14AMfRdBl(const char *Cmd)
   return 0;
 }
 
-int CmdHF14AMfRdSc(const char *Cmd)
+int CmdHF14AMfRdSc(pm3_connection* conn, const char *Cmd)
 {
 	int i;
 	uint8_t sectorNo = 0;
@@ -182,11 +183,11 @@ int CmdHF14AMfRdSc(const char *Cmd)
 
 	UsbCommand c = {CMD_MIFARE_READSC, {sectorNo, keyType, 0}};
 	memcpy(c.d.asBytes, key, 6);
-	SendCommand(&c);
+	SendCommand(conn, &c);
 	PrintAndLog(" ");
 
 	UsbCommand resp;
-	if (WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
+	if (WaitForResponseTimeout(conn, CMD_ACK,&resp,1500)) {
 		isOK  = resp.arg[0] & 0xff;
 		data  = resp.d.asBytes;
 
@@ -244,7 +245,7 @@ static int ParamCardSizeBlocks(const char c) {
 	return numBlocks;
 }
 
-int CmdHF14AMfDump(const char *Cmd)
+int CmdHF14AMfDump(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t sectorNo, blockNo;
 
@@ -306,9 +307,9 @@ int CmdHF14AMfDump(const char *Cmd)
 		for (tries = 0; tries < 3; tries++) {
 			UsbCommand c = {CMD_MIFARE_READBL, {FirstBlockOfSector(sectorNo) + NumBlocksPerSector(sectorNo) - 1, 0, 0}};
 			memcpy(c.d.asBytes, keyA[sectorNo], 6);
-			SendCommand(&c);
+			SendCommand(conn, &c);
 
-			if (WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
+			if (WaitForResponseTimeout(conn, CMD_ACK,&resp,1500)) {
 				uint8_t isOK  = resp.arg[0] & 0xff;
 				uint8_t *data  = resp.d.asBytes;
 				if (isOK){
@@ -342,15 +343,15 @@ int CmdHF14AMfDump(const char *Cmd)
 				if (blockNo == NumBlocksPerSector(sectorNo) - 1) {		// sector trailer. At least the Access Conditions can always be read with key A.
 					UsbCommand c = {CMD_MIFARE_READBL, {FirstBlockOfSector(sectorNo) + blockNo, 0, 0}};
 					memcpy(c.d.asBytes, keyA[sectorNo], 6);
-					SendCommand(&c);
-					received = WaitForResponseTimeout(CMD_ACK,&resp,1500);
+					SendCommand(conn, &c);
+					received = WaitForResponseTimeout(conn, CMD_ACK,&resp,1500);
 				} else {												// data block. Check if it can be read with key A or key B
 					uint8_t data_area = sectorNo<32?blockNo:blockNo/5;
 					if ((rights[sectorNo][data_area] == 0x03) || (rights[sectorNo][data_area] == 0x05)) {	// only key B would work
 						UsbCommand c = {CMD_MIFARE_READBL, {FirstBlockOfSector(sectorNo) + blockNo, 1, 0}};
 						memcpy(c.d.asBytes, keyB[sectorNo], 6);
-						SendCommand(&c);
-						received = WaitForResponseTimeout(CMD_ACK,&resp,1500);
+						SendCommand(conn, &c);
+						received = WaitForResponseTimeout(conn, CMD_ACK,&resp,1500);
 					} else if (rights[sectorNo][data_area] == 0x07) {										// no key would work
 						isOK = false;
 						PrintAndLog("Access rights do not allow reading of sector %2d block %3d", sectorNo, blockNo);
@@ -358,8 +359,8 @@ int CmdHF14AMfDump(const char *Cmd)
 					} else {																				// key A would work
 						UsbCommand c = {CMD_MIFARE_READBL, {FirstBlockOfSector(sectorNo) + blockNo, 0, 0}};
 						memcpy(c.d.asBytes, keyA[sectorNo], 6);
-						SendCommand(&c);
-						received = WaitForResponseTimeout(CMD_ACK,&resp,1500);
+						SendCommand(conn, &c);
+						received = WaitForResponseTimeout(conn, CMD_ACK,&resp,1500);
 					}
 				}
 				if (received) {
@@ -415,7 +416,7 @@ int CmdHF14AMfDump(const char *Cmd)
 	return 0;
 }
 
-int CmdHF14AMfRestore(const char *Cmd)
+int CmdHF14AMfRestore(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t sectorNo,blockNo;
 	uint8_t keyType = 0;
@@ -508,10 +509,10 @@ int CmdHF14AMfRestore(const char *Cmd)
 			PrintAndLog("Writing to block %3d: %s", FirstBlockOfSector(sectorNo) + blockNo, sprint_hex(bldata, 16));
 
 			memcpy(c.d.asBytes + 10, bldata, 16);
-			SendCommand(&c);
+			SendCommand(conn, &c);
 
 			UsbCommand resp;
-			if (WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
+			if (WaitForResponseTimeout(conn, CMD_ACK,&resp,1500)) {
 				uint8_t isOK  = resp.arg[0] & 0xff;
 				PrintAndLog("isOk:%02x", isOK);
 			} else {
@@ -525,7 +526,7 @@ int CmdHF14AMfRestore(const char *Cmd)
 }
 
 # define NESTED_KEY_COUNT 15
-int CmdHF14AMfNested(const char *Cmd)
+int CmdHF14AMfNested(pm3_connection* conn, const char *Cmd)
 {
 	int i, j, res, iterations;
 	sector_t *e_sector = NULL;
@@ -603,7 +604,7 @@ int CmdHF14AMfNested(const char *Cmd)
 		}
 
 		// check if we can authenticate to sector
-		res = mfCheckKeys(blockNo, keyType, true, 1, key, &key64);
+		res = mfCheckKeys(conn, blockNo, keyType, true, 1, key, &key64);
 		if (res) {
 			PrintAndLog("Can't authenticate to block:%3d key type:%c key:%s", blockNo, keyType?'B':'A', sprint_hex(key, 6));
 			return 3;
@@ -636,7 +637,7 @@ int CmdHF14AMfNested(const char *Cmd)
 	// one-sector nested
 	if (cmdp == 'o') { // ------------------------------------  one sector working
 		PrintAndLog("--target block no:%3d, target key type:%c ", trgBlockNo, trgKeyType?'B':'A');
-		int16_t isOK = mfnested(blockNo, keyType, key, trgBlockNo, trgKeyType, keyBlock, true);
+		int16_t isOK = mfnested(conn, blockNo, keyType, key, trgBlockNo, trgKeyType, keyBlock, true);
 		if (isOK) {
 			switch (isOK) {
 				case -1 : PrintAndLog("Error: No response from Proxmark.\n"); break;
@@ -658,13 +659,13 @@ int CmdHF14AMfNested(const char *Cmd)
 				} else {					// 16 block sector
 					sectortrailer = (trgBlockNo & 0x0f) + 15;
 				}
-				mfEmlGetMem(keyBlock, sectortrailer, 1);
-
+				mfEmlGetMem(conn, keyBlock, sectortrailer, 1);
+		
 				if (!trgKeyType)
 					num_to_bytes(key64, 6, keyBlock);
 				else
 					num_to_bytes(key64, 6, &keyBlock[10]);
-				mfEmlSetMem(keyBlock, sectortrailer, 1);
+				mfEmlSetMem(conn, keyBlock, sectortrailer, 1);
 				PrintAndLog("Key transferred to emulator memory.");
 			}
 		} else {
@@ -684,7 +685,7 @@ int CmdHF14AMfNested(const char *Cmd)
 		}
 
 		PrintAndLog("Testing known keys. Sector count=%d", SectorsCnt);
-		mfCheckKeysSec(SectorsCnt, 2, MF_CHKKEYS_DEFTIMEOUT, true, NESTED_KEY_COUNT, keyBlock, e_sector);
+		mfCheckKeysSec(conn, SectorsCnt, 2, MF_CHKKEYS_DEFTIMEOUT, true, NESTED_KEY_COUNT, keyBlock, e_sector);
 		
 		// get known key from array
 		bool keyFound = false;
@@ -721,7 +722,7 @@ int CmdHF14AMfNested(const char *Cmd)
 				for (trgKeyType = 0; trgKeyType < 2; trgKeyType++) {
 					if (e_sector[sectorNo].foundKey[trgKeyType]) continue;
 					PrintAndLog("-----------------------------------------------");
-					int16_t isOK = mfnested(blockNo, keyType, key, FirstBlockOfSector(sectorNo), trgKeyType, keyBlock, calibrate);
+					int16_t isOK = mfnested(conn, blockNo, keyType, key, FirstBlockOfSector(sectorNo), trgKeyType, keyBlock, calibrate);
 					if(isOK) {
 						switch (isOK) {
 							case -1 : PrintAndLog("Error: No response from Proxmark.\n"); break;
@@ -744,7 +745,7 @@ int CmdHF14AMfNested(const char *Cmd)
 						e_sector[sectorNo].Key[trgKeyType] = key64;
 						
 						// try to check this key as a key to the other sectors
-						mfCheckKeysSec(SectorsCnt, 2, MF_CHKKEYS_DEFTIMEOUT, true, 1, keyBlock, e_sector);
+						mfCheckKeysSec(conn, SectorsCnt, 2, MF_CHKKEYS_DEFTIMEOUT, true, 1, keyBlock, e_sector);
 					}
 				}
 			}
@@ -767,12 +768,12 @@ int CmdHF14AMfNested(const char *Cmd)
 		// transfer keys to the emulator memory
 		if (transferToEml) {
 			for (i = 0; i < SectorsCnt; i++) {
-				mfEmlGetMem(keyBlock, FirstBlockOfSector(i) + NumBlocksPerSector(i) - 1, 1);
+				mfEmlGetMem(conn, keyBlock, FirstBlockOfSector(i) + NumBlocksPerSector(i) - 1, 1);
 				if (e_sector[i].foundKey[0])
 					num_to_bytes(e_sector[i].Key[0], 6, keyBlock);
 				if (e_sector[i].foundKey[1])
 					num_to_bytes(e_sector[i].Key[1], 6, &keyBlock[10]);
-				mfEmlSetMem(keyBlock, FirstBlockOfSector(i) + NumBlocksPerSector(i) - 1, 1);
+				mfEmlSetMem(conn, keyBlock, FirstBlockOfSector(i) + NumBlocksPerSector(i) - 1, 1);
 			}
 			PrintAndLog("Keys transferred to emulator memory.");
 		}
@@ -812,7 +813,7 @@ int CmdHF14AMfNested(const char *Cmd)
 }
 
 
-int CmdHF14AMfNestedHard(const char *Cmd)
+int CmdHF14AMfNestedHard(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t blockNo = 0;
 	uint8_t keyType = 0;
@@ -917,7 +918,7 @@ int CmdHF14AMfNestedHard(const char *Cmd)
 			slow?"Yes":"No",
 			tests);
 
-	int16_t isOK = mfnestedhard(blockNo, keyType, key, trgBlockNo, trgKeyType, know_target_key?trgkey:NULL, nonce_file_read, nonce_file_write, slow, tests);
+	int16_t isOK = mfnestedhard(conn, blockNo, keyType, key, trgBlockNo, trgKeyType, know_target_key?trgkey:NULL, nonce_file_read, nonce_file_write, slow, tests);
 
 	if (isOK) {
 		switch (isOK) {
@@ -932,7 +933,7 @@ int CmdHF14AMfNestedHard(const char *Cmd)
 }
 
 
-int CmdHF14AMfChk(const char *Cmd)
+int CmdHF14AMfChk(pm3_connection* conn, const char *Cmd)
 {
 	if (strlen(Cmd)<3) {
 		PrintAndLog("Usage:  hf mf chk <block number>|<*card memory> <key type (A/B/?)> [t|d|s|ss] [<key (12 hex symbols)>] [<dic (*.dic)>]");
@@ -1122,7 +1123,7 @@ int CmdHF14AMfChk(const char *Cmd)
 		for (uint32_t c = 0; c < keycnt; c += max_keys) {
 
 			uint32_t size = keycnt-c > max_keys ? max_keys : keycnt-c;
-			res = mfCheckKeysSec(SectorsCnt, keyType, timeout14a * 1.06 / 100, true, size, &keyBlock[6 * c], e_sector); // timeout is (ms * 106)/10 or us*0.0106
+			res = mfCheckKeysSec(conn, SectorsCnt, keyType, timeout14a * 1.06 / 100, true, size, &keyBlock[6 * c], e_sector); // timeout is (ms * 106)/10 or us*0.0106
 
 			if (res != 1) {
 				if (!res) {
@@ -1140,10 +1141,8 @@ int CmdHF14AMfChk(const char *Cmd)
 		int keyAB = keyType;
 		do {
 			for (uint32_t c = 0; c < keycnt; c+=max_keys) {
-
 				uint32_t size = keycnt-c > max_keys ? max_keys : keycnt-c;
-				res = mfCheckKeys(blockNo, keyAB & 0x01, true, size, &keyBlock[6 * c], &key64); 
-
+				res = mfCheckKeys(conn, blockNo, keyAB & 0x01, true, size, &keyBlock[6 * c], &key64); 
 				if (res != 1) {
 					if (!res) {
 						PrintAndLog("Found valid key:[%d:%c]%012" PRIx64, blockNo, (keyAB & 0x01)?'B':'A', key64);
@@ -1178,13 +1177,13 @@ int CmdHF14AMfChk(const char *Cmd)
 		uint8_t block[16];
 		for (uint16_t sectorNo = 0; sectorNo < SectorsCnt; sectorNo++) {
 			if (e_sector[sectorNo].foundKey[0] || e_sector[sectorNo].foundKey[1]) {
-				mfEmlGetMem(block, FirstBlockOfSector(sectorNo) + NumBlocksPerSector(sectorNo) - 1, 1);
+				mfEmlGetMem(conn, block, FirstBlockOfSector(sectorNo) + NumBlocksPerSector(sectorNo) - 1, 1);
 				for (uint16_t t = 0; t < 2; t++) {
 					if (e_sector[sectorNo].foundKey[t]) {
 						num_to_bytes(e_sector[sectorNo].Key[t], 6, block + t * 10);
 					}
 				}
-				mfEmlSetMem(block, FirstBlockOfSector(sectorNo) + NumBlocksPerSector(sectorNo) - 1, 1);
+				mfEmlSetMem(conn, block, FirstBlockOfSector(sectorNo) + NumBlocksPerSector(sectorNo) - 1, 1);
 			}
 		}
 		PrintAndLog("Found keys have been transferred to the emulator memory");
@@ -1215,7 +1214,7 @@ int CmdHF14AMfChk(const char *Cmd)
 	return 0;
 }
 
-void readerAttack(nonces_t ar_resp[], bool setEmulatorMem, bool doStandardAttack) {
+void readerAttack(pm3_connection* conn, nonces_t ar_resp[], bool setEmulatorMem, bool doStandardAttack) {
 	#define ATTACK_KEY_COUNT 7 // keep same as define in iso14443a.c -> Mifare1ksim()
 	                           // cannot be more than 7 or it will overrun c.d.asBytes(512)
 	uint64_t key = 0;
@@ -1302,8 +1301,8 @@ void readerAttack(nonces_t ar_resp[], bool setEmulatorMem, bool doStandardAttack
 
 				UsbCommand c = {CMD_MIFARE_EML_MEMSET, {(stSector[i]*4+3), 1, 0}};
 				memcpy(c.d.asBytes, memBlock, 16);
-				clearCommandBuffer();
-				SendCommand(&c);
+				clearCommandBuffer(conn);
+				SendCommand(conn, &c);			
 			}
 		}
 	}
@@ -1339,7 +1338,7 @@ int usage_hf14_mf1ksim(void) {
 	return 0;
 }
 
-int CmdHF14AMf1kSim(const char *Cmd) {
+int CmdHF14AMf1kSim(pm3_connection* conn, const char *Cmd) {
 	UsbCommand resp;
 	uint8_t uid[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 	uint8_t exitAfterNReads = 0;
@@ -1470,10 +1469,10 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 
 			UsbCommand c = {CMD_SIMULATE_MIFARE_CARD, {flags, exitAfterNReads,0}};
 			memcpy(c.d.asBytes, uid, sizeof(uid));
-			clearCommandBuffer();
-			SendCommand(&c);
+			clearCommandBuffer(conn);
+			SendCommand(conn, &c);
 
-			while(! WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
+			while(! WaitForResponseTimeout(conn, CMD_ACK,&resp,1500)) {
 				//We're waiting only 1.5 s at a time, otherwise we get the
 				// annoying message about "Waiting for a response... "
 			}
@@ -1481,7 +1480,7 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 			nonces_t ar_resp[ATTACK_KEY_COUNT*2];
 			memcpy(ar_resp, resp.d.asBytes, sizeof(ar_resp));
 			// We can skip the standard attack if we have RANDOM_NONCE set.
-			readerAttack(ar_resp, setEmulatorMem, !(flags & FLAG_RANDOM_NONCE));
+			readerAttack(conn, ar_resp, setEmulatorMem, !(flags & FLAG_RANDOM_NONCE));
 			if ((bool)resp.arg[1]) {
 				PrintAndLog("Device button pressed - quitting");
 				fclose(f);
@@ -1500,12 +1499,12 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 
 		UsbCommand c = {CMD_SIMULATE_MIFARE_CARD, {flags, exitAfterNReads,0}};
 		memcpy(c.d.asBytes, uid, sizeof(uid));
-		clearCommandBuffer();
-		SendCommand(&c);
+		clearCommandBuffer(conn);
+		SendCommand(conn, &c);
 
 		if(flags & FLAG_INTERACTIVE) {
 			PrintAndLog("Press pm3-button to abort simulation");
-			while(! WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
+			while(! WaitForResponseTimeout(conn, CMD_ACK,&resp,1500)) {
 				//We're waiting only 1.5 s at a time, otherwise we get the
 				// annoying message about "Waiting for a response... "
 			}
@@ -1514,7 +1513,7 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 				nonces_t ar_resp[ATTACK_KEY_COUNT*2];
 				memcpy(ar_resp, resp.d.asBytes, sizeof(ar_resp));
 				// We can skip the standard attack if we have RANDOM_NONCE set.
-				readerAttack(ar_resp, setEmulatorMem, !(flags & FLAG_RANDOM_NONCE));
+				readerAttack(conn, ar_resp, setEmulatorMem, !(flags & FLAG_RANDOM_NONCE));
 			}
 		}
 	}
@@ -1522,7 +1521,7 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 	return 0;
 }
 
-int CmdHF14AMfDbg(const char *Cmd)
+int CmdHF14AMfDbg(pm3_connection* conn, const char *Cmd)
 {
 	int dbgMode = param_get32ex(Cmd, 0, 0, 10);
 	if (dbgMode > 4) {
@@ -1541,12 +1540,12 @@ int CmdHF14AMfDbg(const char *Cmd)
 	}
 
   UsbCommand c = {CMD_MIFARE_SET_DBGMODE, {dbgMode, 0, 0}};
-  SendCommand(&c);
+  SendCommand(conn, &c);
 
   return 0;
 }
 
-int CmdHF14AMfEGet(const char *Cmd)
+int CmdHF14AMfEGet(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t blockNo = 0;
 	uint8_t data[16] = {0x00};
@@ -1560,7 +1559,7 @@ int CmdHF14AMfEGet(const char *Cmd)
 	blockNo = param_get8(Cmd, 0);
 
 	PrintAndLog(" ");
-	if (!mfEmlGetMem(data, blockNo, 1)) {
+	if (!mfEmlGetMem(conn, data, blockNo, 1)) {
 		PrintAndLog("data[%3d]:%s", blockNo, sprint_hex(data, 16));
 	} else {
 		PrintAndLog("Command execute timeout");
@@ -1569,7 +1568,7 @@ int CmdHF14AMfEGet(const char *Cmd)
   return 0;
 }
 
-int CmdHF14AMfEClear(const char *Cmd)
+int CmdHF14AMfEClear(pm3_connection* conn, const char *Cmd)
 {
 	if (param_getchar(Cmd, 0) == 'h') {
 		PrintAndLog("Usage:  hf mf eclr");
@@ -1578,12 +1577,12 @@ int CmdHF14AMfEClear(const char *Cmd)
 	}
 
   UsbCommand c = {CMD_MIFARE_EML_MEMCLR, {0, 0, 0}};
-  SendCommand(&c);
+  SendCommand(conn, &c);
   return 0;
 }
 
 
-int CmdHF14AMfESet(const char *Cmd)
+int CmdHF14AMfESet(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t memBlock[16];
 	uint8_t blockNo = 0;
@@ -1606,12 +1605,12 @@ int CmdHF14AMfESet(const char *Cmd)
 	//  1 - blocks count
 	UsbCommand c = {CMD_MIFARE_EML_MEMSET, {blockNo, 1, 0}};
 	memcpy(c.d.asBytes, memBlock, 16);
-	SendCommand(&c);
+	SendCommand(conn, &c);
 	return 0;
 }
 
 
-int CmdHF14AMfELoad(const char *Cmd)
+int CmdHF14AMfELoad(pm3_connection* conn, const char *Cmd)
 {
 	FILE * f;
 	char filename[FILE_PATH_SIZE];
@@ -1684,8 +1683,8 @@ int CmdHF14AMfELoad(const char *Cmd)
 		for (i = 0; i < 32; i += 2) {
 			sscanf(&buf[i], "%02x", (unsigned int *)&buf8[i / 2]);
 		}
-
-		if (mfEmlSetMem(buf8, blockNum, 1)) {
+		
+		if (mfEmlSetMem(conn, buf8, blockNum, 1)) {
 			PrintAndLog("Cant set emul block: %3d", blockNum);
 			fclose(f);
 			return 3;
@@ -1707,7 +1706,7 @@ int CmdHF14AMfELoad(const char *Cmd)
 }
 
 
-int CmdHF14AMfESave(const char *Cmd)
+int CmdHF14AMfESave(pm3_connection* conn, const char *Cmd)
 {
 	FILE * f;
 	char filename[FILE_PATH_SIZE];
@@ -1751,7 +1750,7 @@ int CmdHF14AMfESave(const char *Cmd)
 	// user supplied filename?
 	if (len < 1) {
 		// get filename (UID from memory)
-		if (mfEmlGetMem(buf, 0, 1)) {
+		if (mfEmlGetMem(conn, buf, 0, 1)) {
 			PrintAndLog("Can\'t get UID from block: %d", 0);
 			len = sprintf(fnameptr, "dump");
 			fnameptr += len;
@@ -1777,7 +1776,7 @@ int CmdHF14AMfESave(const char *Cmd)
 
 	// put hex
 	for (i = 0; i < numBlocks; i++) {
-		if (mfEmlGetMem(buf, i, 1)) {
+		if (mfEmlGetMem(conn, buf, i, 1)) {
 			PrintAndLog("Cant get block: %d", i);
 			break;
 		}
@@ -1793,7 +1792,7 @@ int CmdHF14AMfESave(const char *Cmd)
 }
 
 
-int CmdHF14AMfECFill(const char *Cmd)
+int CmdHF14AMfECFill(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t keyType = 0;
 	uint8_t numSectors = 16;
@@ -1828,11 +1827,11 @@ int CmdHF14AMfECFill(const char *Cmd)
 
 	printf("--params: numSectors: %d, keyType:%d", numSectors, keyType);
 	UsbCommand c = {CMD_MIFARE_EML_CARDLOAD, {numSectors, keyType, 0}};
-	SendCommand(&c);
+	SendCommand(conn, &c);
 	return 0;
 }
 
-int CmdHF14AMfEKeyPrn(const char *Cmd)
+int CmdHF14AMfEKeyPrn(pm3_connection* conn, const char *Cmd)
 {
 	int i;
 	uint8_t numSectors;
@@ -1863,7 +1862,7 @@ int CmdHF14AMfEKeyPrn(const char *Cmd)
 	PrintAndLog("|sec|key A           |key B           |");
 	PrintAndLog("|---|----------------|----------------|");
 	for (i = 0; i < numSectors; i++) {
-		if (mfEmlGetMem(data, FirstBlockOfSector(i) + NumBlocksPerSector(i) - 1, 1)) {
+		if (mfEmlGetMem(conn, data, FirstBlockOfSector(i) + NumBlocksPerSector(i) - 1, 1)) {
 			PrintAndLog("error get block %d", FirstBlockOfSector(i) + NumBlocksPerSector(i) - 1);
 			break;
 		}
@@ -1876,7 +1875,7 @@ int CmdHF14AMfEKeyPrn(const char *Cmd)
 	return 0;
 }
 
-int CmdHF14AMfCSetUID(const char *Cmd)
+int CmdHF14AMfCSetUID(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t uid[8] = {0x00};
 	uint8_t oldUid[8] = {0x00};
@@ -1938,7 +1937,7 @@ int CmdHF14AMfCSetUID(const char *Cmd)
 		PrintAndLog("--atqa:%s sak:%02x", sprint_hex(atqa, 2), sak[0]);
 	}
 
-	res = mfCSetUID(uid, (atqaPresent)?atqa:NULL, (atqaPresent)?sak:NULL, oldUid);
+	res = mfCSetUID(conn, uid, (atqaPresent)?atqa:NULL, (atqaPresent)?sak:NULL, oldUid);
 	if (res) {
 			PrintAndLog("Can't set UID. Error=%d", res);
 			return 1;
@@ -1949,7 +1948,7 @@ int CmdHF14AMfCSetUID(const char *Cmd)
 	return 0;
 }
 
-int CmdHF14AMfCWipe(const char *Cmd)
+int CmdHF14AMfCWipe(pm3_connection* conn, const char *Cmd)
 {
 	int res, gen = 0;
 	int numBlocks = 16 * 4;
@@ -1965,7 +1964,7 @@ int CmdHF14AMfCWipe(const char *Cmd)
 		return 0;
 	}
 
-	gen = mfCIdentify();
+	gen = mfCIdentify(conn);
 	if ((gen != 1) && (gen != 2)) 
 		return 1;
 	
@@ -1998,10 +1997,10 @@ int CmdHF14AMfCWipe(const char *Cmd)
 		if (wipeCard) {
 			PrintAndLog("WARNING: can't wipe magic card 1b generation");
 		}
-		res = mfCWipe(numBlocks, true, false, fillCard); 
+		res = mfCWipe(conn, numBlocks, true, false, fillCard); 
 	} else {
 		/* generation 1a magic card by default */
-		res = mfCWipe(numBlocks, false, wipeCard, fillCard); 
+		res = mfCWipe(conn, numBlocks, false, wipeCard, fillCard); 
 	}
 
 	if (res) {
@@ -2012,7 +2011,7 @@ int CmdHF14AMfCWipe(const char *Cmd)
 	return 0;
 }
 
-int CmdHF14AMfCSetBlk(const char *Cmd)
+int CmdHF14AMfCSetBlk(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t memBlock[16] = {0x00};
 	uint8_t blockNo = 0;
@@ -2044,10 +2043,10 @@ int CmdHF14AMfCSetBlk(const char *Cmd)
 
 	if (gen == 2) {
 		/* generation 1b magic card */
-		res = mfCSetBlock(blockNo, memBlock, NULL, wipeCard, CSETBLOCK_SINGLE_OPER | CSETBLOCK_MAGIC_1B);
+		res = mfCSetBlock(conn, blockNo, memBlock, NULL, wipeCard, CSETBLOCK_SINGLE_OPER | CSETBLOCK_MAGIC_1B);
 	} else {
 		/* generation 1a magic card by default */
-		res = mfCSetBlock(blockNo, memBlock, NULL, wipeCard, CSETBLOCK_SINGLE_OPER);
+		res = mfCSetBlock(conn, blockNo, memBlock, NULL, wipeCard, CSETBLOCK_SINGLE_OPER);
 	}
 
 	if (res) {
@@ -2058,7 +2057,7 @@ int CmdHF14AMfCSetBlk(const char *Cmd)
 }
 
 
-int CmdHF14AMfCLoad(const char *Cmd)
+int CmdHF14AMfCLoad(pm3_connection* conn, const char *Cmd)
 {
 	FILE * f;
 	char filename[FILE_PATH_SIZE] = {0x00};
@@ -2090,7 +2089,7 @@ int CmdHF14AMfCLoad(const char *Cmd)
 
 	if (fillFromEmulator) {
 		for (blockNum = 0; blockNum < numblock; blockNum += 1) {
-			if (mfEmlGetMem(buf8, blockNum, 1)) {
+			if (mfEmlGetMem(conn, buf8, blockNum, 1)) {
 				PrintAndLog("Cant get block: %d", blockNum);
 				return 2;
 			}
@@ -2101,7 +2100,7 @@ int CmdHF14AMfCLoad(const char *Cmd)
 			if (gen == 2)
 				/* generation 1b magic card */
 				flags |= CSETBLOCK_MAGIC_1B;
-			if (mfCSetBlock(blockNum, buf8, NULL, 0, flags)) {
+			if (mfCSetBlock(conn, blockNum, buf8, NULL, 0, flags)) {
 				PrintAndLog("Cant set magic card block: %d", blockNum);
 				return 3;
 			}
@@ -2153,7 +2152,7 @@ int CmdHF14AMfCLoad(const char *Cmd)
 			if (gen == 2)
 				/* generation 1b magic card */
 				flags |= CSETBLOCK_MAGIC_1B;
-			if (mfCSetBlock(blockNum, buf8, NULL, 0, flags)) {
+			if (mfCSetBlock(conn, blockNum, buf8, NULL, 0, flags)) {
 				PrintAndLog("Can't set magic card block: %d", blockNum);
 				fclose(f);
 				return 3;
@@ -2175,7 +2174,7 @@ int CmdHF14AMfCLoad(const char *Cmd)
 	return 0;
 }
 
-int CmdHF14AMfCGetBlk(const char *Cmd) {
+int CmdHF14AMfCGetBlk(pm3_connection* conn, const char *Cmd) {
 	uint8_t memBlock[16];
 	uint8_t blockNo = 0;
 	int res, gen = 0;
@@ -2196,10 +2195,10 @@ int CmdHF14AMfCGetBlk(const char *Cmd) {
 
 	if (gen == 2) {
 		/* generation 1b magic card */
-		res = mfCGetBlock(blockNo, memBlock, CSETBLOCK_SINGLE_OPER | CSETBLOCK_MAGIC_1B);
+		res = mfCGetBlock(conn, blockNo, memBlock, CSETBLOCK_SINGLE_OPER | CSETBLOCK_MAGIC_1B);
 	} else {
 		/* generation 1a magic card by default */
-		res = mfCGetBlock(blockNo, memBlock, CSETBLOCK_SINGLE_OPER);
+		res = mfCGetBlock(conn, blockNo, memBlock, CSETBLOCK_SINGLE_OPER);
 	}
 	if (res) {
 			PrintAndLog("Can't read block. error=%d", res);
@@ -2210,7 +2209,7 @@ int CmdHF14AMfCGetBlk(const char *Cmd) {
 	return 0;
 }
 
-int CmdHF14AMfCGetSc(const char *Cmd) {
+int CmdHF14AMfCGetSc(pm3_connection* conn, const char *Cmd) {
 	uint8_t memBlock[16] = {0x00};
 	uint8_t sectorNo = 0;
 	int i, res, flags, gen = 0, baseblock = 0, sect_size = 4;
@@ -2250,7 +2249,7 @@ int CmdHF14AMfCGetSc(const char *Cmd) {
 			/* generation 1b magic card */
 			flags |= CSETBLOCK_MAGIC_1B;
 
-		res = mfCGetBlock(baseblock + i, memBlock, flags);
+		res = mfCGetBlock(conn, baseblock + i, memBlock, flags);
 		if (res) {
 			PrintAndLog("Can't read block. %d error=%d", baseblock + i, res);
 			return 1;
@@ -2262,7 +2261,7 @@ int CmdHF14AMfCGetSc(const char *Cmd) {
 }
 
 
-int CmdHF14AMfCSave(const char *Cmd) {
+int CmdHF14AMfCSave(pm3_connection* conn, const char *Cmd) {
 
 	FILE * f;
 	char filename[FILE_PATH_SIZE] = {0x00};
@@ -2307,12 +2306,12 @@ int CmdHF14AMfCSave(const char *Cmd) {
 				/* generation 1b magic card */
 				flags |= CSETBLOCK_MAGIC_1B;
 
-			if (mfCGetBlock(i, buf, flags)) {
+			if (mfCGetBlock(conn, i, buf, flags)) {
 				PrintAndLog("Cant get block: %d", i);
 				break;
 			}
 
-			if (mfEmlSetMem(buf, i, 1)) {
+			if (mfEmlSetMem(conn, buf, i, 1)) {
 				PrintAndLog("Cant set emul block: %d", i);
 				return 3;
 			}
@@ -2332,7 +2331,7 @@ int CmdHF14AMfCSave(const char *Cmd) {
 			if (gen == 2)
 				/* generation 1b magic card */
 				flags |= CSETBLOCK_MAGIC_1B;
-			if (mfCGetBlock(0, buf, flags)) {
+			if (mfCGetBlock(conn, 0, buf, flags)) {
 				PrintAndLog("Cant get block: %d", 0);
 				len = sprintf(fnameptr, "dump");
 				fnameptr += len;
@@ -2365,7 +2364,7 @@ int CmdHF14AMfCSave(const char *Cmd) {
 			if (gen == 2)
 				/* generation 1b magic card */
 				flags |= CSETBLOCK_MAGIC_1B;
-			if (mfCGetBlock(i, buf, flags)) {
+			if (mfCGetBlock(conn, i, buf, flags)) {
 				PrintAndLog("Cant get block: %d", i);
 				break;
 			}
@@ -2382,7 +2381,7 @@ int CmdHF14AMfCSave(const char *Cmd) {
 }
 
 
-int CmdHF14AMfSniff(const char *Cmd){
+int CmdHF14AMfSniff(pm3_connection* conn, const char *Cmd){
 
 	bool wantLogToFile = 0;
 	bool wantDecrypt = 0;
@@ -2432,8 +2431,8 @@ int CmdHF14AMfSniff(const char *Cmd){
 	printf("-------------------------------------------------------------------------\n");
 
 	UsbCommand c = {CMD_MIFARE_SNIFFER, {0, 0, 0}};
-	clearCommandBuffer();
-	SendCommand(&c);
+	clearCommandBuffer(conn);
+	SendCommand(conn, &c);
 
 	// wait cycle
 	while (true) {
@@ -2446,7 +2445,7 @@ int CmdHF14AMfSniff(const char *Cmd){
 		}
 
 		UsbCommand resp;
-		if (WaitForResponseTimeout(CMD_ACK,&resp,2000)) {
+		if (WaitForResponseTimeout(conn, CMD_ACK,&resp,2000)) {
 			res = resp.arg[0] & 0xff;
 			uint16_t traceLen = resp.arg[1];
 			len = resp.arg[2];
@@ -2533,7 +2532,7 @@ int CmdHF14AMfSniff(const char *Cmd){
 }
 
 //needs nt, ar, at, Data to decrypt
-int CmdDecryptTraceCmds(const char *Cmd){
+int CmdDecryptTraceCmds(pm3_connection* conn, const char *Cmd){
 	uint8_t data[50];
 	int len = 0;
 	param_gethex_ex(Cmd,3,data,&len);
@@ -2573,17 +2572,17 @@ static command_t CommandTable[] =
   {NULL,               NULL,                    0, NULL}
 };
 
-int CmdHFMF(const char *Cmd)
+int CmdHFMF(pm3_connection* conn, const char *Cmd)
 {
 	// flush
-	WaitForResponseTimeout(CMD_ACK,NULL,100);
+	WaitForResponseTimeout(conn, CMD_ACK,NULL,100);
 
-  CmdsParse(CommandTable, Cmd);
+  CmdsParse(conn, CommandTable, Cmd);
   return 0;
 }
 
-int CmdHelp(const char *Cmd)
+int CmdHelp(pm3_connection* conn, const char *Cmd)
 {
-  CmdsHelp(CommandTable);
+  CmdsHelp(conn, CommandTable);
   return 0;
 }

--- a/client/cmdhfmf.h
+++ b/client/cmdhfmf.h
@@ -10,38 +10,37 @@
 
 #ifndef CMDHFMF_H__
 #define CMDHFMF_H__
+#include "comms.h"
 
-#include "mifaredefault.h"
+extern int CmdHFMF(pm3_connection* conn, const char *Cmd);
 
-extern int CmdHFMF(const char *Cmd);
-
-extern int CmdHF14AMfDbg(const char* cmd);
-extern int CmdHF14AMfRdBl(const char* cmd);
-extern int CmdHF14AMfURdBl(const char* cmd);
-extern int CmdHF14AMfRdSc(const char* cmd);
-extern int CmdHF14SMfURdCard(const char* cmd);
-extern int CmdHF14AMfDump(const char* cmd);
-extern int CmdHF14AMfRestore(const char* cmd);
-extern int CmdHF14AMfWrBl(const char* cmd);
-extern int CmdHF14AMfUWrBl(const char* cmd);
-extern int CmdHF14AMfChk(const char* cmd);
-extern int CmdHF14AMifare(const char* cmd);
-extern int CmdHF14AMfNested(const char* cmd);
-extern int CmdHF14AMfSniff(const char* cmd);
-extern int CmdHF14AMf1kSim(const char* cmd);
-extern int CmdHF14AMfEClear(const char* cmd);
-extern int CmdHF14AMfEGet(const char* cmd);
-extern int CmdHF14AMfESet(const char* cmd);
-extern int CmdHF14AMfELoad(const char* cmd);
-extern int CmdHF14AMfESave(const char* cmd);
-extern int CmdHF14AMfECFill(const char* cmd);
-extern int CmdHF14AMfEKeyPrn(const char* cmd);
-extern int CmdHF14AMfCWipe(const char* cmd);
-extern int CmdHF14AMfCSetUID(const char* cmd);
-extern int CmdHF14AMfCSetBlk(const char* cmd);
-extern int CmdHF14AMfCGetBlk(const char* cmd);
-extern int CmdHF14AMfCGetSc(const char* cmd);
-extern int CmdHF14AMfCLoad(const char* cmd);
-extern int CmdHF14AMfCSave(const char* cmd);
+extern int CmdHF14AMfDbg(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfRdBl(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfURdBl(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfRdSc(pm3_connection* conn, const char* cmd);
+extern int CmdHF14SMfURdCard(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfDump(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfRestore(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfWrBl(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfUWrBl(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfChk(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMifare(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfNested(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfSniff(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMf1kSim(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfEClear(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfEGet(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfESet(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfELoad(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfESave(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfECFill(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfEKeyPrn(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfCSetUID(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfCSetBlk(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfCGetBlk(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfCGetSc(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfCLoad(pm3_connection* conn, const char* cmd);
+extern int CmdHF14AMfCSave(pm3_connection* conn, const char* cmd);
 
 #endif
+

--- a/client/cmdhfmfhard.h
+++ b/client/cmdhfmfhard.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "comms.h"
 
 #define NUM_SUMS 						19		// number of possible sum property values
 
@@ -41,7 +42,7 @@ typedef struct noncelist {
 	noncelistentry_t *first;
 } noncelist_t;
 
-int mfnestedhard(uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_t trgBlockNo, uint8_t trgKeyType, uint8_t *trgkey, bool nonce_file_read, bool nonce_file_write, bool slow, int tests);
+int mfnestedhard(pm3_connection* conn, uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_t trgBlockNo, uint8_t trgKeyType, uint8_t *trgkey, bool nonce_file_read, bool nonce_file_write, bool slow, int tests);
 void hardnested_print_progress(uint32_t nonces, char *activity, float brute_force, uint64_t min_diff_print_time);
 
 #endif

--- a/client/cmdhfmfu.h
+++ b/client/cmdhfmfu.h
@@ -4,26 +4,26 @@
 #ifndef CMDHFMFU_H__
 #define CMDHFMFU_H__
 
-int CmdHF14AMfUWrBl(const char *Cmd);
-int CmdHF14AMfURdBl(const char *Cmd);
+int CmdHF14AMfUWrBl(pm3_connection* conn, const char *Cmd);
+int CmdHF14AMfURdBl(pm3_connection* conn, const char *Cmd);
 
 //Crypto Cards
-int CmdHF14AMfucAuth(const char *Cmd);
+int CmdHF14AMfucAuth(pm3_connection* conn, const char *Cmd);
 
 //general stuff
-int CmdHF14AMfUDump(const char *Cmd);
-int CmdHF14AMfUInfo(const char *Cmd);
+int CmdHF14AMfUDump(pm3_connection* conn, const char *Cmd);
+int CmdHF14AMfUInfo(pm3_connection* conn, const char *Cmd);
 
-uint32_t GetHF14AMfU_Type(void);
+uint32_t GetHF14AMfU_Type(pm3_connection* conn);
 int ul_print_type(uint32_t tagtype, uint8_t spacer);
-void ul_switch_off_field(void);
+void ul_switch_off_field(pm3_connection* conn);
 
 int usage_hf_mfu_dump(void);
 int usage_hf_mfu_info(void);
 int usage_hf_mfu_rdbl(void);
 int usage_hf_mfu_wrbl(void);
 
-int CmdHFMFUltra(const char *Cmd);
+int CmdHFMFUltra(pm3_connection* conn, const char *Cmd);
 
 typedef enum TAGTYPE_UL {
 	UNKNOWN       = 0x000000,

--- a/client/cmdhftopaz.h
+++ b/client/cmdhftopaz.h
@@ -11,6 +11,6 @@
 #ifndef CMDHFTOPAZ_H__
 #define CMDHFTOPAZ_H__
 
-int CmdHFTopaz(const char *Cmd);
+int CmdHFTopaz(pm3_connection* conn, const char *Cmd);
 
 #endif

--- a/client/cmdhw.h
+++ b/client/cmdhw.h
@@ -11,17 +11,19 @@
 #ifndef CMDHW_H__
 #define CMDHW_H__
 
-int CmdHW(const char *Cmd);
+#include "comms.h"
 
-int CmdDetectReader(const char *Cmd);
-int CmdFPGAOff(const char *Cmd);
-int CmdLCD(const char *Cmd);
-int CmdLCDReset(const char *Cmd);
-int CmdReadmem(const char *Cmd);
-int CmdReset(const char *Cmd);
-int CmdSetDivisor(const char *Cmd);
-int CmdSetMux(const char *Cmd);
-int CmdTune(const char *Cmd);
-int CmdVersion(const char *Cmd);
+int CmdHW(pm3_connection *conn, const char *Cmd);
+
+int CmdDetectReader(pm3_connection *conn, const char *Cmd);
+int CmdFPGAOff(pm3_connection *conn, const char *Cmd);
+int CmdLCD(pm3_connection *conn, const char *Cmd);
+int CmdLCDReset(pm3_connection *conn, const char *Cmd);
+int CmdReadmem(pm3_connection *conn, const char *Cmd);
+int CmdReset(pm3_connection *conn, const char *Cmd);
+int CmdSetDivisor(pm3_connection *conn, const char *Cmd);
+int CmdSetMux(pm3_connection *conn, const char *Cmd);
+int CmdTune(pm3_connection *conn, const char *Cmd);
+int CmdVersion(pm3_connection *conn, const char *Cmd);
 
 #endif

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -335,7 +335,7 @@ int CmdLFSetConfig(const char *Cmd)
 }
 
 bool lf_read(bool silent, uint32_t samples) {
-	if (offline) return false;
+	if (IsOffline()) return false;
 	UsbCommand c = {CMD_ACQUIRE_RAW_ADC_SAMPLES_125K, {silent,samples,0}};
 	clearCommandBuffer();
 	//And ship it to device
@@ -878,7 +878,7 @@ int CmdVchDemod(const char *Cmd)
 int CheckChipType(char cmdp) {
 	uint32_t wordData = 0;
 
-	if (offline || cmdp == '1') return 0;
+	if (IsOffline() || cmdp == '1') return 0;
 
 	save_restoreGB(GRAPH_SAVE);
 	save_restoreDB(GRAPH_SAVE);
@@ -923,7 +923,7 @@ int CmdLFfind(const char *Cmd)
 		return 0;
 	}
 
-	if (!offline && (cmdp != '1')) {
+	if (!IsOffline() && (cmdp != '1')) {
 		lf_read(true, 30000);
 	} else if (GraphTraceLen < minLength) {
 		PrintAndLog("Data in Graphbuffer was too small.");
@@ -939,7 +939,7 @@ int CmdLFfind(const char *Cmd)
 	// only run if graphbuffer is just noise as it should be for hitag/cotag
 	if (graphJustNoise(GraphBuffer, testLen)) {
 		// only run these tests if we are in online mode 
-		if (!offline && (cmdp != '1')) {
+		if (!IsOffline() && (cmdp != '1')) {
 			// test for em4x05 in reader talk first mode.
 			if (EM4x05Block0Test(&wordData)) {
 				PrintAndLog("\nValid EM4x05/EM4x69 Chip Found\nUse lf em 4x05readword/dump commands to read\n");

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -46,9 +46,10 @@
 #include "cmdlfnoralsy.h"// for noralsy menu
 #include "cmdlfsecurakey.h"//for securakey menu
 #include "cmdlfpac.h"    // for pac menu
+#include "comms.h"       // for pm3_connection
 
 bool g_lf_threshold_set = false;
-static int CmdHelp(const char *Cmd);
+static int CmdHelp(pm3_connection* conn, const char *Cmd);
 
 
 
@@ -71,7 +72,7 @@ int usage_lf_cmdread(void)
 }
 
 /* send a command before reading */
-int CmdLFCommandRead(const char *Cmd)
+int CmdLFCommandRead(pm3_connection* conn, const char *Cmd)
 {
 	static char dummy[3] = {0x20,0x00,0x00};
 	UsbCommand c = {CMD_MOD_THEN_ACQUIRE_RAW_ADC_SAMPLES_125K};
@@ -124,28 +125,28 @@ int CmdLFCommandRead(const char *Cmd)
 	// in case they specified 'H'
 	strcpy((char *)&c.d.asBytes + strlen((char *)c.d.asBytes), dummy);
 
-	clearCommandBuffer();
-	SendCommand(&c);
+	clearCommandBuffer(conn);
+	SendCommand(conn, &c);
 	return 0;
 }
 
-int CmdFlexdemod(const char *Cmd)
+int CmdFlexdemod(pm3_connection* conn, const char *Cmd)
 {
 	int i;
-	for (i = 0; i < GraphTraceLen; ++i) {
-		if (GraphBuffer[i] < 0) {
-			GraphBuffer[i] = -1;
+	for (i = 0; i < conn->GraphTraceLen; ++i) {
+		if (conn->GraphBuffer[i] < 0) {
+			conn->GraphBuffer[i] = -1;
 		} else {
-			GraphBuffer[i] = 1;
+			conn->GraphBuffer[i] = 1;
 		}
 	}
 
  #define LONG_WAIT 100
 	int start;
-	for (start = 0; start < GraphTraceLen - LONG_WAIT; start++) {
-		int first = GraphBuffer[start];
+	for (start = 0; start < conn->GraphTraceLen - LONG_WAIT; start++) {
+		int first = conn->GraphBuffer[start];
 		for (i = start; i < start + LONG_WAIT; i++) {
-			if (GraphBuffer[i] != first) {
+			if (conn->GraphBuffer[i] != first) {
 				break;
 			}
 		}
@@ -153,13 +154,13 @@ int CmdFlexdemod(const char *Cmd)
 			break;
 		}
 	}
-	if (start == GraphTraceLen - LONG_WAIT) {
+	if (start == conn->GraphTraceLen - LONG_WAIT) {
 		PrintAndLog("nothing to wait for");
 		return 0;
 	}
 
-	GraphBuffer[start] = 2;
-	GraphBuffer[start+1] = -2;
+	conn->GraphBuffer[start] = 2;
+	conn->GraphBuffer[start+1] = -2;
 	uint8_t bits[64] = {0x00};
 
 	int bit, sum;
@@ -167,7 +168,7 @@ int CmdFlexdemod(const char *Cmd)
 	for (bit = 0; bit < 64; bit++) {
 		sum = 0;
 		for (int j = 0; j < 16; j++) {
-			sum += GraphBuffer[i++];
+			sum += conn->GraphBuffer[i++];
 		}
 
 		bits[bit] = (sum > 0) ? 1 : 0;
@@ -179,7 +180,7 @@ int CmdFlexdemod(const char *Cmd)
 		int j;
 		int sum = 0;
 		for (j = 0; j < 16; j++) {
-			sum += GraphBuffer[i++];
+			sum += conn->GraphBuffer[i++];
 		}
 		if (sum > 0 && bits[bit] != 1) {
 			PrintAndLog("oops1 at %d", bit);
@@ -190,7 +191,7 @@ int CmdFlexdemod(const char *Cmd)
 	}
 
 	// HACK writing back to graphbuffer.
-	GraphTraceLen = 32*64;
+	conn->GraphTraceLen = 32*64;
 	i = 0;
 	int phase = 0;
 	for (bit = 0; bit < 64; bit++) {
@@ -199,12 +200,12 @@ int CmdFlexdemod(const char *Cmd)
 		
 		int j;
 		for (j = 0; j < 32; j++) {
-			GraphBuffer[i++] = phase;
+			conn->GraphBuffer[i++] = phase;
 			phase = !phase;
 		}
 	}
 
-	RepaintGraphWindow();
+	RepaintGraphWindow(conn);
 	return 0;
 }	
 
@@ -253,7 +254,7 @@ int usage_lf_config(void)
 	return 0;
 }
 
-int CmdLFSetConfig(const char *Cmd)
+int CmdLFSetConfig(pm3_connection* conn, const char *Cmd)
 {
 
 	uint8_t divisor =  0;//Frequency divisor
@@ -329,34 +330,34 @@ int CmdLFSetConfig(const char *Cmd)
 	//Averaging is a flag on high-bit of arg[1]
 	UsbCommand c = {CMD_SET_LF_SAMPLING_CONFIG};
 	memcpy(c.d.asBytes,&config,sizeof(sample_config));
-	clearCommandBuffer();
-	SendCommand(&c);
+	clearCommandBuffer(conn);
+	SendCommand(conn, &c);
 	return 0;
 }
 
-bool lf_read(bool silent, uint32_t samples) {
-	if (IsOffline()) return false;
+bool lf_read(pm3_connection* conn, bool silent, uint32_t samples) {
+	if (conn->offline) return false;
 	UsbCommand c = {CMD_ACQUIRE_RAW_ADC_SAMPLES_125K, {silent,samples,0}};
-	clearCommandBuffer();
+	clearCommandBuffer(conn);
 	//And ship it to device
-	SendCommand(&c);
+	SendCommand(conn, &c);
 
 	UsbCommand resp;
 	if (g_lf_threshold_set) {
-		WaitForResponse(CMD_ACK,&resp);
+		WaitForResponse(conn, CMD_ACK,&resp);
 	} else {
-		if ( !WaitForResponseTimeout(CMD_ACK,&resp,2500) ) {
+		if ( !WaitForResponseTimeout(conn, CMD_ACK,&resp,2500) ) {
 			PrintAndLog("command execution time out");
 			return false;
 		}
 	}
 	// resp.arg[0] is bits read not bytes read.
-	getSamples(resp.arg[0]/8, silent);
+	getSamples(conn, resp.arg[0]/8, silent);
 
 	return true;
 }
 
-int CmdLFRead(const char *Cmd)
+int CmdLFRead(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t cmdp = 0;
 	bool silent = false;
@@ -369,10 +370,10 @@ int CmdLFRead(const char *Cmd)
 		cmdp++;
 	}
 	uint32_t samples = param_get32ex(Cmd, cmdp, 0, 10);
-	return lf_read(silent, samples);
+	return lf_read(conn, silent, samples);
 }
 
-int CmdLFSnoop(const char *Cmd)
+int CmdLFSnoop(pm3_connection* conn, const char *Cmd)
 {
 	uint8_t cmdp =0;
 	if(param_getchar(Cmd, cmdp) == 'h')
@@ -381,29 +382,29 @@ int CmdLFSnoop(const char *Cmd)
 	}
 
 	UsbCommand c = {CMD_LF_SNOOP_RAW_ADC_SAMPLES};
-	clearCommandBuffer();
-	SendCommand(&c);
-	WaitForResponse(CMD_ACK,NULL);
-	getSamples(0, true);
+	clearCommandBuffer(conn);
+	SendCommand(conn, &c);
+	WaitForResponse(conn, CMD_ACK,NULL);
+	getSamples(conn, 0, true);
 
 	return 0;
 }
 
-static void ChkBitstream(const char *str)
+static void ChkBitstream(pm3_connection* conn, const char *str)
 {
 	int i;
  
 	/* convert to bitstream if necessary */
-	for (i = 0; i < (int)(GraphTraceLen / 2); i++){
-		if (GraphBuffer[i] > 1 || GraphBuffer[i] < 0) {
-			CmdGetBitStream("");
+	for (i = 0; i < (int)(conn->GraphTraceLen / 2); i++){
+		if (conn->GraphBuffer[i] > 1 || conn->GraphBuffer[i] < 0) {
+			CmdGetBitStream(conn, "");
 			break;
 		}
 	}
 }
 //Attempt to simulate any wave in buffer (one bit per output sample)
-// converts GraphBuffer to bitstream (based on zero crossings) if needed.
-int CmdLFSim(const char *Cmd)
+// converts conn->GraphBuffer to bitstream (based on zero crossings) if needed.
+int CmdLFSim(pm3_connection* conn, const char *Cmd)
 {
 	int i,j;
 	static int gap;
@@ -411,26 +412,26 @@ int CmdLFSim(const char *Cmd)
 	sscanf(Cmd, "%i", &gap);
 
 	// convert to bitstream if necessary
-	ChkBitstream(Cmd);
+	ChkBitstream(conn, Cmd);
 
 	//can send only 512 bits at a time (1 byte sent per bit...)
-	printf("Sending [%d bytes]", GraphTraceLen);
-	for (i = 0; i < GraphTraceLen; i += USB_CMD_DATA_SIZE) {
+	printf("Sending [%d bytes]", conn->GraphTraceLen);
+	for (i = 0; i < conn->GraphTraceLen; i += USB_CMD_DATA_SIZE) {
 		UsbCommand c = {CMD_DOWNLOADED_SIM_SAMPLES_125K, {i, 0, 0}};
 
 		for (j = 0; j < USB_CMD_DATA_SIZE; j++) {
-			c.d.asBytes[j] = GraphBuffer[i+j];
+			c.d.asBytes[j] = conn->GraphBuffer[i+j];
 		}
-		SendCommand(&c);
-		WaitForResponse(CMD_ACK,NULL);
+		SendCommand(conn, &c);
+		WaitForResponse(conn, CMD_ACK,NULL);
 		printf(".");
 	}
 
 	printf("\n");
 	PrintAndLog("Starting to simulate");
-	UsbCommand c = {CMD_SIMULATE_TAG_125K, {GraphTraceLen, gap, 0}};
-	clearCommandBuffer();
-	SendCommand(&c);
+	UsbCommand c = {CMD_SIMULATE_TAG_125K, {conn->GraphTraceLen, gap, 0}};
+	clearCommandBuffer(conn);
+	SendCommand(conn, &c);
 	return 0;
 }
 
@@ -440,12 +441,12 @@ int usage_lf_simfsk(void)
 	PrintAndLog("Usage: lf simfsk [c <clock>] [i] [H <fcHigh>] [L <fcLow>] [d <hexdata>]");
 	PrintAndLog("Options:        ");
 	PrintAndLog("       h              This help");
-	PrintAndLog("       c <clock>      Manually set clock - can autodetect if using DemodBuffer");
+	PrintAndLog("       c <clock>      Manually set clock - can autodetect if using conn->DemodBuffer");
 	PrintAndLog("       i              invert data");
 	PrintAndLog("       H <fcHigh>     Manually set the larger Field Clock");
 	PrintAndLog("       L <fcLow>      Manually set the smaller Field Clock");
 	//PrintAndLog("       s              TBD- -to enable a gap between playback repetitions - default: no gap");
-	PrintAndLog("       d <hexdata>    Data to sim as hex - omit to sim from DemodBuffer");
+	PrintAndLog("       d <hexdata>    Data to sim as hex - omit to sim from conn->DemodBuffer");
 	PrintAndLog("\n  NOTE: if you set one clock manually set them all manually");
 	return 0;
 }
@@ -456,13 +457,13 @@ int usage_lf_simask(void)
 	PrintAndLog("Usage: lf simask [c <clock>] [i] [b|m|r] [s] [d <raw hex to sim>]");
 	PrintAndLog("Options:        ");
 	PrintAndLog("       h              This help");
-	PrintAndLog("       c <clock>      Manually set clock - can autodetect if using DemodBuffer");
+	PrintAndLog("       c <clock>      Manually set clock - can autodetect if using conn->DemodBuffer");
 	PrintAndLog("       i              invert data");
 	PrintAndLog("       b              sim ask/biphase");
 	PrintAndLog("       m              sim ask/manchester - Default");
 	PrintAndLog("       r              sim ask/raw");
 	PrintAndLog("       s              add t55xx Sequence Terminator gap - default: no gaps (only manchester)");
-	PrintAndLog("       d <hexdata>    Data to sim as hex - omit to sim from DemodBuffer");
+	PrintAndLog("       d <hexdata>    Data to sim as hex - omit to sim from conn->DemodBuffer");
 	return 0;
 }
 
@@ -472,19 +473,19 @@ int usage_lf_simpsk(void)
 	PrintAndLog("Usage: lf simpsk [1|2|3] [c <clock>] [i] [r <carrier>] [d <raw hex to sim>]");
 	PrintAndLog("Options:        ");
 	PrintAndLog("       h              This help");
-	PrintAndLog("       c <clock>      Manually set clock - can autodetect if using DemodBuffer");
+	PrintAndLog("       c <clock>      Manually set clock - can autodetect if using conn->DemodBuffer");
 	PrintAndLog("       i              invert data");
 	PrintAndLog("       1              set PSK1 (default)");
 	PrintAndLog("       2              set PSK2");
 	PrintAndLog("       3              set PSK3");
 	PrintAndLog("       r <carrier>    2|4|8 are valid carriers: default = 2");
-	PrintAndLog("       d <hexdata>    Data to sim as hex - omit to sim from DemodBuffer");
+	PrintAndLog("       d <hexdata>    Data to sim as hex - omit to sim from conn->DemodBuffer");
 	return 0;
 }
 
 // by marshmellow - sim fsk data given clock, fcHigh, fcLow, invert 
-// - allow pull data from DemodBuffer
-int CmdLFfskSim(const char *Cmd)
+// - allow pull data from conn->DemodBuffer
+int CmdLFfskSim(pm3_connection* conn, const char *Cmd)
 {
 	//might be able to autodetect FCs and clock from Graphbuffer if using demod buffer
 	// otherwise will need FChigh, FClow, Clock, and bitstream
@@ -539,7 +540,7 @@ int CmdLFfskSim(const char *Cmd)
 		}
 		if(errors) break;
 	}
-	if(cmdp == 0 && DemodBufferLen == 0)
+	if(cmdp == 0 && conn->DemodBufferLen == 0)
 	{
 		errors = true;// No args
 	}
@@ -550,9 +551,9 @@ int CmdLFfskSim(const char *Cmd)
 		return usage_lf_simfsk();
 	}
 	int firstClockEdge = 0;
-	if (dataLen == 0){ //using DemodBuffer 
+	if (dataLen == 0){ //using conn->DemodBuffer 
 		if (clk==0 || fcHigh==0 || fcLow==0){ //manual settings must set them all
-			uint8_t ans = fskClocks(&fcHigh, &fcLow, &clk, 0, &firstClockEdge);
+			uint8_t ans = fskClocks(conn, &fcHigh, &fcLow, &clk, 0, &firstClockEdge);
 			if (ans==0){
 				if (!fcHigh) fcHigh=10;
 				if (!fcLow) fcLow=8;
@@ -560,7 +561,7 @@ int CmdLFfskSim(const char *Cmd)
 			}
 		}
 	} else {
-		setDemodBuf(data, dataLen, 0);
+		setDemodBuf(conn, data, dataLen, 0);
 	}
 
 	//default if not found
@@ -571,22 +572,22 @@ int CmdLFfskSim(const char *Cmd)
 	uint16_t arg1, arg2;
 	arg1 = fcHigh << 8 | fcLow;
 	arg2 = invert << 8 | clk;
-	size_t size = DemodBufferLen;
+	size_t size = conn->DemodBufferLen;
 	if (size > USB_CMD_DATA_SIZE) {
-		PrintAndLog("DemodBuffer too long for current implementation - length: %d - max: %d", size, USB_CMD_DATA_SIZE);
+		PrintAndLog("conn->DemodBuffer too long for current implementation - length: %d - max: %d", size, USB_CMD_DATA_SIZE);
 		size = USB_CMD_DATA_SIZE;
 	} 
 	UsbCommand c = {CMD_FSK_SIM_TAG, {arg1, arg2, size}};
 
-	memcpy(c.d.asBytes, DemodBuffer, size);
-	clearCommandBuffer();
-	SendCommand(&c);
+	memcpy(c.d.asBytes, conn->DemodBuffer, size);
+	clearCommandBuffer(conn);
+	SendCommand(conn, &c);
 	return 0;
 }
 
 // by marshmellow - sim ask data given clock, invert, manchester or raw, separator 
-// - allow pull data from DemodBuffer
-int CmdLFaskSim(const char *Cmd)
+// - allow pull data from conn->DemodBuffer
+int CmdLFaskSim(pm3_connection* conn, const char *Cmd)
 {
 	//autodetect clock from Graphbuffer if using demod buffer
 	// needs clock, invert, manchester/raw as m or r, separator as s, and bitstream
@@ -645,7 +646,7 @@ int CmdLFaskSim(const char *Cmd)
 		}
 		if(errors) break;
 	}
-	if(cmdp == 0 && DemodBufferLen == 0)
+	if(cmdp == 0 && conn->DemodBufferLen == 0)
 	{
 		errors = true;// No args
 	}
@@ -655,32 +656,32 @@ int CmdLFaskSim(const char *Cmd)
 	{
 		return usage_lf_simask();
 	}
-	if (dataLen == 0){ //using DemodBuffer
-		if (clk == 0) clk = GetAskClock("0", false, false);
+	if (dataLen == 0){ //using conn->DemodBuffer
+		if (clk == 0) clk = GetAskClock(conn, "0", false, false);
 	} else {
-		setDemodBuf(data, dataLen, 0);
+		setDemodBuf(conn, data, dataLen, 0);
 	}
 	if (clk == 0) clk = 64;
 	if (encoding == 0) clk = clk/2; //askraw needs to double the clock speed
 	uint16_t arg1, arg2;
-	size_t size=DemodBufferLen;
+	size_t size=conn->DemodBufferLen;
 	arg1 = clk << 8 | encoding;
 	arg2 = invert << 8 | separator;
 	if (size > USB_CMD_DATA_SIZE) {
-		PrintAndLog("DemodBuffer too long for current implementation - length: %d - max: %d", size, USB_CMD_DATA_SIZE);
+		PrintAndLog("conn->DemodBuffer too long for current implementation - length: %d - max: %d", size, USB_CMD_DATA_SIZE);
 		size = USB_CMD_DATA_SIZE;
 	}
 	UsbCommand c = {CMD_ASK_SIM_TAG, {arg1, arg2, size}};
 	PrintAndLog("preparing to sim ask data: %d bits", size);
-	memcpy(c.d.asBytes, DemodBuffer, size);
-	clearCommandBuffer();
-	SendCommand(&c);
+	memcpy(c.d.asBytes, conn->DemodBuffer, size);
+	clearCommandBuffer(conn);
+	SendCommand(conn, &c);
 	return 0;
 }
 
 // by marshmellow - sim psk data given carrier, clock, invert 
-// - allow pull data from DemodBuffer or parameters
-int CmdLFpskSim(const char *Cmd)
+// - allow pull data from conn->DemodBuffer or parameters
+int CmdLFpskSim(pm3_connection* conn, const char *Cmd)
 {
 	//might be able to autodetect FC and clock from Graphbuffer if using demod buffer
 	//will need carrier, Clock, and bitstream
@@ -740,7 +741,7 @@ int CmdLFpskSim(const char *Cmd)
 		}
 		if (errors) break;
 	}
-	if (cmdp == 0 && DemodBufferLen == 0)
+	if (cmdp == 0 && conn->DemodBufferLen == 0)
 	{
 		errors = true;// No args
 	}
@@ -750,14 +751,14 @@ int CmdLFpskSim(const char *Cmd)
 	{
 		return usage_lf_simpsk();
 	}
-	if (dataLen == 0){ //using DemodBuffer
+	if (dataLen == 0){ //using conn->DemodBuffer
 		PrintAndLog("Getting Clocks");
-		if (clk==0) clk = GetPskClock("", false, false);
+		if (clk==0) clk = GetPskClock(conn, "", false, false);
 		PrintAndLog("clk: %d",clk);
-		if (!carrier) carrier = GetPskCarrier("", false, false); 
+		if (!carrier) carrier = GetPskCarrier(conn, "", false, false); 
 		PrintAndLog("carrier: %d", carrier);
 	} else {
-		setDemodBuf(data, dataLen, 0);
+		setDemodBuf(conn, data, dataLen, 0);
 	}
 
 	if (clk <= 0) clk = 32;
@@ -765,7 +766,7 @@ int CmdLFpskSim(const char *Cmd)
 	if (pskType != 1){
 		if (pskType == 2){
 			//need to convert psk2 to psk1 data before sim
-			psk2TOpsk1(DemodBuffer, DemodBufferLen);
+			psk2TOpsk1(conn->DemodBuffer, conn->DemodBufferLen);
 		} else {
 			PrintAndLog("Sorry, PSK3 not yet available");
 		}
@@ -773,31 +774,31 @@ int CmdLFpskSim(const char *Cmd)
 	uint16_t arg1, arg2;
 	arg1 = clk << 8 | carrier;
 	arg2 = invert;
-	size_t size=DemodBufferLen;
+	size_t size=conn->DemodBufferLen;
 	if (size > USB_CMD_DATA_SIZE) {
-		PrintAndLog("DemodBuffer too long for current implementation - length: %d - max: %d", size, USB_CMD_DATA_SIZE);
+		PrintAndLog("conn->DemodBuffer too long for current implementation - length: %d - max: %d", size, USB_CMD_DATA_SIZE);
 		size=USB_CMD_DATA_SIZE;
 	}
 	UsbCommand c = {CMD_PSK_SIM_TAG, {arg1, arg2, size}};
-	PrintAndLog("DEBUG: Sending DemodBuffer Length: %d", size);
-	memcpy(c.d.asBytes, DemodBuffer, size);
-	clearCommandBuffer();
-	SendCommand(&c);
+	PrintAndLog("DEBUG: Sending conn->DemodBuffer Length: %d", size);
+	memcpy(c.d.asBytes, conn->DemodBuffer, size);
+	clearCommandBuffer(conn);
+	SendCommand(conn, &c);
 	
 	return 0;
 }
 
-int CmdLFSimBidir(const char *Cmd)
+int CmdLFSimBidir(pm3_connection* conn, const char *Cmd)
 {
 	// Set ADC to twice the carrier for a slight supersampling
 	// HACK: not implemented in ARMSRC.
 	PrintAndLog("Not implemented yet.");
 	UsbCommand c = {CMD_LF_SIMULATE_BIDIR, {47, 384, 0}};
-	SendCommand(&c);
+	SendCommand(conn, &c);
 	return 0;
 }
 
-int CmdVchDemod(const char *Cmd)
+int CmdVchDemod(pm3_connection* conn, const char *Cmd)
 {
 	// Is this the entire sync pattern, or does this also include some
 	// data bits that happen to be the same everywhere? That would be
@@ -820,11 +821,11 @@ int CmdVchDemod(const char *Cmd)
 	int i;
 	// It does us no good to find the sync pattern, with fewer than
 	// 2048 samples after it...
-	for (i = 0; i < (GraphTraceLen-2048); i++) {
+	for (i = 0; i < (conn->GraphTraceLen-2048); i++) {
 		int sum = 0;
 		int j;
 		for (j = 0; j < arraylen(SyncPattern); j++) {
-			sum += GraphBuffer[i+j]*SyncPattern[j];
+			sum += conn->GraphBuffer[i+j]*SyncPattern[j];
 		}
 		if (sum > bestCorrel) {
 			bestCorrel = sum;
@@ -843,7 +844,7 @@ int CmdVchDemod(const char *Cmd)
 		int sum = 0;
 		int j;
 		for (j = 0; j < 8; j++) {
-			sum += GraphBuffer[bestPos+i+j];
+			sum += conn->GraphBuffer[bestPos+i+j];
 		}
 		if (sum < 0) {
 			bits[i/8] = '.';
@@ -860,50 +861,50 @@ int CmdVchDemod(const char *Cmd)
 	PrintAndLog("worst metric: %d at pos %d", worst, worstPos);
 
 	if (strcmp(Cmd, "clone")==0) {
-		GraphTraceLen = 0;
+		conn->GraphTraceLen = 0;
 		char *s;
 		for(s = bits; *s; s++) {
 			int j;
 			for(j = 0; j < 16; j++) {
-				GraphBuffer[GraphTraceLen++] = (*s == '1') ? 1 : 0;
+				conn->GraphBuffer[conn->GraphTraceLen++] = (*s == '1') ? 1 : 0;
 			}
 		}
-		RepaintGraphWindow();
+		RepaintGraphWindow(conn);
 	}
 	return 0;
 }
 
 
 //by marshmellow
-int CheckChipType(char cmdp) {
+int CheckChipType(pm3_connection* conn, char cmdp) {
 	uint32_t wordData = 0;
 
-	if (IsOffline() || cmdp == '1') return 0;
+	if (conn->offline || cmdp == '1') return 0;
 
-	save_restoreGB(GRAPH_SAVE);
-	save_restoreDB(GRAPH_SAVE);
+	save_restoreGB(conn, GRAPH_SAVE);
+	save_restoreDB(conn, GRAPH_SAVE);
 	//check for em4x05/em4x69 chips first
-	if (EM4x05Block0Test(&wordData)) {
+	if (EM4x05Block0Test(conn, &wordData)) {
 		PrintAndLog("\nValid EM4x05/EM4x69 Chip Found\nTry lf em 4x05... commands\n");
-		save_restoreGB(GRAPH_RESTORE);
-		save_restoreDB(GRAPH_RESTORE);
+		save_restoreGB(conn, GRAPH_RESTORE);
+		save_restoreDB(conn, GRAPH_RESTORE);
 		return 1;
 	}
 
 	//check for t55xx chip...
-	if (tryDetectP1(true)) {
+	if (tryDetectP1(conn, true)) {
 		PrintAndLog("\nValid T55xx Chip Found\nTry lf t55xx ... commands\n");
-		save_restoreGB(GRAPH_RESTORE);
-		save_restoreDB(GRAPH_RESTORE);
+		save_restoreGB(conn, GRAPH_RESTORE);
+		save_restoreDB(conn, GRAPH_RESTORE);
 		return 1;		
 	}
-	save_restoreGB(GRAPH_RESTORE);
-	save_restoreDB(GRAPH_RESTORE);
+	save_restoreGB(conn, GRAPH_RESTORE);
+	save_restoreDB(conn, GRAPH_RESTORE);
 	return 0;
 }
 
 //by marshmellow
-int CmdLFfind(const char *Cmd)
+int CmdLFfind(pm3_connection* conn, const char *Cmd)
 {
 	uint32_t wordData = 0;
 	int ans=0;
@@ -916,16 +917,16 @@ int CmdLFfind(const char *Cmd)
 		PrintAndLog("     [Search for Unknown tags] , if not set, reads only known tags.");
 		PrintAndLog("");
 		PrintAndLog("    sample: lf search     = try reading data from tag & search for known tags");
-		PrintAndLog("          : lf search 1   = use data from GraphBuffer & search for known tags");
+		PrintAndLog("          : lf search 1   = use data from conn->GraphBuffer & search for known tags");
 		PrintAndLog("          : lf search u   = try reading data from tag & search for known and unknown tags");
-		PrintAndLog("          : lf search 1 u = use data from GraphBuffer & search for known and unknown tags");
+		PrintAndLog("          : lf search 1 u = use data from conn->GraphBuffer & search for known and unknown tags");
 
 		return 0;
 	}
 
-	if (!IsOffline() && (cmdp != '1')) {
-		lf_read(true, 30000);
-	} else if (GraphTraceLen < minLength) {
+	if (!conn->offline && (cmdp != '1')) {
+		lf_read(conn, true, 30000);
+	} else if (conn->GraphTraceLen < minLength) {
 		PrintAndLog("Data in Graphbuffer was too small.");
 		return 0;
 	}
@@ -937,19 +938,19 @@ int CmdLFfind(const char *Cmd)
 
 	size_t testLen = minLength;
 	// only run if graphbuffer is just noise as it should be for hitag/cotag
-	if (graphJustNoise(GraphBuffer, testLen)) {
+	if (graphJustNoise(conn->GraphBuffer, testLen)) {
 		// only run these tests if we are in online mode 
-		if (!IsOffline() && (cmdp != '1')) {
+		if (!conn->offline && (cmdp != '1')) {
 			// test for em4x05 in reader talk first mode.
-			if (EM4x05Block0Test(&wordData)) {
+			if (EM4x05Block0Test(conn, &wordData)) {
 				PrintAndLog("\nValid EM4x05/EM4x69 Chip Found\nUse lf em 4x05readword/dump commands to read\n");
 				return 1;
 			}
-			ans=CmdLFHitagReader("26");
+			ans=CmdLFHitagReader(conn, "26");
 			if (ans==0) {
 				return 1;
 			}
-			ans=CmdCOTAGRead("");
+			ans=CmdCOTAGRead(conn, "");
 			if (ans>0) {
 				PrintAndLog("\nValid COTAG ID Found!");
 				return 1;
@@ -960,138 +961,138 @@ int CmdLFfind(const char *Cmd)
 
 	// TODO test for modulation then only test formats that use that modulation
 
-	ans=CmdFSKdemodIO("");
+	ans=CmdFSKdemodIO(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid IO Prox ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdFSKdemodPyramid("");
+	ans=CmdFSKdemodPyramid(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid Pyramid ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdFSKdemodParadox("");
+	ans=CmdFSKdemodParadox(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid Paradox ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdFSKdemodAWID("");
+	ans=CmdFSKdemodAWID(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid AWID ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdFSKdemodHID("");
+	ans=CmdFSKdemodHID(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid HID Prox ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdAskEM410xDemod("");
+	ans=CmdAskEM410xDemod(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid EM410x ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdVisa2kDemod("");
+	ans=CmdVisa2kDemod(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid Visa2000 ID Found!");
-		return CheckChipType(cmdp);		
+		return CheckChipType(conn, cmdp);		
 	}
 	
-	ans=CmdG_Prox_II_Demod("");
+	ans=CmdG_Prox_II_Demod(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid G Prox II ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdFdxDemod(""); //biphase
+	ans=CmdFdxDemod(conn, ""); //biphase
 	if (ans>0) {
 		PrintAndLog("\nValid FDX-B ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=EM4x50Read("", false); //ask
+	ans=EM4x50Read(conn, "", false); //ask
 	if (ans>0) {
 		PrintAndLog("\nValid EM4x50 ID Found!");
 		return 1;
 	}
 
-	ans=CmdJablotronDemod("");
+	ans=CmdJablotronDemod(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid Jablotron ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdNoralsyDemod("");
+	ans=CmdNoralsyDemod(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid Noralsy ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdSecurakeyDemod("");
+	ans=CmdSecurakeyDemod(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid Securakey ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdVikingDemod("");
+	ans=CmdVikingDemod(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid Viking ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdIndalaDecode(""); //psk
+	ans=CmdIndalaDecode(conn, ""); //psk
 	if (ans>0) {
 		PrintAndLog("\nValid Indala ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdPSKNexWatch("");
+	ans=CmdPSKNexWatch(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid NexWatch ID Found!");
-		return CheckChipType(cmdp);
+		return CheckChipType(conn, cmdp);
 	}
 
-	ans=CmdPacDemod("");
+	ans=CmdPacDemod(conn, "");
 	if (ans>0) {
 		PrintAndLog("\nValid PAC/Stanley ID Found!");
-		return CheckChipType(cmdp);		
+		return CheckChipType(conn, cmdp);		
 	}
 
 	PrintAndLog("\nNo Known Tags Found!\n");
 	if (testRaw=='u' || testRaw=='U') {
-		//ans=CheckChipType(cmdp);
+		//ans=CheckChipType(conn, cmdp);
 		//test unknown tag formats (raw mode)0
 		PrintAndLog("\nChecking for Unknown tags:\n");
-		ans=AutoCorrelate(GraphBuffer, GraphBuffer, GraphTraceLen, 4000, false, false);
+		ans=AutoCorrelate(conn, conn->GraphBuffer, conn->GraphBuffer, conn->GraphTraceLen, 4000, false, false);
 		if (ans > 0) PrintAndLog("Possible Auto Correlation of %d repeating samples",ans);
-		ans=GetFskClock("",false,false); 
+		ans=GetFskClock(conn, "", false, false); 
 		if (ans != 0) { //fsk
-			ans=FSKrawDemod("",true);
+			ans=FSKrawDemod(conn, "", true);
 			if (ans>0) {
 				PrintAndLog("\nUnknown FSK Modulated Tag Found!");
-				return CheckChipType(cmdp);
+				return CheckChipType(conn, cmdp);
 			}
 		}
 		bool st = true;
-		ans=ASKDemod_ext("0 0 0",true,false,1,&st);
+		ans=ASKDemod_ext(conn, "0 0 0",true,false,1,&st);
 		if (ans>0) {
 			PrintAndLog("\nUnknown ASK Modulated and Manchester encoded Tag Found!");
 			PrintAndLog("\nif it does not look right it could instead be ASK/Biphase - try 'data rawdemod ab'");
-			return CheckChipType(cmdp);
+			return CheckChipType(conn, cmdp);
 		}
-		ans=CmdPSK1rawDemod("");
+		ans=CmdPSK1rawDemod(conn, "");
 		if (ans>0) {
 			PrintAndLog("Possible unknown PSK1 Modulated Tag Found above!\n\nCould also be PSK2 - try 'data rawdemod p2'");
 			PrintAndLog("\nCould also be PSK3 - [currently not supported]");
 			PrintAndLog("\nCould also be NRZ - try 'data rawdemod nr'");
-			return CheckChipType(cmdp);
+			return CheckChipType(conn, cmdp);
 		}
-		ans = CheckChipType(cmdp);
+		ans = CheckChipType(conn, cmdp);
 		PrintAndLog("\nNo Data Found!\n");
 	}
 	return 0;
@@ -1122,29 +1123,29 @@ static command_t CommandTable[] =
 	{"ti",          CmdLFTI,            1, "{ TI CHIPs...                }"},
 	{"viking",      CmdLFViking,        1, "{ Viking RFIDs...            }"},
 	{"visa2000",    CmdLFVisa2k,        1, "{ Visa2000 RFIDs...          }"},
-	{"cmdread",     CmdLFCommandRead,   0, "<d period> <z period> <o period> <c command> ['H'] -- Modulate LF reader field to send command before read (all periods in microseconds) (option 'H' for 134)"},
+	{"cmdread",     CmdLFCommandRead,   0, "<d period> <z period> <o period> <c command> ['H'] -- Modulate LF reader field to send command before read (conn, all periods in microseconds) (option 'H' for 134)"},
 	{"config",      CmdLFSetConfig,     0, "Set config for LF sampling, bit/sample, decimation, frequency"},
 	{"flexdemod",   CmdFlexdemod,       1, "Demodulate samples for FlexPass"},
 	{"read",        CmdLFRead,          0, "['s' silent] Read 125/134 kHz LF ID-only tag. Do 'lf read h' for help"},
-	{"search",      CmdLFfind,          1, "[offline] ['u'] Read and Search for valid known tag (in offline mode it you can load first then search) - 'u' to search for unknown tags"},
-	{"sim",         CmdLFSim,           0, "[GAP] -- Simulate LF tag from buffer with optional GAP (in microseconds)"},
+	{"search",      CmdLFfind,          1, "[offline] ['u'] Read and Search for valid known tag (conn, in offline mode it you can load first then search) - 'u' to search for unknown tags"},
+	{"sim",         CmdLFSim,           0, "[GAP] -- Simulate LF tag from buffer with optional GAP (conn, in microseconds)"},
 	{"simask",      CmdLFaskSim,        0, "[clock] [invert <1|0>] [biphase/manchester/raw <'b'|'m'|'r'>] [msg separator 's'] [d <hexdata>] -- Simulate LF ASK tag from demodbuffer or input"},
 	{"simfsk",      CmdLFfskSim,        0, "[c <clock>] [i] [H <fcHigh>] [L <fcLow>] [d <hexdata>] -- Simulate LF FSK tag from demodbuffer or input"},
 	{"simpsk",      CmdLFpskSim,        0, "[1|2|3] [c <clock>] [i] [r <carrier>] [d <raw hex to sim>] -- Simulate LF PSK tag from demodbuffer or input"},
-	{"simbidir",    CmdLFSimBidir,      0, "Simulate LF tag (with bidirectional data transmission between reader and tag)"},
-	{"snoop",       CmdLFSnoop,         0, "['l'|'h'|<divisor>] [trigger threshold]-- Snoop LF (l:125khz, h:134khz)"},
+	{"simbidir",    CmdLFSimBidir,      0, "Simulate LF tag (conn, with bidirectional data transmission between reader and tag)"},
+	{"snoop",       CmdLFSnoop,         0, "['l'|'h'|<divisor>] [trigger threshold]-- Snoop LF (conn, l:125khz, h:134khz)"},
 	{"vchdemod",    CmdVchDemod,        1, "['clone'] -- Demodulate samples for VeriChip"},
 	{NULL, NULL, 0, NULL}
 };
 
-int CmdLF(const char *Cmd)
+int CmdLF(pm3_connection* conn, const char *Cmd)
 {
-	CmdsParse(CommandTable, Cmd);
+	CmdsParse(conn, CommandTable, Cmd);
 	return 0; 
 }
 
-int CmdHelp(const char *Cmd)
+int CmdHelp(pm3_connection* conn, const char *Cmd)
 {
-	CmdsHelp(CommandTable);
+	CmdsHelp(conn, CommandTable);
 	return 0;
 }

--- a/client/cmdlf.h
+++ b/client/cmdlf.h
@@ -13,22 +13,23 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "comms.h"
 
-extern int CmdLF(const char *Cmd);
+extern int CmdLF(pm3_connection* conn, const char *Cmd);
 
-extern int CmdLFCommandRead(const char *Cmd);
-extern int CmdFlexdemod(const char *Cmd);
-extern int CmdIndalaDemod(const char *Cmd);
-extern int CmdIndalaClone(const char *Cmd);
-extern int CmdLFRead(const char *Cmd);
-extern int CmdLFSim(const char *Cmd);
-extern int CmdLFaskSim(const char *Cmd);
-extern int CmdLFfskSim(const char *Cmd);
-extern int CmdLFpskSim(const char *Cmd);
-extern int CmdLFSimBidir(const char *Cmd);
-extern int CmdLFSnoop(const char *Cmd);
-extern int CmdVchDemod(const char *Cmd);
-extern int CmdLFfind(const char *Cmd);
-extern bool lf_read(bool silent, uint32_t samples);
+extern int CmdLFCommandRead(pm3_connection* conn, const char *Cmd);
+extern int CmdFlexdemod(pm3_connection* conn, const char *Cmd);
+extern int CmdIndalaDemod(pm3_connection* conn, const char *Cmd);
+extern int CmdIndalaClone(pm3_connection* conn, const char *Cmd);
+extern int CmdLFRead(pm3_connection* conn, const char *Cmd);
+extern int CmdLFSim(pm3_connection* conn, const char *Cmd);
+extern int CmdLFaskSim(pm3_connection* conn, const char *Cmd);
+extern int CmdLFfskSim(pm3_connection* conn, const char *Cmd);
+extern int CmdLFpskSim(pm3_connection* conn, const char *Cmd);
+extern int CmdLFSimBidir(pm3_connection* conn, const char *Cmd);
+extern int CmdLFSnoop(pm3_connection* conn, const char *Cmd);
+extern int CmdVchDemod(pm3_connection* conn, const char *Cmd);
+extern int CmdLFfind(pm3_connection* conn, const char *Cmd);
+extern bool lf_read(pm3_connection* conn, bool silent, uint32_t samples);
 
 #endif

--- a/client/cmdlfawid.h
+++ b/client/cmdlfawid.h
@@ -12,12 +12,13 @@
 #define CMDLFAWID_H__
 
 #include <stdint.h>  // for uint_32+
+#include "comms.h"
 
-int CmdLFAWID(const char *Cmd);
-int CmdAWIDReadFSK(const char *Cmd);
-int CmdAWIDSim(const char *Cmd);
-int CmdAWIDClone(const char *Cmd);
-int CmdFSKdemodAWID(const char *Cmd);
+int CmdLFAWID(pm3_connection* conn, const char *Cmd);
+int CmdAWIDReadFSK(pm3_connection* conn, const char *Cmd);
+int CmdAWIDSim(pm3_connection* conn, const char *Cmd);
+int CmdAWIDClone(pm3_connection* conn, const char *Cmd);
+int CmdFSKdemodAWID(pm3_connection* conn, const char *Cmd);
 int getAWIDBits(unsigned int fc, unsigned int cn, uint8_t *AWIDBits);
 int usage_lf_awid_fskdemod(void);
 int usage_lf_awid_clone(void);

--- a/client/cmdlfcotag.h
+++ b/client/cmdlfcotag.h
@@ -15,9 +15,9 @@
 #define COTAG_BITS 264
 #endif
 
-int CmdLFCOTAG(const char *Cmd);
-int CmdCOTAGRead(const char *Cmd);
-int CmdCOTAGDemod(const char *Cmd);
+int CmdLFCOTAG(pm3_connection* conn, const char *Cmd);
+int CmdCOTAGRead(pm3_connection* conn, const char *Cmd);
+int CmdCOTAGDemod(pm3_connection* conn, const char *Cmd);
 
 int usage_lf_cotag_read(void);
 #endif

--- a/client/cmdlfem4x.h
+++ b/client/cmdlfem4x.h
@@ -13,27 +13,28 @@
 
 #include <stdbool.h>    // for bool
 #include <inttypes.h>
+#include "comms.h"
 
-extern int CmdLFEM4X(const char *Cmd);
+extern int CmdLFEM4X(pm3_connection* conn, const char *Cmd);
 extern void printEM410x(uint32_t hi, uint64_t id);
-extern int CmdEMdemodASK(const char *Cmd);
-extern int CmdAskEM410xDemod(const char *Cmd);
-extern int AskEm410xDecode(bool verbose, uint32_t *hi, uint64_t *lo );
-extern int AskEm410xDemod(const char *Cmd, uint32_t *hi, uint64_t *lo, bool verbose);
-extern int CmdEM410xSim(const char *Cmd);
-extern int CmdEM410xBrute(const char *Cmd);
-extern int CmdEM410xWatch(const char *Cmd);
-extern int CmdEM410xWatchnSpoof(const char *Cmd);
-extern int CmdEM410xWrite(const char *Cmd);
-extern bool EM4x05Block0Test(uint32_t *wordData);
-extern int CmdEM4x05info(const char *Cmd);
-extern int EM4x05WriteWord(uint8_t addr, uint32_t data, uint32_t pwd, bool usePwd, bool swap, bool invert);
-extern int CmdEM4x05WriteWord(const char *Cmd);
-extern int CmdEM4x05dump(const char *Cmd);
-extern int CmdEM4x05ReadWord(const char *Cmd);
-extern int EM4x05ReadWord_ext(uint8_t addr, uint32_t pwd, bool usePwd, uint32_t *wordData);
-extern int EM4x50Read(const char *Cmd, bool verbose);
-extern int CmdEM4x50Read(const char *Cmd);
+extern int CmdEMdemodASK(pm3_connection* conn, const char *Cmd);
+extern int CmdAskEM410xDemod(pm3_connection* conn, const char *Cmd);
+extern int AskEm410xDecode(pm3_connection* conn, bool verbose, uint32_t *hi, uint64_t *lo );
+extern int AskEm410xDemod(pm3_connection* conn, const char *Cmd, uint32_t *hi, uint64_t *lo, bool verbose);
+extern int CmdEM410xSim(pm3_connection* conn, const char *Cmd);
+extern int CmdEM410xBrute(pm3_connection* conn, const char *Cmd);
+extern int CmdEM410xWatch(pm3_connection* conn, const char *Cmd);
+extern int CmdEM410xWatchnSpoof(pm3_connection* conn, const char *Cmd);
+extern int CmdEM410xWrite(pm3_connection* conn, const char *Cmd);
+extern bool EM4x05Block0Test(pm3_connection* conn, uint32_t *wordData);
+extern int CmdEM4x05info(pm3_connection* conn, const char *Cmd);
+extern int EM4x05WriteWord(pm3_connection* conn, uint8_t addr, uint32_t data, uint32_t pwd, bool usePwd, bool swap, bool invert);
+extern int CmdEM4x05WriteWord(pm3_connection* conn, const char *Cmd);
+extern int CmdEM4x05dump(pm3_connection* conn, const char *Cmd);
+extern int CmdEM4x05ReadWord(pm3_connection* conn, const char *Cmd);
+extern int EM4x05ReadWord_ext(pm3_connection* conn, uint8_t addr, uint32_t pwd, bool usePwd, uint32_t *wordData);
+extern int EM4x50Read(pm3_connection* conn, const char *Cmd, bool verbose);
+extern int CmdEM4x50Read(pm3_connection* conn, const char *Cmd);
 
 
 #endif

--- a/client/cmdlffdx.h
+++ b/client/cmdlffdx.h
@@ -8,10 +8,11 @@
 //-----------------------------------------------------------------------------
 #ifndef CMDLFFDX_H__
 #define CMDLFFDX_H__
+#include "comms.h"
 
-extern int CmdLFFdx(const char *Cmd);
-extern int CmdFdxClone(const char *Cmd);
-extern int CmdFdxSim(const char *Cmd);
-extern int CmdFdxRead(const char *Cmd);
-extern int CmdFdxDemod(const char *Cmd);
+extern int CmdLFFdx(pm3_connection* conn, const char *Cmd);
+extern int CmdFdxClone(pm3_connection* conn, const char *Cmd);
+extern int CmdFdxSim(pm3_connection* conn, const char *Cmd);
+extern int CmdFdxRead(pm3_connection* conn, const char *Cmd);
+extern int CmdFdxDemod(pm3_connection* conn, const char *Cmd);
 #endif

--- a/client/cmdlfgproxii.h
+++ b/client/cmdlfgproxii.h
@@ -8,7 +8,9 @@
 //-----------------------------------------------------------------------------
 #ifndef CMDLFGPROXII_H__
 #define CMDLFGPROXII_H__
-extern int CmdLF_G_Prox_II(const char *Cmd);
-extern int CmdG_Prox_II_Demod(const char *Cmd);
-extern int CmdG_Prox_II_Read(const char *Cmd);
+#include "comms.h"
+
+extern int CmdLF_G_Prox_II(pm3_connection* conn, const char *Cmd);
+extern int CmdG_Prox_II_Demod(pm3_connection* conn, const char *Cmd);
+extern int CmdG_Prox_II_Read(pm3_connection* conn, const char *Cmd);
 #endif

--- a/client/cmdlfhid.c
+++ b/client/cmdlfhid.c
@@ -18,18 +18,18 @@
 #include "cmddata.h"  //for g_debugMode, demodbuff cmds
 #include "lfdemod.h" // for HIDdemodFSK
 
-static int CmdHelp(const char *Cmd);
+static int CmdHelp(pm3_connection* conn, const char *Cmd);
 
 //by marshmellow (based on existing demod + holiman's refactor)
 //HID Prox demod - FSK RF/50 with preamble of 00011101 (then manchester encoded)
 //print full HID Prox ID and some bit format details if found
-int CmdFSKdemodHID(const char *Cmd)
+int CmdFSKdemodHID(pm3_connection* conn, const char *Cmd)
 {
   //raw fsk demod no manchester decoding no start bit finding just get binary from wave
   uint32_t hi2=0, hi=0, lo=0;
 
   uint8_t BitStream[MAX_GRAPH_TRACE_LEN]={0};
-  size_t BitLen = getFromGraphBuf(BitStream);
+  size_t BitLen = getFromGraphBuf(conn, BitStream);
   if (BitLen==0) return 0;
   //get binary from fsk wave
   int waveIdx = 0;
@@ -99,26 +99,26 @@ int CmdFSKdemodHID(const char *Cmd)
       (unsigned int) hi, (unsigned int) lo, (unsigned int) (lo>>1) & 0xFFFF,
       (unsigned int) fmtLen, (unsigned int) fc, (unsigned int) cardnum);
   }
-  setDemodBuf(BitStream,BitLen,idx);
-  setClockGrid(50, waveIdx + (idx*50));
+  setDemodBuf(conn, BitStream,BitLen,idx);
+  setClockGrid(conn, 50, waveIdx + (idx*50));
   if (g_debugMode){ 
     PrintAndLog("DEBUG: idx: %d, Len: %d, Printing Demod Buffer:", idx, BitLen);
-    printDemodBuff();
+    printDemodBuff(conn);
   }
   return 1;
 }
 
-int CmdHIDReadFSK(const char *Cmd)
+int CmdHIDReadFSK(pm3_connection* conn, const char *Cmd)
 {
   int findone=0;
 	if(Cmd[0]=='1') findone=1;
   UsbCommand c={CMD_HID_DEMOD_FSK};
   c.arg[0]=findone;
-  SendCommand(&c);
+  SendCommand(conn, &c);
   return 0;
 }
 
-int CmdHIDSim(const char *Cmd)
+int CmdHIDSim(pm3_connection* conn, const char *Cmd)
 {
 	uint32_t hi = 0, lo = 0;
 	int n = 0, i = 0;
@@ -132,11 +132,11 @@ int CmdHIDSim(const char *Cmd)
 	PrintAndLog("Press pm3-button to abort simulation");
 
 	UsbCommand c = {CMD_HID_SIM_TAG, {hi, lo, 0}};
-	SendCommand(&c);
+	SendCommand(conn, &c);
 	return 0;
 }
 
-int CmdHIDClone(const char *Cmd)
+int CmdHIDClone(pm3_connection* conn, const char *Cmd)
 {
   unsigned int hi2 = 0, hi = 0, lo = 0;
   int n = 0, i = 0;
@@ -170,7 +170,7 @@ int CmdHIDClone(const char *Cmd)
   c.arg[1] = hi;
   c.arg[2] = lo;
 
-  SendCommand(&c);
+  SendCommand(conn, &c);
   return 0;
 }
 
@@ -184,14 +184,14 @@ static command_t CommandTable[] =
   {NULL, NULL, 0, NULL}
 };
 
-int CmdLFHID(const char *Cmd)
+int CmdLFHID(pm3_connection* conn, const char *Cmd)
 {
-  CmdsParse(CommandTable, Cmd);
+  CmdsParse(conn, CommandTable, Cmd);
   return 0;
 }
 
-int CmdHelp(const char *Cmd)
+int CmdHelp(pm3_connection* conn, const char *Cmd)
 {
-  CmdsHelp(CommandTable);
+  CmdsHelp(conn, CommandTable);
   return 0;
 }

--- a/client/cmdlfhid.h
+++ b/client/cmdlfhid.h
@@ -10,11 +10,12 @@
 
 #ifndef CMDLFHID_H__
 #define CMDLFHID_H__
+#include "comms.h"
 
-int CmdLFHID(const char *Cmd);
-int CmdFSKdemodHID(const char *Cmd);
-int CmdHIDReadDemod(const char *Cmd);
-int CmdHIDSim(const char *Cmd);
-int CmdHIDClone(const char *Cmd);
+int CmdLFHID(pm3_connection* conn, const char *Cmd);
+int CmdFSKdemodHID(pm3_connection* conn, const char *Cmd);
+int CmdHIDReadDemod(pm3_connection* conn, const char *Cmd);
+int CmdHIDSim(pm3_connection* conn, const char *Cmd);
+int CmdHIDClone(pm3_connection* conn, const char *Cmd);
 
 #endif

--- a/client/cmdlfhitag.c
+++ b/client/cmdlfhitag.c
@@ -22,20 +22,20 @@
 #include "hitagS.h"
 #include "cmdmain.h"
 
-static int CmdHelp(const char *Cmd);
+static int CmdHelp(pm3_connection* conn, const char *Cmd);
 
 size_t nbytes(size_t nbits) {
 	return (nbits/8)+((nbits%8)>0);
 }
 
-int CmdLFHitagList(const char *Cmd)
+int CmdLFHitagList(pm3_connection* conn, const char *Cmd)
 {
  	uint8_t *got = malloc(USB_CMD_DATA_SIZE);
 
 	// Query for the actual size of the trace
 	UsbCommand response;
-	GetFromBigBuf(got, USB_CMD_DATA_SIZE, 0);
-	WaitForResponse(CMD_ACK, &response);
+	GetFromBigBuf(conn, got, USB_CMD_DATA_SIZE, 0);
+	WaitForResponse(conn, CMD_ACK, &response);
 	uint16_t traceLen = response.arg[2];
 	if (traceLen > USB_CMD_DATA_SIZE) {
 		uint8_t *p = realloc(got, traceLen);
@@ -45,8 +45,8 @@ int CmdLFHitagList(const char *Cmd)
 			return 2;
 		}
 		got = p;
-		GetFromBigBuf(got, traceLen, 0);
-		WaitForResponse(CMD_ACK,NULL);
+		GetFromBigBuf(conn, got, traceLen, 0);
+		WaitForResponse(conn, CMD_ACK,NULL);
 	}
 	
 	PrintAndLog("recorded activity (TraceLen = %d bytes):");
@@ -145,13 +145,13 @@ int CmdLFHitagList(const char *Cmd)
 	return 0;
 }
 
-int CmdLFHitagSnoop(const char *Cmd) {
+int CmdLFHitagSnoop(pm3_connection* conn, const char *Cmd) {
   UsbCommand c = {CMD_SNOOP_HITAG};
-  SendCommand(&c);
+  SendCommand(conn, &c);
   return 0;
 }
 
-int CmdLFHitagSim(const char *Cmd) {
+int CmdLFHitagSim(pm3_connection* conn, const char *Cmd) {
     
   UsbCommand c = {CMD_SIMULATE_HITAG};
 	char filename[FILE_PATH_SIZE] = { 0x00 };
@@ -180,11 +180,11 @@ int CmdLFHitagSim(const char *Cmd) {
 	// Does the tag comes with memory
 	c.arg[0] = (uint32_t)tag_mem_supplied;
 
-  SendCommand(&c);
+  SendCommand(conn, &c);
   return 0;
 }
 
-int CmdLFHitagReader(const char *Cmd) {
+int CmdLFHitagReader(pm3_connection* conn, const char *Cmd) {
 	UsbCommand c = {CMD_READER_HITAG};//, {param_get32ex(Cmd,0,0,10),param_get32ex(Cmd,1,0,16),param_get32ex(Cmd,2,0,16),param_get32ex(Cmd,3,0,16)}};
 	hitag_data* htd = (hitag_data*)c.d.asBytes;
 	hitag_function htf = param_get32ex(Cmd,0,0,10);
@@ -239,10 +239,10 @@ int CmdLFHitagReader(const char *Cmd) {
 	c.arg[0] = htf;
 
 	// Send the command to the proxmark
-	SendCommand(&c);
+	SendCommand(conn, &c);
 
 	UsbCommand resp;
-	WaitForResponse(CMD_ACK,&resp);
+	WaitForResponse(conn, CMD_ACK,&resp);
 
 	// Check the return status, stored in the first argument
 	if (resp.arg[0] == false) return 1;
@@ -273,7 +273,7 @@ int CmdLFHitagReader(const char *Cmd) {
 }
 
 
-int CmdLFHitagSimS(const char *Cmd) {
+int CmdLFHitagSimS(pm3_connection* conn, const char *Cmd) {
 	UsbCommand c = { CMD_SIMULATE_HITAG_S };
 	char filename[FILE_PATH_SIZE] = { 0x00 };
 	FILE* pf;
@@ -302,11 +302,11 @@ int CmdLFHitagSimS(const char *Cmd) {
 	// Does the tag comes with memory
 	c.arg[0] = (uint32_t) tag_mem_supplied;
 
-	SendCommand(&c);
+	SendCommand(conn, &c);
 	return 0;
 }
 
-int CmdLFHitagCheckChallenges(const char *Cmd) {
+int CmdLFHitagCheckChallenges(pm3_connection* conn, const char *Cmd) {
 	UsbCommand c = { CMD_TEST_HITAGS_TRACES };
 	char filename[FILE_PATH_SIZE] = { 0x00 };
 	FILE* pf;
@@ -334,12 +334,12 @@ int CmdLFHitagCheckChallenges(const char *Cmd) {
 	//file with all the challenges to try
 	c.arg[0] = (uint32_t)file_given;
 
-  SendCommand(&c);
+  SendCommand(conn, &c);
   return 0;
 }
 
 
-int CmdLFHitagWP(const char *Cmd) {
+int CmdLFHitagWP(pm3_connection* conn, const char *Cmd) {
 	UsbCommand c = { CMD_WR_HITAG_S };
 	hitag_data* htd = (hitag_data*)c.d.asBytes;
 	hitag_function htf = param_get32ex(Cmd,0,0,10);
@@ -373,10 +373,10 @@ int CmdLFHitagWP(const char *Cmd) {
 	c.arg[0] = htf;
 
   // Send the command to the proxmark
-  SendCommand(&c);
+  SendCommand(conn, &c);
   
   UsbCommand resp;
-  WaitForResponse(CMD_ACK,&resp);
+  WaitForResponse(conn, CMD_ACK,&resp);
   
   // Check the return status, stored in the first argument
   if (resp.arg[0] == false) return 1;
@@ -397,14 +397,14 @@ static command_t CommandTable[] =
 				NULL,NULL, 0, NULL }
 };
 
-int CmdLFHitag(const char *Cmd)
+int CmdLFHitag(pm3_connection* conn, const char *Cmd)
 {
-  CmdsParse(CommandTable, Cmd);
+  CmdsParse(conn, CommandTable, Cmd);
   return 0;
 }
 
-int CmdHelp(const char *Cmd)
+int CmdHelp(pm3_connection* conn, const char *Cmd)
 {
-  CmdsHelp(CommandTable);
+  CmdsHelp(conn, CommandTable);
   return 0;
 }

--- a/client/cmdlfhitag.h
+++ b/client/cmdlfhitag.h
@@ -10,12 +10,13 @@
 
 #ifndef CMDLFHITAG_H__
 #define CMDLFHITAG_H__
+#include "comms.h"
 
-int CmdLFHitag(const char *Cmd);
+int CmdLFHitag(pm3_connection* conn, const char *Cmd);
 
-int CmdLFHitagList(const char *Cmd);
-int CmdLFHitagSnoop(const char *Cmd);
-int CmdLFHitagSim(const char *Cmd);
-int CmdLFHitagReader(const char *Cmd);
+int CmdLFHitagList(pm3_connection* conn, const char *Cmd);
+int CmdLFHitagSnoop(pm3_connection* conn, const char *Cmd);
+int CmdLFHitagSim(pm3_connection* conn, const char *Cmd);
+int CmdLFHitagReader(pm3_connection* conn, const char *Cmd);
 
 #endif

--- a/client/cmdlfindala.h
+++ b/client/cmdlfindala.h
@@ -9,10 +9,11 @@
 
 #ifndef CMDLFINDALA_H__
 #define CMDLFINDALA_H__
+#include "comms.h"
 
-extern int CmdLFINDALA(const char *Cmd);
-extern int CmdIndalaDecode(const char *Cmd);
-extern int CmdIndalaRead(const char *Cmd);
-extern int CmdIndalaClone(const char *Cmd);
+extern int CmdLFINDALA(pm3_connection* conn, const char *Cmd);
+extern int CmdIndalaDecode(pm3_connection* conn, const char *Cmd);
+extern int CmdIndalaRead(pm3_connection* conn, const char *Cmd);
+extern int CmdIndalaClone(pm3_connection* conn, const char *Cmd);
 
 #endif

--- a/client/cmdlfio.c
+++ b/client/cmdlfio.c
@@ -25,32 +25,32 @@
 #include "lfdemod.h"  //for IOdemodFSK + bytebits_to_byte
 #include "util.h"     //for sprint_bin_break
 
-static int CmdHelp(const char *Cmd);
+static int CmdHelp(pm3_connection* conn, const char *Cmd);
 
-int CmdIOReadFSK(const char *Cmd)
+int CmdIOReadFSK(pm3_connection* conn, const char *Cmd)
 {
   int findone=0;
   if(Cmd[0]=='1') findone=1;
 	
   UsbCommand c={CMD_IO_DEMOD_FSK};
   c.arg[0]=findone;
-  SendCommand(&c);
+  SendCommand(conn, &c);
   return 0;
 }
 
 //by marshmellow
 //IO-Prox demod - FSK RF/64 with preamble of 000000001
 //print ioprox ID and some format details
-int CmdFSKdemodIO(const char *Cmd)
+int CmdFSKdemodIO(pm3_connection* conn, const char *Cmd)
 {
   int idx=0;
   //something in graphbuffer?
-  if (GraphTraceLen < 65) {
-    if (g_debugMode)PrintAndLog("DEBUG: not enough samples in GraphBuffer");
+  if (conn->GraphTraceLen < 65) {
+    if (g_debugMode)PrintAndLog("DEBUG: not enough samples in conn->GraphBuffer");
     return 0;
   }
   uint8_t BitStream[MAX_GRAPH_TRACE_LEN]={0};
-  size_t BitLen = getFromGraphBuf(BitStream);
+  size_t BitLen = getFromGraphBuf(conn, BitStream);
   if (BitLen==0) return 0;
 
   int waveIdx = 0;
@@ -119,17 +119,17 @@ int CmdFSKdemodIO(const char *Cmd)
   char *crcStr = (crc == calccrc) ? "crc ok": "!crc";
 
   PrintAndLog("IO Prox XSF(%02d)%02x:%05d (%08x%08x) [%02x %s]",version,facilitycode,number,code,code2, crc, crcStr);
-  setDemodBuf(BitStream,64,idx);
-  setClockGrid(64, waveIdx + (idx*64));
+  setDemodBuf(conn, BitStream,64,idx);
+  setClockGrid(conn, 64, waveIdx + (idx*64));
 
   if (g_debugMode){
     PrintAndLog("DEBUG: idx: %d, Len: %d, Printing demod buffer:",idx,64);
-    printDemodBuff();
+    printDemodBuff(conn);
   }
   return 1;
 }
 
-int CmdIOClone(const char *Cmd)
+int CmdIOClone(pm3_connection* conn, const char *Cmd)
 {
   unsigned int hi = 0, lo = 0;
   int n = 0, i = 0;
@@ -152,27 +152,27 @@ int CmdIOClone(const char *Cmd)
   c.arg[0] = hi;
   c.arg[1] = lo;
 
-  SendCommand(&c);
+  SendCommand(conn, &c);
   return 0;
 }
 
 static command_t CommandTable[] = 
 {
   {"help",        CmdHelp,            1, "This help"},
-  {"demod",       CmdFSKdemodIO,      1, "Demodulate IO Prox tag from the GraphBuffer"},
+  {"demod",       CmdFSKdemodIO,      1, "Demodulate IO Prox tag from the conn->GraphBuffer"},
   {"read",        CmdIOReadFSK,       0, "['1'] Realtime IO FSK demodulate from antenna (option '1' for one tag only)"},
   {"clone",       CmdIOClone,         0, "Clone ioProx Tag"},
   {NULL, NULL, 0, NULL}
 };
 
-int CmdLFIO(const char *Cmd)
+int CmdLFIO(pm3_connection* conn, const char *Cmd)
 {
-  CmdsParse(CommandTable, Cmd);
+  CmdsParse(conn, CommandTable, Cmd);
   return 0; 
 }
 
-int CmdHelp(const char *Cmd)
+int CmdHelp(pm3_connection* conn, const char *Cmd)
 {
-  CmdsHelp(CommandTable);
+  CmdsHelp(conn, CommandTable);
   return 0;
 }

--- a/client/cmdlfio.h
+++ b/client/cmdlfio.h
@@ -4,8 +4,10 @@
 #ifndef CMDLFIO_H__
 #define CMDLFIO_H__
 
-extern int CmdLFIO(const char *Cmd);
-extern int CmdFSKdemodIO(const char *Cmd);
-extern int CmdIOReadFSK(const char *Cmd);
+#include "comms.h"
+
+extern int CmdLFIO(pm3_connection* conn, const char *Cmd);
+extern int CmdFSKdemodIO(pm3_connection* conn, const char *Cmd);
+extern int CmdIOReadFSK(pm3_connection* conn, const char *Cmd);
 
 #endif

--- a/client/cmdlfjablotron.h
+++ b/client/cmdlfjablotron.h
@@ -9,11 +9,13 @@
 #ifndef CMDLFJABLOTRON_H__
 #define CMDLFJABLOTRON_H__
 
-extern int CmdLFJablotron(const char *Cmd);
-extern int CmdJablotronClone(const char *Cmd);
-extern int CmdJablotronSim(const char *Cmd);
-extern int CmdJablotronRead(const char *Cmd);
-extern int CmdJablotronDemod(const char *Cmd);
+#include "comms.h"
+
+extern int CmdLFJablotron(pm3_connection* conn, const char *Cmd);
+extern int CmdJablotronClone(pm3_connection* conn, const char *Cmd);
+extern int CmdJablotronSim(pm3_connection* conn, const char *Cmd);
+extern int CmdJablotronRead(pm3_connection* conn, const char *Cmd);
+extern int CmdJablotronDemod(pm3_connection* conn, const char *Cmd);
 
 #endif
 

--- a/client/cmdlfnexwatch.h
+++ b/client/cmdlfnexwatch.h
@@ -8,7 +8,10 @@
 //-----------------------------------------------------------------------------
 #ifndef CMDLFNEXWATCH_H__
 #define CMDLFNEXWATCH_H__
-extern int CmdLFNexWatch(const char *Cmd);
-extern int CmdPSKNexWatch(const char *Cmd);
-extern int CmdNexWatchRead(const char *Cmd);
+
+#include "comms.h"
+
+extern int CmdLFNexWatch(pm3_connection* conn, const char *Cmd);
+extern int CmdPSKNexWatch(pm3_connection* conn, const char *Cmd);
+extern int CmdNexWatchRead(pm3_connection* conn, const char *Cmd);
 #endif

--- a/client/cmdlfnoralsy.h
+++ b/client/cmdlfnoralsy.h
@@ -9,11 +9,13 @@
 #ifndef CMDLFNORALSY_H__
 #define CMDLFNORALSY_H__
 
-extern int CmdLFNoralsy(const char *Cmd);
-extern int CmdNoralsyClone(const char *Cmd);
-extern int CmdNoralsySim(const char *Cmd);
-extern int CmdNoralsyRead(const char *Cmd);
-extern int CmdNoralsyDemod(const char *Cmd);
+#include "comms.h"
+
+extern int CmdLFNoralsy(pm3_connection* conn, const char *Cmd);
+extern int CmdNoralsyClone(pm3_connection* conn, const char *Cmd);
+extern int CmdNoralsySim(pm3_connection* conn, const char *Cmd);
+extern int CmdNoralsyRead(pm3_connection* conn, const char *Cmd);
+extern int CmdNoralsyDemod(pm3_connection* conn, const char *Cmd);
 
 #endif
 

--- a/client/cmdlfpac.h
+++ b/client/cmdlfpac.h
@@ -9,9 +9,11 @@
 #ifndef CMDLFPAC_H__
 #define CMDLFPAC_H__
 
-extern int CmdLFPac(const char *Cmd);
-extern int CmdPacRead(const char *Cmd);
-extern int CmdPacDemod(const char *Cmd);
+#include "comms.h"
+
+extern int CmdLFPac(pm3_connection* conn, const char *Cmd);
+extern int CmdPacRead(pm3_connection* conn, const char *Cmd);
+extern int CmdPacDemod(pm3_connection* conn, const char *Cmd);
 
 #endif
 

--- a/client/cmdlfparadox.c
+++ b/client/cmdlfparadox.c
@@ -19,18 +19,18 @@
 #include "cmddata.h"
 #include "cmdlf.h"
 #include "lfdemod.h"
-static int CmdHelp(const char *Cmd);
+static int CmdHelp(pm3_connection* conn, const char *Cmd);
 
 //by marshmellow
 //Paradox Prox demod - FSK RF/50 with preamble of 00001111 (then manchester encoded)
 //print full Paradox Prox ID and some bit format details if found
-int CmdFSKdemodParadox(const char *Cmd)
+int CmdFSKdemodParadox(pm3_connection* conn, const char *Cmd)
 {
 	//raw fsk demod no manchester decoding no start bit finding just get binary from wave
 	uint32_t hi2=0, hi=0, lo=0;
 
 	uint8_t BitStream[MAX_GRAPH_TRACE_LEN]={0};
-	size_t BitLen = getFromGraphBuf(BitStream);
+	size_t BitLen = getFromGraphBuf(conn, BitStream);
 	if (BitLen==0) return 0;
 	int waveIdx=0;
 	//get binary from fsk wave
@@ -63,21 +63,21 @@ int CmdFSKdemodParadox(const char *Cmd)
 
 	PrintAndLog("Paradox TAG ID: %x%08x - FC: %d - Card: %d - Checksum: %02x - RAW: %08x%08x%08x",
 		hi>>10, (hi & 0x3)<<26 | (lo>>10), fc, cardnum, (lo>>2) & 0xFF, rawHi2, rawHi, rawLo);
-	setDemodBuf(BitStream,BitLen,idx);
-	setClockGrid(50, waveIdx + (idx*50));
+	setDemodBuf(conn, BitStream,BitLen,idx);
+	setClockGrid(conn, 50, waveIdx + (idx*50));
 	if (g_debugMode){ 
 		PrintAndLog("DEBUG: idx: %d, len: %d, Printing Demod Buffer:", idx, BitLen);
-		printDemodBuff();
+		printDemodBuff(conn);
 	}
 	return 1;
 }
 //by marshmellow
 //see ASKDemod for what args are accepted
-int CmdParadoxRead(const char *Cmd) {
+int CmdParadoxRead(pm3_connection* conn, const char *Cmd) {
 	// read lf silently
-	lf_read(true, 10000);
+	lf_read(conn, true, 10000);
 	// demod and output viking ID	
-	return CmdFSKdemodParadox(Cmd);
+	return CmdFSKdemodParadox(conn, Cmd);
 }
 
 static command_t CommandTable[] = {
@@ -87,12 +87,12 @@ static command_t CommandTable[] = {
 	{NULL, NULL, 0, NULL}
 };
 
-int CmdLFParadox(const char *Cmd) {
-	CmdsParse(CommandTable, Cmd);
+int CmdLFParadox(pm3_connection* conn, const char *Cmd) {
+	CmdsParse(conn, CommandTable, Cmd);
 	return 0;
 }
 
-int CmdHelp(const char *Cmd) {
-	CmdsHelp(CommandTable);
+int CmdHelp(pm3_connection* conn, const char *Cmd) {
+	CmdsHelp(conn, CommandTable);
 	return 0;
 }

--- a/client/cmdlfparadox.h
+++ b/client/cmdlfparadox.h
@@ -8,7 +8,10 @@
 //-----------------------------------------------------------------------------
 #ifndef CMDLFPARADOX_H__
 #define CMDLFPARADOX_H__
-extern int CmdLFParadox(const char *Cmd);
-extern int CmdFSKdemodParadox(const char *Cmd);
-extern int CmdParadoxRead(const char *Cmd);
+
+#include "comms.h"
+
+extern int CmdLFParadox(pm3_connection* conn, const char *Cmd);
+extern int CmdFSKdemodParadox(pm3_connection* conn, const char *Cmd);
+extern int CmdParadoxRead(pm3_connection* conn, const char *Cmd);
 #endif

--- a/client/cmdlfpcf7931.c
+++ b/client/cmdlfpcf7931.c
@@ -20,7 +20,7 @@
 #include "cmdlf.h"
 #include "cmdlfpcf7931.h"
 
-static int CmdHelp(const char *Cmd);
+static int CmdHelp(pm3_connection* conn, const char *Cmd);
 
 #define PCF7931_DEFAULT_INITDELAY 17500
 #define PCF7931_DEFAULT_OFFSET_WIDTH 0
@@ -94,23 +94,23 @@ int usage_pcf7931_config(){
 	return 0;
 }
 
-int CmdLFPCF7931Read(const char *Cmd){  
+int CmdLFPCF7931Read(pm3_connection* conn, const char *Cmd){  
 
 	uint8_t ctmp = param_getchar(Cmd, 0);
 	if ( ctmp == 'H' || ctmp == 'h' ) return usage_pcf7931_read();
 
 	UsbCommand resp;
 	UsbCommand c = {CMD_PCF7931_READ, {0, 0, 0}};
-	clearCommandBuffer();
-	SendCommand(&c);
-	if ( !WaitForResponseTimeout(CMD_ACK, &resp, 2500) ) {
+	clearCommandBuffer(conn);
+	SendCommand(conn, &c);
+	if ( !WaitForResponseTimeout(conn, CMD_ACK, &resp, 2500) ) {
 		PrintAndLog("command execution time out");
 		return 1;
 	}
 	return 0;
 }
 
-int CmdLFPCF7931Config(const char *Cmd){ 
+int CmdLFPCF7931Config(pm3_connection* conn, const char *Cmd){ 
 
 	uint8_t ctmp = param_getchar(Cmd, 0);
 	if ( ctmp == 0) return pcf7931_printConfig();
@@ -127,7 +127,7 @@ int CmdLFPCF7931Config(const char *Cmd){
 	return 0;
 }
 
-int CmdLFPCF7931Write(const char *Cmd){
+int CmdLFPCF7931Write(pm3_connection* conn, const char *Cmd){
 
 	uint8_t ctmp = param_getchar(Cmd, 0);
 	if (strlen(Cmd) < 1 || ctmp == 'h' || ctmp == 'H') return usage_pcf7931_write();  
@@ -151,8 +151,8 @@ int CmdLFPCF7931Write(const char *Cmd){
 	  c.d.asDwords[8] = (configPcf.OffsetPosition + 128);
 	  c.d.asDwords[9] = configPcf.InitDelay;
 
-	clearCommandBuffer();
-	SendCommand(&c);
+	clearCommandBuffer(conn);
+	SendCommand(conn, &c);
 	//no ack?
 	return 0;
 }
@@ -166,14 +166,14 @@ static command_t CommandTable[] =
 	{NULL,     NULL,               0, NULL}
 };
 
-int CmdLFPCF7931(const char *Cmd)
+int CmdLFPCF7931(pm3_connection* conn, const char *Cmd)
 {
-	CmdsParse(CommandTable, Cmd);
+	CmdsParse(conn, CommandTable, Cmd);
 	return 0;
 }
 
-int CmdHelp(const char *Cmd)
+int CmdHelp(pm3_connection* conn, const char *Cmd)
 {
-	CmdsHelp(CommandTable);
+	CmdsHelp(conn, CommandTable);
 	return 0;
 }

--- a/client/cmdlfpcf7931.h
+++ b/client/cmdlfpcf7931.h
@@ -12,6 +12,8 @@
 #ifndef CMDLFPCF7931_H__
 #define CMDLFPCF7931_H__
 
+#include "comms.h"
+
 struct pcf7931_config{
 	uint8_t Pwd[7];
 	uint16_t InitDelay;
@@ -26,10 +28,10 @@ int usage_pcf7931_read();
 int usage_pcf7931_write();
 int usage_pcf7931_config();
 
-int CmdLFPCF7931(const char *Cmd);
+int CmdLFPCF7931(pm3_connection* conn, const char *Cmd);
 
-int CmdLFPCF7931Read(const char *Cmd);
-int CmdLFPCF7931Write(const char *Cmd);
-int CmdLFPCF7931Config(const char *Cmd);
+int CmdLFPCF7931Read(pm3_connection* conn, const char *Cmd);
+int CmdLFPCF7931Write(pm3_connection* conn, const char *Cmd);
+int CmdLFPCF7931Config(pm3_connection* conn, const char *Cmd);
 
 #endif

--- a/client/cmdlfpresco.h
+++ b/client/cmdlfpresco.h
@@ -11,10 +11,11 @@
 
 #include <stdint.h>  //uint_32+
 #include <stdbool.h> //bool
+#include "comms.h"
 
-int CmdLFPresco(const char *Cmd);
-int CmdPrescoClone(const char *Cmd);
-int CmdPrescoSim(const char *Cmd);
+int CmdLFPresco(pm3_connection* conn, const char *Cmd);
+int CmdPrescoClone(pm3_connection* conn, const char *Cmd);
+int CmdPrescoSim(pm3_connection* conn, const char *Cmd);
 
 int GetWiegandFromPresco(const char *id, uint32_t *sitecode, uint32_t *usercode, uint32_t *fullcode, bool *Q5);
 

--- a/client/cmdlfpyramid.h
+++ b/client/cmdlfpyramid.h
@@ -9,10 +9,12 @@
 #ifndef CMDLFPYRAMID_H__
 #define CMDLFPYRAMID_H__
 
-extern int CmdLFPyramid(const char *Cmd);
-extern int CmdPyramidClone(const char *Cmd);
-extern int CmdPyramidSim(const char *Cmd);
-extern int CmdFSKdemodPyramid(const char *Cmd);
-extern int CmdPyramidRead(const char *Cmd);
+#include "comms.h"
+
+extern int CmdLFPyramid(pm3_connection* conn, const char *Cmd);
+extern int CmdPyramidClone(pm3_connection* conn, const char *Cmd);
+extern int CmdPyramidSim(pm3_connection* conn, const char *Cmd);
+extern int CmdFSKdemodPyramid(pm3_connection* conn, const char *Cmd);
+extern int CmdPyramidRead(pm3_connection* conn, const char *Cmd);
 #endif
 

--- a/client/cmdlfsecurakey.h
+++ b/client/cmdlfsecurakey.h
@@ -9,11 +9,13 @@
 #ifndef CMDLFSECURAKEY_H__
 #define CMDLFSECURAKEY_H__
 
-extern int CmdLFSecurakey(const char *Cmd);
-extern int CmdSecurakeyClone(const char *Cmd);
-extern int CmdSecurakeySim(const char *Cmd);
-extern int CmdSecurakeyRead(const char *Cmd);
-extern int CmdSecurakeyDemod(const char *Cmd);
+#include "comms.h"
+
+extern int CmdLFSecurakey(pm3_connection* conn, const char *Cmd);
+extern int CmdSecurakeyClone(pm3_connection* conn, const char *Cmd);
+extern int CmdSecurakeySim(pm3_connection* conn, const char *Cmd);
+extern int CmdSecurakeyRead(pm3_connection* conn, const char *Cmd);
+extern int CmdSecurakeyDemod(pm3_connection* conn, const char *Cmd);
 
 #endif
 

--- a/client/cmdlft55xx.h
+++ b/client/cmdlft55xx.h
@@ -10,6 +10,8 @@
 #ifndef CMDLFT55XX_H__
 #define CMDLFT55XX_H__
 
+#include "comms.h"
+
 typedef struct {
 	uint32_t bl1;
 	uint32_t bl2; 
@@ -69,16 +71,16 @@ typedef struct {
 t55xx_conf_block_t Get_t55xx_Config(void);
 void Set_t55xx_Config(t55xx_conf_block_t conf);
 
-extern int CmdLFT55XX(const char *Cmd);
-extern int CmdT55xxBruteForce(const char *Cmd);
-extern int CmdT55xxSetConfig(const char *Cmd);
-extern int CmdT55xxReadBlock(const char *Cmd);
-extern int CmdT55xxWriteBlock(const char *Cmd);
-extern int CmdT55xxReadTrace(const char *Cmd);
-extern int CmdT55xxInfo(const char *Cmd);
-extern int CmdT55xxDetect(const char *Cmd);
-extern int CmdResetRead(const char *Cmd);
-extern int CmdT55xxWipe(const char *Cmd);
+extern int CmdLFT55XX(pm3_connection* conn, const char *Cmd);
+extern int CmdT55xxBruteForce(pm3_connection* conn, const char *Cmd);
+extern int CmdT55xxSetConfig(pm3_connection* conn, const char *Cmd);
+extern int CmdT55xxReadBlock(pm3_connection* conn, const char *Cmd);
+extern int CmdT55xxWriteBlock(pm3_connection* conn, const char *Cmd);
+extern int CmdT55xxReadTrace(pm3_connection* conn, const char *Cmd);
+extern int CmdT55xxInfo(pm3_connection* conn, const char *Cmd);
+extern int CmdT55xxDetect(pm3_connection* conn, const char *Cmd);
+extern int CmdResetRead(pm3_connection* conn, const char *Cmd);
+extern int CmdT55xxWipe(pm3_connection* conn, const char *Cmd);
 
 char * GetBitRateStr(uint32_t id, bool xmode);
 char * GetSaferStr(uint32_t id);
@@ -87,17 +89,17 @@ char * GetModelStrFromCID(uint32_t cid);
 char * GetSelectedModulationStr( uint8_t id);
 uint32_t PackBits(uint8_t start, uint8_t len, uint8_t *bitstream);
 void printT5xxHeader(uint8_t page);
-void printT55xxBlock(const char *demodStr);
+void printT55xxBlock(pm3_connection* conn, const char *demodStr);
 int printConfiguration( t55xx_conf_block_t b);
 
-bool DecodeT55xxBlock(void);
-bool tryDetectModulation(void);
-extern bool tryDetectP1(bool getData);
-bool test(uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t clk, bool *Q5);
-int special(const char *Cmd);
-int AquireData( uint8_t page, uint8_t block, bool pwdmode, uint32_t password );
+bool DecodeT55xxBlock(pm3_connection* conn);
+bool tryDetectModulation(pm3_connection* conn);
+extern bool tryDetectP1(pm3_connection* conn, bool getData);
+bool test(pm3_connection* conn, uint8_t mode, uint8_t *offset, int *fndBitRate, uint8_t clk, bool *Q5);
+int special(pm3_connection* conn, const char *Cmd);
+int AcquireData(pm3_connection* conn, uint8_t page, uint8_t block, bool pwdmode, uint32_t password );
 
-void printT55x7Trace( t55x7_tracedata_t data, uint8_t repeat );
-void printT5555Trace( t5555_tracedata_t data, uint8_t repeat );
+void printT55x7Trace(pm3_connection* conn, t55x7_tracedata_t data, uint8_t repeat );
+void printT5555Trace(pm3_connection* conn, t5555_tracedata_t data, uint8_t repeat );
 
 #endif

--- a/client/cmdlfti.h
+++ b/client/cmdlfti.h
@@ -11,10 +11,12 @@
 #ifndef CMDLFTI_H__
 #define CMDLFTI_H__
 
-int CmdLFTI(const char *Cmd);
+#include "comms.h"
 
-int CmdTIDemod(const char *Cmd);
-int CmdTIRead(const char *Cmd);
-int CmdTIWrite(const char *Cmd);
+int CmdLFTI(pm3_connection* conn, const char *Cmd);
+
+int CmdTIDemod(pm3_connection* conn, const char *Cmd);
+int CmdTIRead(pm3_connection* conn, const char *Cmd);
+int CmdTIWrite(pm3_connection* conn, const char *Cmd);
 
 #endif

--- a/client/cmdlfviking.h
+++ b/client/cmdlfviking.h
@@ -8,9 +8,12 @@
 //-----------------------------------------------------------------------------
 #ifndef CMDLFVIKING_H__
 #define CMDLFVIKING_H__
-extern int CmdLFViking(const char *Cmd);
-extern int CmdVikingDemod(const char *Cmd);
-extern int CmdVikingRead(const char *Cmd);
-extern int CmdVikingClone(const char *Cmd);
-extern int CmdVikingSim(const char *Cmd);
+
+#include "comms.h"
+
+extern int CmdLFViking(pm3_connection* conn, const char *Cmd);
+extern int CmdVikingDemod(pm3_connection* conn, const char *Cmd);
+extern int CmdVikingRead(pm3_connection* conn, const char *Cmd);
+extern int CmdVikingClone(pm3_connection* conn, const char *Cmd);
+extern int CmdVikingSim(pm3_connection* conn, const char *Cmd);
 #endif

--- a/client/cmdlfvisa2000.h
+++ b/client/cmdlfvisa2000.h
@@ -8,12 +8,15 @@
 //-----------------------------------------------------------------------------
 #ifndef CMDLFVISA2000_H__
 #define CMDLFVISA2000_H__
+
 #include <inttypes.h>
-extern int CmdLFVisa2k(const char *Cmd);
-extern int CmdVisa2kClone(const char *Cmd);
-extern int CmdVisa2kSim(const char *Cmd);
-extern int CmdVisa2kRead(const char *Cmd);
-extern int CmdVisa2kDemod(const char *Cmd);
+#include "comms.h"
+
+extern int CmdLFVisa2k(pm3_connection* conn, const char *Cmd);
+extern int CmdVisa2kClone(pm3_connection* conn, const char *Cmd);
+extern int CmdVisa2kSim(pm3_connection* conn, const char *Cmd);
+extern int CmdVisa2kRead(pm3_connection* conn, const char *Cmd);
+extern int CmdVisa2kDemod(pm3_connection* conn, const char *Cmd);
 
 #endif
 

--- a/client/cmdmain.c
+++ b/client/cmdmain.c
@@ -34,14 +34,6 @@ static int CmdHelp(const char *Cmd);
 static int CmdQuit(const char *Cmd);
 static int CmdRev(const char *Cmd);
 
-//For storing command that are received from the device
-#define CMD_BUFFER_SIZE 50
-static UsbCommand cmdBuffer[CMD_BUFFER_SIZE];
-//Points to the next empty position to write to
-static int cmd_head;//Starts as 0
-//Points to the position of the last unread command
-static int cmd_tail;//Starts as 0
-
 static command_t CommandTable[] = 
 {
   {"help",  CmdHelp,  1, "This help. Use '<command> help' for details of a particular command."},
@@ -60,6 +52,7 @@ command_t* getTopLevelCommandTable()
 {
   return CommandTable;
 }
+
 int CmdHelp(const char *Cmd)
 {
   CmdsHelp(CommandTable);
@@ -77,141 +70,11 @@ int CmdRev(const char *Cmd)
   return 0;
 }
 
-/**
- * @brief This method should be called when sending a new command to the pm3. In case any old
- *  responses from previous commands are stored in the buffer, a call to this method should clear them.
- *  A better method could have been to have explicit command-ACKS, so we can know which ACK goes to which
- *  operation. Right now we'll just have to live with this.
- */
-void clearCommandBuffer()
-{
-    //This is a very simple operation
-    cmd_tail = cmd_head;
-}
-
-/**
- * @brief storeCommand stores a USB command in a circular buffer
- * @param UC
- */
-void storeCommand(UsbCommand *command)
-{
-    if( ( cmd_head+1) % CMD_BUFFER_SIZE == cmd_tail)
-    {
-        //If these two are equal, we're about to overwrite in the
-        // circular buffer.
-        PrintAndLog("WARNING: Command buffer about to overwrite command! This needs to be fixed!");
-    }
-    //Store the command at the 'head' location
-    UsbCommand* destination = &cmdBuffer[cmd_head];
-    memcpy(destination, command, sizeof(UsbCommand));
-
-    cmd_head = (cmd_head +1) % CMD_BUFFER_SIZE; //increment head and wrap
-}
-
-
-/**
- * @brief getCommand gets a command from an internal circular buffer.
- * @param response location to write command
- * @return 1 if response was returned, 0 if nothing has been received
- */
-int getCommand(UsbCommand* response)
-{
-    //If head == tail, there's nothing to read, or if we just got initialized
-    if(cmd_head == cmd_tail){
-        return 0;
-    }
-    //Pick out the next unread command
-    UsbCommand* last_unread = &cmdBuffer[cmd_tail];
-    memcpy(response, last_unread, sizeof(UsbCommand));
-    //Increment tail - this is a circular buffer, so modulo buffer size
-    cmd_tail = (cmd_tail +1 ) % CMD_BUFFER_SIZE;
-
-    return 1;
-}
-
-
-/**
- * Waits for a certain response type. This method waits for a maximum of
- * ms_timeout milliseconds for a specified response command.
- *@brief WaitForResponseTimeout
- * @param cmd command to wait for
- * @param response struct to copy received command into.
- * @param ms_timeout
- * @return true if command was returned, otherwise false
- */
-bool WaitForResponseTimeoutW(uint32_t cmd, UsbCommand* response, size_t ms_timeout, bool show_warning) {
-  
-	UsbCommand resp;
-	
-	if (response == NULL) {
-		response = &resp;
-	}
-
-	// Wait until the command is received
-	for(size_t dm_seconds=0; dm_seconds < ms_timeout/10; dm_seconds++) {
-		while(getCommand(response)) {
-			if(response->cmd == cmd){
-				return true;
-			}
-		}
-		msleep(10); // XXX ugh
-		if (dm_seconds == 200 && show_warning) { // Two seconds elapsed
-			PrintAndLog("Waiting for a response from the proxmark...");
-			PrintAndLog("Don't forget to cancel its operation first by pressing on the button");
-		}
-	}
-	return false;
-}
-
-bool WaitForResponseTimeout(uint32_t cmd, UsbCommand* response, size_t ms_timeout) {
-	return WaitForResponseTimeoutW(cmd, response, ms_timeout, true);
-}
-
-bool WaitForResponse(uint32_t cmd, UsbCommand* response) {
-	return WaitForResponseTimeoutW(cmd, response, -1, true);
-}
-
-
 //-----------------------------------------------------------------------------
 // Entry point into our code: called whenever the user types a command and
 // then presses Enter, which the full command line that they typed.
 //-----------------------------------------------------------------------------
 int CommandReceived(char *Cmd) {
 	return CmdsParse(CommandTable, Cmd);
-}
-
-
-//-----------------------------------------------------------------------------
-// Entry point into our code: called whenever we received a packet over USB
-// that we weren't necessarily expecting, for example a debug print.
-//-----------------------------------------------------------------------------
-void UsbCommandReceived(UsbCommand *UC)
-{
-	switch(UC->cmd) {
-		// First check if we are handling a debug message
-		case CMD_DEBUG_PRINT_STRING: {
-			char s[USB_CMD_DATA_SIZE+1];
-			memset(s, 0x00, sizeof(s));
-			size_t len = MIN(UC->arg[0],USB_CMD_DATA_SIZE);
-			memcpy(s,UC->d.asBytes,len);
-			PrintAndLog("#db# %s", s);
-			return;
-		} break;
-
-		case CMD_DEBUG_PRINT_INTEGERS: {
-			PrintAndLog("#db# %08x, %08x, %08x       \r\n", UC->arg[0], UC->arg[1], UC->arg[2]);
-			return;
-		} break;
-
-		case CMD_DOWNLOADED_RAW_ADC_SAMPLES_125K: {
-			memcpy(sample_buf+(UC->arg[0]),UC->d.asBytes,UC->arg[1]);
-			return;
-		} break;
-
-		default:
-			storeCommand(UC);
-			break;
-	}
-
 }
 

--- a/client/cmdmain.c
+++ b/client/cmdmain.c
@@ -5,7 +5,8 @@
 // at your option, any later version. See the LICENSE.txt file for the text of
 // the license.
 //-----------------------------------------------------------------------------
-// Main command parser entry point
+// This module handles the main entry point into the command parser for the
+// proxmark3 CLI.
 //-----------------------------------------------------------------------------
 
 #include <stdio.h>
@@ -27,12 +28,9 @@
 #include "cmdscript.h"
 #include "cmdcrc.h"
 
-
-unsigned int current_command = CMD_UNKNOWN;
-
-static int CmdHelp(const char *Cmd);
-static int CmdQuit(const char *Cmd);
-static int CmdRev(const char *Cmd);
+static int CmdHelp(pm3_connection* conn, const char *Cmd);
+static int CmdQuit(pm3_connection* conn, const char *Cmd);
+static int CmdRev(pm3_connection* conn, const char *Cmd);
 
 static command_t CommandTable[] = 
 {
@@ -53,20 +51,20 @@ command_t* getTopLevelCommandTable()
   return CommandTable;
 }
 
-int CmdHelp(const char *Cmd)
+int CmdHelp(pm3_connection* conn, const char *Cmd)
 {
-  CmdsHelp(CommandTable);
+  CmdsHelp(conn, CommandTable);
   return 0;
 }
 
-int CmdQuit(const char *Cmd)
+int CmdQuit(pm3_connection* conn, const char *Cmd)
 {
   return 99;
 }
 
-int CmdRev(const char *Cmd)
+int CmdRev(pm3_connection* conn, const char *Cmd)
 {
-  CmdCrc(Cmd);
+  CmdCrc(conn, Cmd);
   return 0;
 }
 
@@ -74,7 +72,7 @@ int CmdRev(const char *Cmd)
 // Entry point into our code: called whenever the user types a command and
 // then presses Enter, which the full command line that they typed.
 //-----------------------------------------------------------------------------
-int CommandReceived(char *Cmd) {
-	return CmdsParse(CommandTable, Cmd);
+int CommandReceived(pm3_connection* conn, char *Cmd) {
+	return CmdsParse(conn, CommandTable, Cmd);
 }
 

--- a/client/cmdmain.h
+++ b/client/cmdmain.h
@@ -15,13 +15,10 @@
 #include <stddef.h>
 #include "usb_cmd.h"
 #include "cmdparser.h"
+#include "comms.h"
 
-extern void UsbCommandReceived(UsbCommand *UC);
+
 extern int CommandReceived(char *Cmd);
-extern bool WaitForResponseTimeoutW(uint32_t cmd, UsbCommand* response, size_t ms_timeout, bool show_warning);
-extern bool WaitForResponseTimeout(uint32_t cmd, UsbCommand* response, size_t ms_timeout);
-extern bool WaitForResponse(uint32_t cmd, UsbCommand* response);
-extern void clearCommandBuffer();
 extern command_t* getTopLevelCommandTable();
 
 #endif

--- a/client/cmdmain.h
+++ b/client/cmdmain.h
@@ -17,8 +17,7 @@
 #include "cmdparser.h"
 #include "comms.h"
 
-
-extern int CommandReceived(char *Cmd);
+extern int CommandReceived(pm3_connection* conn, char *Cmd);
 extern command_t* getTopLevelCommandTable();
 
 #endif

--- a/client/cmdparser.c
+++ b/client/cmdparser.c
@@ -14,6 +14,7 @@
 #include "ui.h"
 #include "cmdparser.h"
 #include "proxmark3.h"
+#include "comms.h"
 
 
 void CmdsHelp(const command_t Commands[])
@@ -23,7 +24,7 @@ void CmdsHelp(const command_t Commands[])
   int i = 0;
   while (Commands[i].Name)
   {
-    if (!offline || Commands[i].Offline)
+    if (!IsOffline() || Commands[i].Offline)
        PrintAndLog("%-16s %s", Commands[i].Name, Commands[i].Help);
     ++i;
   }

--- a/client/cmdparser.c
+++ b/client/cmdparser.c
@@ -17,21 +17,21 @@
 #include "comms.h"
 
 
-void CmdsHelp(const command_t Commands[])
+void CmdsHelp(pm3_connection* conn, const command_t Commands[])
 {
   if (Commands[0].Name == NULL)
     return;
   int i = 0;
   while (Commands[i].Name)
   {
-    if (!IsOffline() || Commands[i].Offline)
+    if (!(conn->offline) || Commands[i].Offline)
        PrintAndLog("%-16s %s", Commands[i].Name, Commands[i].Help);
     ++i;
   }
 }
 
 
-int CmdsParse(const command_t Commands[], const char *Cmd)
+int CmdsParse(pm3_connection* conn, const command_t Commands[], const char *Cmd)
 {
 	if(strcmp( Cmd, "XX_internal_command_dump_XX") == 0)
 	{// Help dump children
@@ -68,10 +68,10 @@ int CmdsParse(const command_t Commands[], const char *Cmd)
 	if (Commands[i].Name) {
 		while (Cmd[len] == ' ')
 			++len;
-	return Commands[i].Parse(Cmd + len);
+		return Commands[i].Parse(conn, Cmd + len);
 	} else {
 		// show help for selected hierarchy or if command not recognised
-		CmdsHelp(Commands);
+		CmdsHelp(conn, Commands);
 	}
 
 	return 0;
@@ -127,9 +127,9 @@ void dumpCommandsRecursive(const command_t cmds[], int markdown)
     // This is what causes the recursion, since commands Parse-implementation
     // in turn calls the CmdsParse above. 
     if (markdown)
-      cmds[i].Parse("XX_internal_command_dump_markdown_XX");
+      cmds[i].Parse(NULL, "XX_internal_command_dump_markdown_XX");
     else
-      cmds[i].Parse("XX_internal_command_dump_XX");
+      cmds[i].Parse(NULL, "XX_internal_command_dump_XX");
     parent = old_parent;
     ++i;
   }

--- a/client/cmdparser.h
+++ b/client/cmdparser.h
@@ -11,10 +11,12 @@
 #ifndef CMDPARSER_H__
 #define CMDPARSER_H__ 
 
+#include "comms.h"
+
 typedef struct command_s
 {
   const char * Name;
-  int (*Parse)(const char *Cmd);
+  int (*Parse)(pm3_connection *conn, const char *Cmd);
   int Offline;
   const char * Help;
 } command_t;
@@ -22,9 +24,9 @@ typedef struct command_s
 // command_t array are expected to be NULL terminated
 
 // Print help for each command in the command array
-void CmdsHelp(const command_t Commands[]);
+void CmdsHelp(pm3_connection* conn, const command_t Commands[]);
 // Parse a command line
-int CmdsParse(const command_t Commands[], const char *Cmd);
+int CmdsParse(pm3_connection* conn, const command_t Commands[], const char *Cmd);
 void dumpCommandsRecursive(const command_t cmds[], int markdown);
 
 #endif

--- a/client/cmdscript.c
+++ b/client/cmdscript.c
@@ -30,9 +30,9 @@
 #include <lualib.h>
 #include <lauxlib.h>
 
-static int CmdHelp(const char *Cmd);
-static int CmdList(const char *Cmd);
-static int CmdRun(const char *Cmd);
+static int CmdHelp(pm3_connection* conn, const char *Cmd);
+static int CmdList(pm3_connection* conn, const char *Cmd);
+static int CmdRun(pm3_connection* conn, const char *Cmd);
 
 command_t CommandTable[] =
 {
@@ -61,7 +61,7 @@ int str_ends_with(const char * str, const char * suffix) {
  * @param Cmd
  * @return
  */
-int CmdHelp(const char * Cmd)
+int CmdHelp(pm3_connection* conn, const char * Cmd)
 {
     PrintAndLog("This is a feature to run Lua-scripts. You can place lua-scripts within the scripts/-folder. ");
     return 0;
@@ -72,7 +72,7 @@ int CmdHelp(const char * Cmd)
 * generate a file listing of the script-directory for files
 * ending with .lua
 */
-int CmdList(const char *Cmd)
+int CmdList(pm3_connection* conn, const char *Cmd)
 {
     DIR *dp;
     struct dirent *ep;
@@ -100,9 +100,9 @@ int CmdList(const char *Cmd)
  * @param Cmd
  * @return
  */
-int CmdScript(const char *Cmd)
+int CmdScript(pm3_connection* conn, const char *Cmd)
 {
-  CmdsParse(CommandTable, Cmd);
+  CmdsParse(conn, CommandTable, Cmd);
   return 0;
 }
 /**
@@ -120,7 +120,7 @@ bool endsWith (char* base, char* str) {
  * @param argv
  * @return
  */
-int CmdRun(const char *Cmd)
+int CmdRun(pm3_connection* conn, const char *Cmd)
 {
     // create new Lua state
     lua_State *lua_state;
@@ -130,7 +130,7 @@ int CmdRun(const char *Cmd)
     luaL_openlibs(lua_state);
 
     //Sets the pm3 core libraries, that go a bit 'under the hood'
-    set_pm3_libraries(lua_state);
+    set_pm3_libraries(lua_state, conn);
 
     //Add the 'bin' library
     set_bin_library(lua_state);

--- a/client/cmdscript.h
+++ b/client/cmdscript.h
@@ -12,7 +12,8 @@
 #ifndef CMDSCRIPT_H__
 #define CMDSCRIPT_H__
 
+#include "comms.h"
 
-int CmdScript(const char *Cmd);
+int CmdScript(pm3_connection* conn, const char *Cmd);
 
 #endif

--- a/client/comms.c
+++ b/client/comms.c
@@ -14,61 +14,13 @@
 #include "comms.h"
 #include "uart.h"
 #include "ui.h"
-#include "common.h"
-#include "data.h"
-#include "util_posix.h"
 
-// Declare globals.
-
-// Serial port that we are communicating with the PM3 on.
-static serial_port* port;
-
-// If TRUE, then there is no active connection to the PM3, and we will drop commands sent.
-static bool offline;
-
-// Transmit buffer.
-// TODO: Use locks and execute this on the main thread, rather than the receiver
-// thread.  Running on the main thread means we need to be careful in the
-// flasher, as it means SendCommand is no longer async, and can't be used as a
-// buffer for a pending command when the connection is re-established.
-static UsbCommand txcmd;
-static bool txcmd_pending;
-
-// Used by UsbReceiveCommand as a ring buffer for messages that are yet to be
-// processed by a command handler (WaitForResponse{,Timeout})
-static UsbCommand cmdBuffer[CMD_BUFFER_SIZE];
-
-// Points to the next empty position to write to
-static int cmd_head = 0;
-
-// Points to the position of the last unread command
-static int cmd_tail = 0;
-
-// These wrappers are required because it is not possible to access a static
-// global variable outside of the context of a single file.
-
-void SetSerialPort(serial_port* new_port) {
-	port = new_port;
-}
-
-serial_port* GetSerialPort() {
-	return port;
-}
-
-void SetOffline(bool new_offline) {
-	offline = new_offline;
-}
-
-bool IsOffline() {
-	return offline;
-}
-
-void SendCommand(UsbCommand *c) {
+void SendCommand(pm3_connection *conn, UsbCommand *c) {
 	#ifdef COMMS_DEBUG
 	printf("Sending %04x cmd\n", c->cmd);
 	#endif
 
-	if (offline) {
+	if (conn->offline) {
       PrintAndLog("Sending bytes to proxmark failed - offline");
       return;
     }
@@ -77,9 +29,9 @@ void SendCommand(UsbCommand *c) {
 	or disconnected. The main console thread is alive, but comm thread just spins here.
 	Not good.../holiman
 	**/
-	while(txcmd_pending);
-	txcmd = *c;
-	txcmd_pending = true;
+	while(conn->txcmd_pending);
+	conn->txcmd = *c;
+	conn->txcmd_pending = true;
 }
 
 /**
@@ -88,48 +40,51 @@ void SendCommand(UsbCommand *c) {
  *  A better method could have been to have explicit command-ACKS, so we can know which ACK goes to which
  *  operation. Right now we'll just have to live with this.
  */
-void clearCommandBuffer()
+void clearCommandBuffer(pm3_connection* conn)
 {
+	if (!conn) return;
 	//This is a very simple operation
-    cmd_tail = cmd_head;
+    conn->cmd_tail = conn->cmd_head;
 }
 
 /**
  * @brief storeCommand stores a USB command in a circular buffer
  * @param UC
  */
-void storeCommand(UsbCommand *command)
+void storeCommand(pm3_connection *conn, UsbCommand *command)
 {
-    if( (cmd_head+1) % CMD_BUFFER_SIZE == cmd_tail)
+    if (!conn) return;
+    if( (conn->cmd_head+1) % CMD_BUFFER_SIZE == conn->cmd_tail)
     {
         //If these two are equal, we're about to overwrite in the
         // circular buffer.
         PrintAndLog("WARNING: Command buffer about to overwrite command! This needs to be fixed!");
     }
     //Store the command at the 'head' location
-    UsbCommand* destination = &cmdBuffer[cmd_head];
+    UsbCommand* destination = &conn->cmdBuffer[conn->cmd_head];
     memcpy(destination, command, sizeof(UsbCommand));
 
-    cmd_head = (cmd_head +1) % CMD_BUFFER_SIZE; //increment head and wrap
+    conn->cmd_head = (conn->cmd_head +1) % CMD_BUFFER_SIZE; //increment head and wrap
 }
 
 
 /**
  * @brief getCommand gets a command from an internal circular buffer.
+ * @param conn reference to Proxmark3 connection
  * @param response location to write command
  * @return 1 if response was returned, 0 if nothing has been received
  */
-int getCommand(UsbCommand* response)
+int getCommand(pm3_connection *conn, UsbCommand* response)
 {
     //If head == tail, there's nothing to read, or if we just got initialized
-    if (cmd_head == cmd_tail){
+    if (!conn || conn->cmd_head == conn->cmd_tail){
         return 0;
     }
     //Pick out the next unread command
-    UsbCommand* last_unread = &cmdBuffer[cmd_tail];
+    UsbCommand* last_unread = &conn->cmdBuffer[conn->cmd_tail];
     memcpy(response, last_unread, sizeof(UsbCommand));
     //Increment tail - this is a circular buffer, so modulo buffer size
-    cmd_tail = (cmd_tail + 1) % CMD_BUFFER_SIZE;
+    conn->cmd_tail = (conn->cmd_tail +1 ) % CMD_BUFFER_SIZE;
 
     return 1;
 }
@@ -138,7 +93,7 @@ int getCommand(UsbCommand* response)
 // Entry point into our code: called whenever we received a packet over USB
 // that we weren't necessarily expecting, for example a debug print.
 //-----------------------------------------------------------------------------
-void UsbCommandReceived(UsbCommand *UC)
+void UsbCommandReceived(pm3_connection* conn, UsbCommand *UC)
 {
 	switch(UC->cmd) {
 
@@ -160,14 +115,14 @@ void UsbCommandReceived(UsbCommand *UC)
 	case CMD_DOWNLOADED_RAW_ADC_SAMPLES_125K: {
 		// FIXME: This does unsanitised copies into memory when we don't know
 		// the size of the buffer.
-		if (sample_buf) {
-			memcpy(sample_buf+(UC->arg[0]),UC->d.asBytes,UC->arg[1]);
+		if (conn->sample_buf) {
+			memcpy(conn->sample_buf+(UC->arg[0]),UC->d.asBytes,UC->arg[1]);
 		}
 		return;
 	}
-
+	
 	default: {
-		storeCommand(UC);
+		storeCommand(conn, UC);
 		return;
 	}
 	}
@@ -176,9 +131,9 @@ void UsbCommandReceived(UsbCommand *UC)
 // Gets a single command from a proxmark3 device. This should never be used
 // with the full client.
 //
-// @param conn A receiver_arg structure.
+// @param conn A pm3_connection structure.
 // @param command A buffer to store the received command.
-bool ReceiveCommand(receiver_arg* conn, UsbCommand* command) {
+bool ReceiveCommand(pm3_connection* conn, UsbCommand* command) {
 	// Local recieve buffer
 	size_t rxlen;
 	byte_t rx[sizeof(UsbCommand)];
@@ -186,18 +141,16 @@ bool ReceiveCommand(receiver_arg* conn, UsbCommand* command) {
 
 	while (conn->run) {
 		rxlen = 0;
-		if (uart_receive(port, prx, sizeof(UsbCommand) - (prx-rx), &rxlen)) {
+		if (uart_receive(conn->port, prx, sizeof(UsbCommand) - (prx-rx), &rxlen)) {
 			prx += rxlen;
 			if (prx-rx < sizeof(UsbCommand)) {
-				// Keep reading until we have a completed response.
 				continue;
 			}
-
-			// We have a completed response.
+			
 			memcpy(command, rx, sizeof(UsbCommand));
 			return true;
 		}
-
+		
 		if (prx == rx) {
 			// We got no complete command while waiting, give up control
 			return false;
@@ -210,47 +163,35 @@ bool ReceiveCommand(receiver_arg* conn, UsbCommand* command) {
 
 // Worker thread for processing incoming events from the PM3
 void *uart_receiver(void *targ) {
-	receiver_arg *conn = (receiver_arg*)targ;
+	pm3_connection *conn = (pm3_connection*)targ;
 	UsbCommand rx;
 
 	while (conn->run) {
-		#ifdef COMMS_DEBUG
-		printf("uart_receiver: get lock\n");
-		#endif
 		// Lock up receives, in case they try to take it away from us.
 		pthread_mutex_lock(&conn->recv_lock);
-		#ifdef COMMS_DEBUG
-		printf("uart_receiver: lock acquired\n");
-		#endif
 
-		if (port == NULL) {
-			#ifdef COMMS_DEBUG
-			printf("uart_receiver: port disappeared\n");
-			#endif
+		if (conn->port == NULL) {
 			// Our port disappeared, stall. This code path matters for the flasher,
 			// where it is fiddling with the serial port under us.
 			pthread_mutex_unlock(&conn->recv_lock);
 			msleep(10);
 			continue;
 		}
-
+		
 		bool got_command = ReceiveCommand(conn, &rx);
-		#ifdef COMMS_DEBUG
-		printf("uart_receiver: got command\n");
-		#endif
 		pthread_mutex_unlock(&conn->recv_lock);
-
+		
 		if (got_command) {
-			UsbCommandReceived(&rx);
+			UsbCommandReceived(conn, &rx);
 		}
 
 		// We aren't normally trying to transmit in the flasher when the port would
 		// be reset, so we can just keep going at this point.
-		if (txcmd_pending) {
-			if (!uart_send(port, (byte_t*) &txcmd, sizeof(UsbCommand))) {
+		if (conn->txcmd_pending) {
+			if (!uart_send(conn->port, (byte_t*) &(conn->txcmd), sizeof(UsbCommand))) {
 				PrintAndLog("Sending bytes to proxmark failed");
 			}
-			txcmd_pending = false;
+			conn->txcmd_pending = false;
 		}
 	}
 
@@ -268,7 +209,7 @@ void *uart_receiver(void *targ) {
  * @param show_warning
  * @return true if command was returned, otherwise false
  */
-bool WaitForResponseTimeoutW(uint64_t cmd, UsbCommand* response, size_t ms_timeout, bool show_warning) {
+bool WaitForResponseTimeoutW(pm3_connection *conn, uint64_t cmd, UsbCommand* response, size_t ms_timeout, bool show_warning) {
 	UsbCommand resp;
 
 	#ifdef COMMS_DEBUG
@@ -281,7 +222,7 @@ bool WaitForResponseTimeoutW(uint64_t cmd, UsbCommand* response, size_t ms_timeo
 
 	// Wait until the command is received
 	for(size_t dm_seconds=0; dm_seconds < ms_timeout/10; dm_seconds++) {
-		while(getCommand(response)) {
+		while(getCommand(conn, response)) {
 			if (cmd == CMD_ANY || response->cmd == cmd) {
 				return true;
 			}
@@ -295,10 +236,11 @@ bool WaitForResponseTimeoutW(uint64_t cmd, UsbCommand* response, size_t ms_timeo
 	return false;
 }
 
-bool WaitForResponseTimeout(uint64_t cmd, UsbCommand* response, size_t ms_timeout) {
-	return WaitForResponseTimeoutW(cmd, response, ms_timeout, true);
+bool WaitForResponseTimeout(pm3_connection* conn, uint64_t cmd, UsbCommand* response, size_t ms_timeout) {
+	return WaitForResponseTimeoutW(conn, cmd, response, ms_timeout, true);
 }
 
-bool WaitForResponse(uint64_t cmd, UsbCommand* response) {
-	return WaitForResponseTimeout(cmd, response, -1);
+bool WaitForResponse(pm3_connection* conn, uint64_t cmd, UsbCommand* response) {
+	return WaitForResponseTimeout(conn, cmd, response, -1);
 }
+

--- a/client/comms.c
+++ b/client/comms.c
@@ -1,0 +1,304 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) 2009 Michael Gernoth <michael at gernoth.net>
+// Copyright (C) 2010 iZsh <izsh at fail0verflow.com>
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// Code for communicating with the proxmark3 hardware.
+//-----------------------------------------------------------------------------
+
+#include <pthread.h>
+
+#include "comms.h"
+#include "uart.h"
+#include "ui.h"
+#include "common.h"
+#include "data.h"
+#include "util_posix.h"
+
+// Declare globals.
+
+// Serial port that we are communicating with the PM3 on.
+static serial_port* port;
+
+// If TRUE, then there is no active connection to the PM3, and we will drop commands sent.
+static bool offline;
+
+// Transmit buffer.
+// TODO: Use locks and execute this on the main thread, rather than the receiver
+// thread.  Running on the main thread means we need to be careful in the
+// flasher, as it means SendCommand is no longer async, and can't be used as a
+// buffer for a pending command when the connection is re-established.
+static UsbCommand txcmd;
+static bool txcmd_pending;
+
+// Used by UsbReceiveCommand as a ring buffer for messages that are yet to be
+// processed by a command handler (WaitForResponse{,Timeout})
+static UsbCommand cmdBuffer[CMD_BUFFER_SIZE];
+
+// Points to the next empty position to write to
+static int cmd_head = 0;
+
+// Points to the position of the last unread command
+static int cmd_tail = 0;
+
+// These wrappers are required because it is not possible to access a static
+// global variable outside of the context of a single file.
+
+void SetSerialPort(serial_port* new_port) {
+	port = new_port;
+}
+
+serial_port* GetSerialPort() {
+	return port;
+}
+
+void SetOffline(bool new_offline) {
+	offline = new_offline;
+}
+
+bool IsOffline() {
+	return offline;
+}
+
+void SendCommand(UsbCommand *c) {
+	#ifdef COMMS_DEBUG
+	printf("Sending %04x cmd\n", c->cmd);
+	#endif
+
+	if (offline) {
+      PrintAndLog("Sending bytes to proxmark failed - offline");
+      return;
+    }
+  /**
+	The while-loop below causes hangups at times, when the pm3 unit is unresponsive
+	or disconnected. The main console thread is alive, but comm thread just spins here.
+	Not good.../holiman
+	**/
+	while(txcmd_pending);
+	txcmd = *c;
+	txcmd_pending = true;
+}
+
+/**
+ * @brief This method should be called when sending a new command to the pm3. In case any old
+ *  responses from previous commands are stored in the buffer, a call to this method should clear them.
+ *  A better method could have been to have explicit command-ACKS, so we can know which ACK goes to which
+ *  operation. Right now we'll just have to live with this.
+ */
+void clearCommandBuffer()
+{
+	//This is a very simple operation
+    cmd_tail = cmd_head;
+}
+
+/**
+ * @brief storeCommand stores a USB command in a circular buffer
+ * @param UC
+ */
+void storeCommand(UsbCommand *command)
+{
+    if( (cmd_head+1) % CMD_BUFFER_SIZE == cmd_tail)
+    {
+        //If these two are equal, we're about to overwrite in the
+        // circular buffer.
+        PrintAndLog("WARNING: Command buffer about to overwrite command! This needs to be fixed!");
+    }
+    //Store the command at the 'head' location
+    UsbCommand* destination = &cmdBuffer[cmd_head];
+    memcpy(destination, command, sizeof(UsbCommand));
+
+    cmd_head = (cmd_head +1) % CMD_BUFFER_SIZE; //increment head and wrap
+}
+
+
+/**
+ * @brief getCommand gets a command from an internal circular buffer.
+ * @param response location to write command
+ * @return 1 if response was returned, 0 if nothing has been received
+ */
+int getCommand(UsbCommand* response)
+{
+    //If head == tail, there's nothing to read, or if we just got initialized
+    if (cmd_head == cmd_tail){
+        return 0;
+    }
+    //Pick out the next unread command
+    UsbCommand* last_unread = &cmdBuffer[cmd_tail];
+    memcpy(response, last_unread, sizeof(UsbCommand));
+    //Increment tail - this is a circular buffer, so modulo buffer size
+    cmd_tail = (cmd_tail + 1) % CMD_BUFFER_SIZE;
+
+    return 1;
+}
+
+//-----------------------------------------------------------------------------
+// Entry point into our code: called whenever we received a packet over USB
+// that we weren't necessarily expecting, for example a debug print.
+//-----------------------------------------------------------------------------
+void UsbCommandReceived(UsbCommand *UC)
+{
+	switch(UC->cmd) {
+
+	// First check if we are handling a debug message
+	case CMD_DEBUG_PRINT_STRING: {
+		char s[USB_CMD_DATA_SIZE+1];
+		memset(s, 0x00, sizeof(s));
+		size_t len = MIN(UC->arg[0],USB_CMD_DATA_SIZE);
+		memcpy(s,UC->d.asBytes,len);
+		PrintAndLog("#db# %s", s);
+		return;
+	}
+
+	case CMD_DEBUG_PRINT_INTEGERS: {
+		PrintAndLog("#db# %08x, %08x, %08x       \r\n", UC->arg[0], UC->arg[1], UC->arg[2]);
+		return;
+	}
+
+	case CMD_DOWNLOADED_RAW_ADC_SAMPLES_125K: {
+		// FIXME: This does unsanitised copies into memory when we don't know
+		// the size of the buffer.
+		if (sample_buf) {
+			memcpy(sample_buf+(UC->arg[0]),UC->d.asBytes,UC->arg[1]);
+		}
+		return;
+	}
+
+	default: {
+		storeCommand(UC);
+		return;
+	}
+	}
+}
+
+// Gets a single command from a proxmark3 device. This should never be used
+// with the full client.
+//
+// @param conn A receiver_arg structure.
+// @param command A buffer to store the received command.
+bool ReceiveCommand(receiver_arg* conn, UsbCommand* command) {
+	// Local recieve buffer
+	size_t rxlen;
+	byte_t rx[sizeof(UsbCommand)];
+	byte_t* prx = rx;
+
+	while (conn->run) {
+		rxlen = 0;
+		if (uart_receive(port, prx, sizeof(UsbCommand) - (prx-rx), &rxlen)) {
+			prx += rxlen;
+			if (prx-rx < sizeof(UsbCommand)) {
+				// Keep reading until we have a completed response.
+				continue;
+			}
+
+			// We have a completed response.
+			memcpy(command, rx, sizeof(UsbCommand));
+			return true;
+		}
+
+		if (prx == rx) {
+			// We got no complete command while waiting, give up control
+			return false;
+		}
+	}
+
+	// did not get a complete command before being cancelled.
+	return false;
+}
+
+// Worker thread for processing incoming events from the PM3
+void *uart_receiver(void *targ) {
+	receiver_arg *conn = (receiver_arg*)targ;
+	UsbCommand rx;
+
+	while (conn->run) {
+		#ifdef COMMS_DEBUG
+		printf("uart_receiver: get lock\n");
+		#endif
+		// Lock up receives, in case they try to take it away from us.
+		pthread_mutex_lock(&conn->recv_lock);
+		#ifdef COMMS_DEBUG
+		printf("uart_receiver: lock acquired\n");
+		#endif
+
+		if (port == NULL) {
+			#ifdef COMMS_DEBUG
+			printf("uart_receiver: port disappeared\n");
+			#endif
+			// Our port disappeared, stall. This code path matters for the flasher,
+			// where it is fiddling with the serial port under us.
+			pthread_mutex_unlock(&conn->recv_lock);
+			msleep(10);
+			continue;
+		}
+
+		bool got_command = ReceiveCommand(conn, &rx);
+		#ifdef COMMS_DEBUG
+		printf("uart_receiver: got command\n");
+		#endif
+		pthread_mutex_unlock(&conn->recv_lock);
+
+		if (got_command) {
+			UsbCommandReceived(&rx);
+		}
+
+		// We aren't normally trying to transmit in the flasher when the port would
+		// be reset, so we can just keep going at this point.
+		if (txcmd_pending) {
+			if (!uart_send(port, (byte_t*) &txcmd, sizeof(UsbCommand))) {
+				PrintAndLog("Sending bytes to proxmark failed");
+			}
+			txcmd_pending = false;
+		}
+	}
+
+	pthread_exit(NULL);
+	return NULL;
+}
+
+/**
+ * Waits for a certain response type. This method waits for a maximum of
+ * ms_timeout milliseconds for a specified response command.
+ *@brief WaitForResponseTimeout
+ * @param cmd command to wait for, or CMD_ANY to take any command.
+ * @param response struct to copy received command into.
+ * @param ms_timeout
+ * @param show_warning
+ * @return true if command was returned, otherwise false
+ */
+bool WaitForResponseTimeoutW(uint64_t cmd, UsbCommand* response, size_t ms_timeout, bool show_warning) {
+	UsbCommand resp;
+
+	#ifdef COMMS_DEBUG
+	printf("Waiting for %04x cmd\n", cmd);
+	#endif
+	
+	if (response == NULL) {
+		response = &resp;
+	}
+
+	// Wait until the command is received
+	for(size_t dm_seconds=0; dm_seconds < ms_timeout/10; dm_seconds++) {
+		while(getCommand(response)) {
+			if (cmd == CMD_ANY || response->cmd == cmd) {
+				return true;
+			}
+		}
+		msleep(10); // XXX ugh
+		if (dm_seconds == 200 && show_warning) { // Two seconds elapsed
+			PrintAndLog("Waiting for a response from the proxmark...");
+			PrintAndLog("Don't forget to cancel its operation first by pressing on the button");
+		}
+	}
+	return false;
+}
+
+bool WaitForResponseTimeout(uint64_t cmd, UsbCommand* response, size_t ms_timeout) {
+	return WaitForResponseTimeoutW(cmd, response, ms_timeout, true);
+}
+
+bool WaitForResponse(uint64_t cmd, UsbCommand* response) {
+	return WaitForResponseTimeout(cmd, response, -1);
+}

--- a/client/comms.h
+++ b/client/comms.h
@@ -1,0 +1,45 @@
+#ifndef COMMS_H_
+#define COMMS_H_
+
+#include <stdbool.h>
+#include <pthread.h>
+
+#include "usb_cmd.h"
+#include "uart.h"
+
+#ifndef CMD_BUFFER_SIZE
+#define CMD_BUFFER_SIZE 50
+#endif
+
+#ifndef MAX_DEMOD_BUF_LEN
+#define MAX_DEMOD_BUF_LEN (1024*128)
+#endif
+
+#ifndef BIGBUF_SIZE
+#define BIGBUF_SIZE 40000
+#endif
+
+typedef struct {
+	// If TRUE, continue running the uart_receiver thread.
+	bool run;
+
+	// Lock around serial port receives
+	pthread_mutex_t recv_lock;
+} receiver_arg;
+
+
+// Wrappers required as static variables can only be used in one file.
+void SetSerialPort(serial_port* new_port);
+serial_port* GetSerialPort();
+void SetOffline(bool new_offline);
+bool IsOffline();
+
+void SendCommand(UsbCommand *c);
+void *uart_receiver(void *targ);
+void UsbCommandReceived(UsbCommand *UC);
+void clearCommandBuffer();
+bool WaitForResponseTimeoutW(uint64_t cmd, UsbCommand* response, size_t ms_timeout, bool show_warning);
+bool WaitForResponseTimeout(uint64_t cmd, UsbCommand* response, size_t ms_timeout);
+bool WaitForResponse(uint64_t cmd, UsbCommand* response);
+
+#endif // COMMS_H_

--- a/client/comms.h
+++ b/client/comms.h
@@ -6,6 +6,7 @@
 
 #include "usb_cmd.h"
 #include "uart.h"
+#include "util_posix.h"
 
 #ifndef CMD_BUFFER_SIZE
 #define CMD_BUFFER_SIZE 50

--- a/client/comms.h
+++ b/client/comms.h
@@ -19,27 +19,76 @@
 #define BIGBUF_SIZE 40000
 #endif
 
-typedef struct {
-	// If TRUE, continue running the uart_receiver thread.
-	bool run;
+// Max graph trace len: 40000 (bigbuf) * 8 (at 1 bit per sample)
+#define MAX_GRAPH_TRACE_LEN (40000 * 8)
 
+/* pm3_connection: holds state related to a connection to a single PM3
+ * All global state related to a single connection should make its way into this struct.
+ */
+typedef struct {
+	// If TRUE, continue running the uart_reciever thread.
+	bool run;
+	
+	// Serial port that we are communicating with the PM3 on.
+	serial_port* port;
+	
 	// Lock around serial port receives
 	pthread_mutex_t recv_lock;
-} receiver_arg;
+	
+	// If TRUE, then there is no active connection to the PM3, and we will drop commands sent.
+	bool offline;
+	
+	// Transmit buffer.
+	UsbCommand txcmd;
+	bool txcmd_pending;
+	
+	// Used by UsbReceiveCommand as a ring buffer for messages that are yet to be
+	// processed by a command handler (WaitForResponse{,Timeout})
+	UsbCommand cmdBuffer[CMD_BUFFER_SIZE];
 
+	// Points to the next empty position to write to
+	int cmd_head;//Starts as 0
+	
+	// Points to the position of the last unread command
+	int cmd_tail;//Starts as 0
+	
+	// Demodulation buffer, used by mainly low-frequency tags
+	uint8_t DemodBuffer[MAX_DEMOD_BUF_LEN];
+	size_t DemodBufferLen;
+	int g_DemodStartIdx;
+	int g_DemodClock;
+	
+	// Sample buffer, to be supplied in GetFromBigBuf and then written in by the device.
+	uint8_t* sample_buf;
+	
+	// Graphing related globals.
+	// FIXME: These should eventually make their way into particular UI implementations instead.
+	int GraphBuffer[MAX_GRAPH_TRACE_LEN];
+	int GraphTraceLen;
 
-// Wrappers required as static variables can only be used in one file.
-void SetSerialPort(serial_port* new_port);
-serial_port* GetSerialPort();
-void SetOffline(bool new_offline);
-bool IsOffline();
+	int s_Buff[MAX_GRAPH_TRACE_LEN];
+	double CursorScaleFactor;
+	int PlotGridX;
+	int PlotGridY;
+	int PlotGridXdefault;
+	int PlotGridYdefault;
+	int CursorCPos;
+	int CursorDPos;
+	int flushAfterWrite;  //buzzy
+	int GridOffset;
+	bool GridLocked;
+	bool showDemod;
+	
+} pm3_connection;
 
-void SendCommand(UsbCommand *c);
+void SendCommand(pm3_connection *conn, UsbCommand *c);
+bool ReceiveCommand(pm3_connection* conn, UsbCommand* command); // only for flasher
 void *uart_receiver(void *targ);
-void UsbCommandReceived(UsbCommand *UC);
-void clearCommandBuffer();
-bool WaitForResponseTimeoutW(uint64_t cmd, UsbCommand* response, size_t ms_timeout, bool show_warning);
-bool WaitForResponseTimeout(uint64_t cmd, UsbCommand* response, size_t ms_timeout);
-bool WaitForResponse(uint64_t cmd, UsbCommand* response);
+void UsbCommandReceived(pm3_connection *conn, UsbCommand *UC);
+void clearCommandBuffer(pm3_connection *conn);
+bool WaitForResponseTimeoutW(pm3_connection* conn, uint64_t cmd, UsbCommand* response, size_t ms_timeout, bool show_warning);
+bool WaitForResponseTimeout(pm3_connection* conn, uint64_t cmd, UsbCommand* response, size_t ms_timeout);
+bool WaitForResponse(pm3_connection* conn, uint64_t cmd, UsbCommand* response);
+
 
 #endif // COMMS_H_

--- a/client/data.c
+++ b/client/data.c
@@ -15,11 +15,11 @@
 #include "proxmark3.h"
 #include "cmdmain.h"
 
-uint8_t* sample_buf;
-
-void GetFromBigBuf(uint8_t *dest, int bytes, int start_index)
+void GetFromBigBuf(pm3_connection* conn, uint8_t *dest, int bytes, int start_index)
 {
-  sample_buf = dest;
-  UsbCommand c = {CMD_DOWNLOAD_RAW_ADC_SAMPLES_125K, {start_index, bytes, 0}};
-  SendCommand(&c);
+	// FIXME: This instructs the proxmark3 hardware to write into a buffer, and then
+	// implicitly trusts that it'll do the right thing in comms.c:UsbCommandReceived.
+	conn->sample_buf = dest;
+	UsbCommand c = {CMD_DOWNLOAD_RAW_ADC_SAMPLES_125K, {start_index, bytes, 0}};
+	SendCommand(conn, &c);
 }

--- a/client/data.h
+++ b/client/data.h
@@ -12,12 +12,12 @@
 #define DATA_H__
 
 #include <stdint.h>
+#include "comms.h"
 
 #define FILE_PATH_SIZE 1000
 
-extern uint8_t* sample_buf;
 #define arraylen(x) (sizeof(x)/sizeof((x)[0]))
 
-void GetFromBigBuf(uint8_t *dest, int bytes, int start_index);
+void GetFromBigBuf(pm3_connection* conn, uint8_t *dest, int bytes, int start_index);
 
 #endif

--- a/client/flash.c
+++ b/client/flash.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <inttypes.h>
 #include <unistd.h>
+
 #include "proxmark3.h"
 #include "util.h"
 #include "util_posix.h"
@@ -20,11 +21,7 @@
 #include "elf.h"
 #include "proxendian.h"
 #include "usb_cmd.h"
-
-void SendCommand(UsbCommand* txcmd);
-void ReceiveCommand(UsbCommand* rxcmd);
-void CloseProxmark();
-int OpenProxmark(size_t i);
+#include "comms.h"
 
 // FIXME: what the fuckity fuck
 unsigned int current_command = CMD_UNKNOWN;
@@ -43,6 +40,32 @@ static const uint8_t elf_ident[] = {
 	ELFDATA2LSB,
 	EV_CURRENT
 };
+
+void CloseProxmark(receiver_arg* conn, char* serial_port_name) {
+	pthread_mutex_lock(&conn->recv_lock);
+
+	// Block the port from being used by anything
+	serial_port* my_port = GetSerialPort();
+	SetSerialPort(NULL);
+
+	// Then close the port.
+	uart_close(my_port);
+	pthread_mutex_unlock(&conn->recv_lock);
+
+	// Fix for linux, it seems that it is extremely slow to release the serial port file descriptor /dev/*
+	unlink(serial_port_name);
+}
+
+bool OpenProxmark(char* serial_port_name) {
+	serial_port *new_port = uart_open(serial_port_name);
+	if (new_port == INVALID_SERIAL_PORT || new_port == CLAIMED_SERIAL_PORT) {
+		//poll once a second
+		return false;
+	}
+	
+	SetSerialPort(new_port);
+	return true;
+}
 
 // Turn PHDRs into flasher segments, checking for PHDR sanity and merging adjacent
 // unaligned segments if needed
@@ -278,9 +301,12 @@ static int get_proxmark_state(uint32_t *state)
 {
 	UsbCommand c;
 	c.cmd = CMD_DEVICE_INFO;
-  SendCommand(&c);
+	SendCommand(&c);
 	UsbCommand resp;
-	ReceiveCommand(&resp);
+	while (!WaitForResponse(CMD_ANY, &resp)) {
+		// Keep waiting for a response
+		msleep(100);
+	}
 
 	// Three outcomes:
 	// 1. The old bootrom code will ignore CMD_DEVICE_INFO, but respond with an ACK
@@ -307,7 +333,7 @@ static int get_proxmark_state(uint32_t *state)
 }
 
 // Enter the bootloader to be able to start flashing
-static int enter_bootloader(char *serial_port_name)
+static int enter_bootloader(receiver_arg* conn, char *serial_port_name)
 {
 	uint32_t state;
 
@@ -338,16 +364,17 @@ static int enter_bootloader(char *serial_port_name)
 			SendCommand(&c);
 			fprintf(stderr,"Press and hold down button NOW if your bootloader requires it.\n");
 		}
-    msleep(100);
-		CloseProxmark();
+		
+		msleep(100);
+		CloseProxmark(conn, serial_port_name);
 
 		fprintf(stderr,"Waiting for Proxmark to reappear on %s",serial_port_name);
-    do {
+		do {
 			sleep(1);
 			fprintf(stderr, ".");
-		} while (!OpenProxmark(0));
+		} while (!OpenProxmark(serial_port_name));
+		
 		fprintf(stderr," Found.\n");
-
 		return 0;
 	}
 
@@ -355,23 +382,25 @@ static int enter_bootloader(char *serial_port_name)
 	return -1;
 }
 
-static int wait_for_ack(void)
+static int wait_for_ack()
 {
-  UsbCommand ack;
-	ReceiveCommand(&ack);
-	if (ack.cmd != CMD_ACK) {
-		printf("Error: Unexpected reply 0x%04" PRIx64 " (expected ACK)\n", ack.cmd);
+	UsbCommand resp;
+	while (!WaitForResponse(CMD_ANY, &resp)) {
+		msleep(100);
+	}
+	if (resp.cmd != CMD_ACK) {
+		printf("Error: Unexpected reply 0x%04" PRIx64 " (expected ACK)\n", resp.cmd);
 		return -1;
 	}
 	return 0;
 }
 
 // Go into flashing mode
-int flash_start_flashing(int enable_bl_writes,char *serial_port_name)
+int flash_start_flashing(receiver_arg* conn, int enable_bl_writes,char *serial_port_name)
 {
 	uint32_t state;
 
-	if (enter_bootloader(serial_port_name) < 0)
+	if (enter_bootloader(conn, serial_port_name) < 0)
 		return -1;
 
 	if (get_proxmark_state(&state) < 0)
@@ -470,9 +499,9 @@ void flash_free(flash_file_t *ctx)
 }
 
 // just reset the unit
-int flash_stop_flashing(void) {
+int flash_stop_flashing() {
 	UsbCommand c = {CMD_HARDWARE_RESET};
-  SendCommand(&c);
-  msleep(100);
-  return 0;
+	SendCommand(&c);
+	msleep(100);
+	return 0;
 }

--- a/client/flash.h
+++ b/client/flash.h
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 #include "elf.h"
+#include "comms.h"
 
 typedef struct {
 	void *data;
@@ -26,10 +27,12 @@ typedef struct {
 } flash_file_t;
 
 int flash_load(flash_file_t *ctx, const char *name, int can_write_bl);
-int flash_start_flashing(int enable_bl_writes,char *serial_port_name);
+int flash_start_flashing(receiver_arg* conn, int enable_bl_writes, char *serial_port_name);
 int flash_write(flash_file_t *ctx);
 void flash_free(flash_file_t *ctx);
 int flash_stop_flashing(void);
+void CloseProxmark(receiver_arg* conn, char* serial_port_name);
+bool OpenProxmark(char* serial_port_name);
 
 #endif
 

--- a/client/flash.h
+++ b/client/flash.h
@@ -27,12 +27,12 @@ typedef struct {
 } flash_file_t;
 
 int flash_load(flash_file_t *ctx, const char *name, int can_write_bl);
-int flash_start_flashing(receiver_arg* conn, int enable_bl_writes, char *serial_port_name);
-int flash_write(flash_file_t *ctx);
+int flash_start_flashing(pm3_connection* conn, int enable_bl_writes, char *serial_port_name);
+int flash_write(pm3_connection* conn, flash_file_t *ctx);
 void flash_free(flash_file_t *ctx);
-int flash_stop_flashing(void);
-void CloseProxmark(receiver_arg* conn, char* serial_port_name);
-bool OpenProxmark(char* serial_port_name);
+int flash_stop_flashing(pm3_connection* conn);
+void CloseProxmark(pm3_connection* conn, char* serial_port_name);
+bool OpenProxmark(pm3_connection* conn, char* serial_port_name);
 
 #endif
 

--- a/client/flasher.c
+++ b/client/flasher.c
@@ -10,21 +10,21 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include <pthread.h>
+
 #include "proxmark3.h"
 #include "util.h"
 #include "util_posix.h"
 #include "flash.h"
 #include "uart.h"
 #include "usb_cmd.h"
+#include "comms.h"
 
 #ifdef _WIN32
 # define unlink(x)
 #else
 # include <unistd.h>
 #endif
-
-static serial_port sp;
-static char* serial_port_name;
 
 void cmd_debug(UsbCommand* UC) {
   //  Debug
@@ -40,45 +40,6 @@ void cmd_debug(UsbCommand* UC) {
   printf("...\n");
 }
 
-void SendCommand(UsbCommand* txcmd) {
-//  printf("send: ");
-//  cmd_debug(txcmd);
-  if (!uart_send(sp,(byte_t*)txcmd,sizeof(UsbCommand))) {
-    printf("Sending bytes to proxmark failed\n");
-    exit(1);
-  }
-}
-
-void ReceiveCommand(UsbCommand* rxcmd) {
-  byte_t* prxcmd = (byte_t*)rxcmd;
-  byte_t* prx = prxcmd;
-  size_t rxlen;
-  while (true) {
-    if (uart_receive(sp, prx, sizeof(UsbCommand) - (prx-prxcmd), &rxlen)) {
-      prx += rxlen;
-      if ((prx-prxcmd) >= sizeof(UsbCommand)) {
-        return;
-      }
-    }
-  }
-}
-
-void CloseProxmark() {
-  // Clean up the port
-  uart_close(sp);
-  // Fix for linux, it seems that it is extremely slow to release the serial port file descriptor /dev/*
-  unlink(serial_port_name);
-}
-
-int OpenProxmark(size_t i) {
-  sp = uart_open(serial_port_name);
-  if (sp == INVALID_SERIAL_PORT || sp == CLAIMED_SERIAL_PORT) {
-    //poll once a second
-    return 0;
-  }
-  return 1;
-}
-
 static void usage(char *argv0)
 {
 	fprintf(stderr, "Usage:   %s <port> [-b] image.elf [image.elf...]\n\n", argv0);
@@ -86,9 +47,10 @@ static void usage(char *argv0)
 	//Is the example below really true? /Martin
 	fprintf(stderr, "Example:\n\n\t %s path/to/osimage.elf path/to/fpgaimage.elf\n", argv0);
 	fprintf(stderr, "\nExample (Linux):\n\n\t %s  /dev/ttyACM0 armsrc/obj/fullimage.elf\n", argv0);
-	fprintf(stderr, "\nNote (Linux): if the flasher gets stuck in 'Waiting for Proxmark to reappear on <DEVICE>',\n");
-	fprintf(stderr, "              you need to blacklist proxmark for modem-manager - see wiki for more details:\n");
-	fprintf(stderr, "              http://code.google.com/p/proxmark3/wiki/Linux\n\n");
+	fprintf(stderr, "\nNote (Linux): if the flasher gets stuck at 'Waiting for Proxmark to reappear',\n");
+	fprintf(stderr, "       you may need to blacklist proxmark for modem-manager. v1.4.14 and later\n");
+	fprintf(stderr, "       include this configuration patch already. The change can be found at:\n");
+	fprintf(stderr, "       https://cgit.freedesktop.org/ModemManager/ModemManager/commit/?id=6e7ff47\n\n");
 }
 
 #define MAX_FILES 4
@@ -99,7 +61,10 @@ int main(int argc, char **argv)
 	int num_files = 0;
 	int res;
 	flash_file_t files[MAX_FILES];
+	receiver_arg conn;
+	pthread_t reader_thread;
 
+	memset(&conn, 0, sizeof(receiver_arg));
 	memset(files, 0, sizeof(files));
 
 	if (argc < 3) {
@@ -126,16 +91,22 @@ int main(int argc, char **argv)
 		}
 	}
 
-  serial_port_name = argv[1];
-  
-  fprintf(stderr,"Waiting for Proxmark to appear on %s",serial_port_name);
-  do {
-    msleep(1000);
-    fprintf(stderr, ".");
-  } while (!OpenProxmark(0));
-  fprintf(stderr," Found.\n");
+	pthread_mutex_init(&conn.recv_lock, NULL);
 
-	res = flash_start_flashing(can_write_bl,serial_port_name);
+	char* serial_port_name = argv[1];
+
+	fprintf(stderr,"Waiting for Proxmark to appear on %s", serial_port_name);
+	do {
+		sleep(1);
+		fprintf(stderr, ".");
+	} while (!OpenProxmark(serial_port_name));
+	fprintf(stderr," Found.\n");
+
+	// Lets start up the communications thread
+	conn.run = true;
+	pthread_create(&reader_thread, NULL, &uart_receiver, &conn);
+
+	res = flash_start_flashing(&conn, can_write_bl, serial_port_name);
 	if (res < 0)
 		return -1;
 
@@ -155,7 +126,11 @@ int main(int argc, char **argv)
 	if (res < 0)
 		return -1;
 
-	CloseProxmark();
+	// Stop the command thread.
+	conn.run = false;
+	pthread_join(reader_thread, NULL);
+	CloseProxmark(&conn, serial_port_name);
+	pthread_mutex_destroy(&conn.recv_lock);
 
 	fprintf(stderr, "All done.\n\n");
 	fprintf(stderr, "Have a nice day!\n");

--- a/client/graph.c
+++ b/client/graph.c
@@ -14,96 +14,93 @@
 #include "ui.h"
 #include "graph.h"
 #include "lfdemod.h"
-#include "cmddata.h" //for g_debugmode
-
-int GraphBuffer[MAX_GRAPH_TRACE_LEN];
-int GraphTraceLen;
-
-int s_Buff[MAX_GRAPH_TRACE_LEN];
+#include "cmddata.h" // SetClockGrid
 
 /* write a manchester bit to the graph */
-void AppendGraph(int redraw, int clock, int bit)
+void AppendGraph(pm3_connection* conn, int redraw, int clock, int bit)
 {
   int i;
   //set first half the clock bit (all 1's or 0's for a 0 or 1 bit) 
   for (i = 0; i < (int)(clock / 2); ++i)
-    GraphBuffer[GraphTraceLen++] = bit ;
+    conn->GraphBuffer[conn->GraphTraceLen++] = bit ;
   //set second half of the clock bit (all 0's or 1's for a 0 or 1 bit)
   for (i = (int)(clock / 2); i < clock; ++i)
-    GraphBuffer[GraphTraceLen++] = bit ^ 1;
+    conn->GraphBuffer[conn->GraphTraceLen++] = bit ^ 1;
 
   if (redraw)
-    RepaintGraphWindow();
+    RepaintGraphWindow(conn);
 }
 
 // clear out our graph window
-int ClearGraph(int redraw)
+int ClearGraph(pm3_connection* conn, int redraw)
 {
-  int gtl = GraphTraceLen;
-  memset(GraphBuffer, 0x00, GraphTraceLen);
+  int gtl = conn->GraphTraceLen;
+  memset(conn->GraphBuffer, 0x00, sizeof(conn->GraphBuffer));
 
-  GraphTraceLen = 0;
+  conn->GraphTraceLen = 0;
 
   if (redraw)
-    RepaintGraphWindow();
+    RepaintGraphWindow(conn);
 
   return gtl;
 }
 // option '1' to save GraphBuffer any other to restore
-void save_restoreGB(uint8_t saveOpt)
+void save_restoreGB(pm3_connection* conn, uint8_t saveOpt)
 {
+	// FIXME: This function only allows a buffer of 1 graph to be stored.
+	// FIXME: This function is not thread-safe.
 	static int SavedGB[MAX_GRAPH_TRACE_LEN];
 	static int SavedGBlen=0;
 	static bool GB_Saved = false;
 	static int SavedGridOffsetAdj=0;
 
 	if (saveOpt == GRAPH_SAVE) { //save
-		memcpy(SavedGB, GraphBuffer, sizeof(GraphBuffer));
-		SavedGBlen = GraphTraceLen;
+		memcpy(SavedGB, conn->GraphBuffer, MAX_GRAPH_TRACE_LEN);
+		SavedGBlen = conn->GraphTraceLen;
 		GB_Saved=true;
-		SavedGridOffsetAdj = GridOffset;
+		SavedGridOffsetAdj = conn->GridOffset;
 	} else if (GB_Saved) { //restore
-		memcpy(GraphBuffer, SavedGB, sizeof(GraphBuffer));
-		GraphTraceLen = SavedGBlen;
-		GridOffset = SavedGridOffsetAdj;
-		RepaintGraphWindow();
+		memcpy(conn->GraphBuffer, SavedGB, MAX_GRAPH_TRACE_LEN);
+		conn->GraphTraceLen = SavedGBlen;
+		conn->GridOffset = SavedGridOffsetAdj;
+		RepaintGraphWindow(conn);
 	}
 	return;
 }
 
 // DETECT CLOCK NOW IN LFDEMOD.C
 
-void setGraphBuf(uint8_t *buff, size_t size)
+void setGraphBuf(pm3_connection* conn, uint8_t *buff, size_t size)
 {
 	if ( buff == NULL ) return;
 	
 	uint16_t i = 0;  
 	if ( size > MAX_GRAPH_TRACE_LEN )
 		size = MAX_GRAPH_TRACE_LEN;
-	ClearGraph(0);
+	ClearGraph(conn, 0);
 	for (; i < size; ++i){
-		GraphBuffer[i]=buff[i]-128;
+		conn->GraphBuffer[i]=buff[i]-128;
 	}
-	GraphTraceLen=size;
-	RepaintGraphWindow();
+	conn->GraphTraceLen=size;
+	RepaintGraphWindow(conn);
 	return;
 }
-size_t getFromGraphBuf(uint8_t *buff)
+
+size_t getFromGraphBuf(pm3_connection* conn, uint8_t *buff)
 {
 	if (buff == NULL ) return 0;
 	uint32_t i;
-	for (i=0;i<GraphTraceLen;++i){
-		if (GraphBuffer[i]>127) GraphBuffer[i]=127; //trim
-		if (GraphBuffer[i]<-127) GraphBuffer[i]=-127; //trim
-		buff[i]=(uint8_t)(GraphBuffer[i]+128);
+	for (i=0;i<conn->GraphTraceLen;++i){
+		if (conn->GraphBuffer[i]>127) conn->GraphBuffer[i]=127; //trim
+		if (conn->GraphBuffer[i]<-127) conn->GraphBuffer[i]=-127; //trim
+		buff[i]=(uint8_t)(conn->GraphBuffer[i]+128);
 	}
 	return i;
 }
 
 // A simple test to see if there is any data inside Graphbuffer. 
-bool HasGraphData(){
-
-	if ( GraphTraceLen <= 0) {
+bool HasGraphData(pm3_connection* conn){
+	if (conn->GraphTraceLen <= 0) {
 		PrintAndLog("No data available, try reading something first");
 		return false;
 	}
@@ -112,17 +109,17 @@ bool HasGraphData(){
 
 // Detect high and lows in Grapbuffer.
 // Only loops the first 256 values. 
-void DetectHighLowInGraph(int *high, int *low, bool addFuzz) {
+void DetectHighLowInGraph(pm3_connection* conn, int *high, int *low, bool addFuzz) {
 
 	uint8_t loopMax = 255;
-	if ( loopMax > GraphTraceLen)
-		loopMax = GraphTraceLen;
+	if ( loopMax > conn->GraphTraceLen)
+		loopMax = conn->GraphTraceLen;
   
 	for (uint8_t i = 0; i < loopMax; ++i) {
-		if (GraphBuffer[i] > *high)
-			*high = GraphBuffer[i];
-		else if (GraphBuffer[i] < *low)
-			*low = GraphBuffer[i];
+		if (conn->GraphBuffer[i] > *high)
+			*high = conn->GraphBuffer[i];
+		else if (conn->GraphBuffer[i] < *low)
+			*low = conn->GraphBuffer[i];
 	}
 	
 	//12% fuzz in case highs and lows aren't clipped
@@ -133,9 +130,10 @@ void DetectHighLowInGraph(int *high, int *low, bool addFuzz) {
 }
 
 // Get or auto-detect ask clock rate
-int GetAskClock(const char str[], bool printAns, bool verbose)
+int GetAskClock(pm3_connection* conn, const char str[], bool printAns, bool verbose)
 {
 	int clock;
+	// FIXME: Use atoi instead
 	sscanf(str, "%i", &clock);
 	if (!strcmp(str, ""))
 		clock = 0;
@@ -144,7 +142,7 @@ int GetAskClock(const char str[], bool printAns, bool verbose)
 		return clock;
 	// Auto-detect clock
 	uint8_t grph[MAX_GRAPH_TRACE_LEN]={0};
-	size_t size = getFromGraphBuf(grph);
+	size_t size = getFromGraphBuf(conn, grph);
 	if (size == 0) {
 		if (verbose)
 			PrintAndLog("Failed to copy from graphbuffer");
@@ -157,7 +155,7 @@ int GetAskClock(const char str[], bool printAns, bool verbose)
 	if (st == false) {
 		start = DetectASKClock(grph, size, &clock, 20);
 	}
-	setClockGrid(clock, start);
+	setClockGrid(conn, clock, start);
 	// Only print this message if we're not looping something
 	if (printAns || g_debugMode) {
 		PrintAndLog("Auto-detected clock rate: %d, Best Starting Position: %d", clock, start);
@@ -165,11 +163,11 @@ int GetAskClock(const char str[], bool printAns, bool verbose)
 	return clock;
 }
 
-uint8_t GetPskCarrier(const char str[], bool printAns, bool verbose)
+uint8_t GetPskCarrier(pm3_connection* conn, const char str[], bool printAns, bool verbose)
 {
 	uint8_t carrier=0;
 	uint8_t grph[MAX_GRAPH_TRACE_LEN]={0};
-	size_t size = getFromGraphBuf(grph);
+	size_t size = getFromGraphBuf(conn, grph);
 	if ( size == 0 ) {
 		if (verbose) 
 			PrintAndLog("Failed to copy from graphbuffer");
@@ -186,9 +184,10 @@ uint8_t GetPskCarrier(const char str[], bool printAns, bool verbose)
 	return carrier;
 }
 
-int GetPskClock(const char str[], bool printAns, bool verbose)
+int GetPskClock(pm3_connection* conn, const char str[], bool printAns, bool verbose)
 {
 	int clock;
+	// FIXME: Use atoi instead.
 	sscanf(str, "%i", &clock);
 	if (!strcmp(str, "")) 
 		clock = 0;
@@ -197,7 +196,7 @@ int GetPskClock(const char str[], bool printAns, bool verbose)
 		return clock;
 	// Auto-detect clock
 	uint8_t grph[MAX_GRAPH_TRACE_LEN]={0};
-	size_t size = getFromGraphBuf(grph);
+	size_t size = getFromGraphBuf(conn, grph);
 	if ( size == 0 ) {
 		if (verbose) 
 			PrintAndLog("Failed to copy from graphbuffer");
@@ -206,7 +205,7 @@ int GetPskClock(const char str[], bool printAns, bool verbose)
 	size_t firstPhaseShiftLoc = 0;
 	uint8_t curPhase = 0, fc = 0;
 	clock = DetectPSKClock(grph, size, 0, &firstPhaseShiftLoc, &curPhase, &fc);
-	setClockGrid(clock, firstPhaseShiftLoc);
+	setClockGrid(conn, clock, firstPhaseShiftLoc);
 	// Only print this message if we're not looping something
 	if (printAns){
 		PrintAndLog("Auto-detected clock rate: %d", clock);
@@ -214,7 +213,7 @@ int GetPskClock(const char str[], bool printAns, bool verbose)
 	return clock;
 }
 
-uint8_t GetNrzClock(const char str[], bool printAns, bool verbose)
+uint8_t GetNrzClock(pm3_connection* conn, const char str[], bool printAns, bool verbose)
 {
 	int clock;
 	sscanf(str, "%i", &clock);
@@ -225,7 +224,7 @@ uint8_t GetNrzClock(const char str[], bool printAns, bool verbose)
 		return clock;
 	// Auto-detect clock
 	uint8_t grph[MAX_GRAPH_TRACE_LEN]={0};
-	size_t size = getFromGraphBuf(grph);
+	size_t size = getFromGraphBuf(conn, grph);
 	if ( size == 0 ) {
 		if (verbose) 
 			PrintAndLog("Failed to copy from graphbuffer");
@@ -233,7 +232,7 @@ uint8_t GetNrzClock(const char str[], bool printAns, bool verbose)
 	}
 	size_t clkStartIdx = 0;
 	clock = DetectNRZClock(grph, size, 0, &clkStartIdx);
-	setClockGrid(clock, clkStartIdx);
+	setClockGrid(conn, clock, clkStartIdx);
 	// Only print this message if we're not looping something
 	if (printAns){
 		PrintAndLog("Auto-detected clock rate: %d", clock);
@@ -242,7 +241,7 @@ uint8_t GetNrzClock(const char str[], bool printAns, bool verbose)
 }
 //by marshmellow
 //attempt to detect the field clock and bit clock for FSK
-uint8_t GetFskClock(const char str[], bool printAns, bool verbose)
+uint8_t GetFskClock(pm3_connection* conn, const char str[], bool printAns, bool verbose)
 {
 	int clock;
 	sscanf(str, "%i", &clock);
@@ -253,11 +252,11 @@ uint8_t GetFskClock(const char str[], bool printAns, bool verbose)
 
 	uint8_t fc1=0, fc2=0, rf1=0;
 	int firstClockEdge = 0;
-	uint8_t ans = fskClocks(&fc1, &fc2, &rf1, verbose, &firstClockEdge);
+	uint8_t ans = fskClocks(conn, &fc1, &fc2, &rf1, verbose, &firstClockEdge);
 	if (ans == 0) return 0;
 	if ((fc1==10 && fc2==8) || (fc1==8 && fc2==5)){
 		if (printAns) PrintAndLog("Detected Field Clocks: FC/%d, FC/%d - Bit Clock: RF/%d", fc1, fc2, rf1);
-		setClockGrid(rf1, firstClockEdge);
+		setClockGrid(conn, rf1, firstClockEdge);
 		return rf1;
 	}
 	if (verbose){
@@ -266,10 +265,10 @@ uint8_t GetFskClock(const char str[], bool printAns, bool verbose)
 	}
 	return 0;
 }
-uint8_t fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, bool verbose, int *firstClockEdge)
+uint8_t fskClocks(pm3_connection* conn, uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, bool verbose, int *firstClockEdge)
 {
 	uint8_t BitStream[MAX_GRAPH_TRACE_LEN]={0};
-	size_t size = getFromGraphBuf(BitStream);
+	size_t size = getFromGraphBuf(conn, BitStream);
 	if (size==0) return 0;
 	uint16_t ans = countFC(BitStream, size, 1); 
 	if (ans==0) {

--- a/client/graph.h
+++ b/client/graph.h
@@ -25,7 +25,14 @@ uint8_t fskClocks(pm3_connection* conn, uint8_t *fc1, uint8_t *fc2, uint8_t *rf1
 //uint8_t fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, bool verbose);
 bool graphJustNoise(int *BitStream, int size);
 void setGraphBuf(pm3_connection* conn, uint8_t *buff, size_t size);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 void save_restoreGB(pm3_connection* conn, uint8_t saveOpt);
+#ifdef __cplusplus
+}
+#endif
 
 bool HasGraphData();
 void DetectHighLowInGraph(pm3_connection* conn, int *high, int *low, bool addFuzz); 

--- a/client/graph.h
+++ b/client/graph.h
@@ -12,31 +12,25 @@
 #define GRAPH_H__
 #include <stdint.h>
 
-void AppendGraph(int redraw, int clock, int bit);
-int ClearGraph(int redraw);
+void AppendGraph(pm3_connection* conn, int redraw, int clock, int bit);
+int ClearGraph(pm3_connection* conn, int redraw);
 //int DetectClock(int peak);
-size_t getFromGraphBuf(uint8_t *buff);
-int GetAskClock(const char str[], bool printAns, bool verbose);
-int GetPskClock(const char str[], bool printAns, bool verbose);
-uint8_t GetPskCarrier(const char str[], bool printAns, bool verbose);
-uint8_t GetNrzClock(const char str[], bool printAns, bool verbose);
-uint8_t GetFskClock(const char str[], bool printAns, bool verbose);
-uint8_t fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, bool verbose, int *firstClockEdge);
+size_t getFromGraphBuf(pm3_connection* conn, uint8_t *buff);
+int GetAskClock(pm3_connection* conn, const char str[], bool printAns, bool verbose);
+int GetPskClock(pm3_connection* conn, const char str[], bool printAns, bool verbose);
+uint8_t GetPskCarrier(pm3_connection* conn, const char str[], bool printAns, bool verbose);
+uint8_t GetNrzClock(pm3_connection* conn, const char str[], bool printAns, bool verbose);
+uint8_t GetFskClock(pm3_connection* conn, const char str[], bool printAns, bool verbose);
+uint8_t fskClocks(pm3_connection* conn, uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, bool verbose, int *firstClockEdge);
 //uint8_t fskClocks(uint8_t *fc1, uint8_t *fc2, uint8_t *rf1, bool verbose);
 bool graphJustNoise(int *BitStream, int size);
-void setGraphBuf(uint8_t *buff, size_t size);
-void save_restoreGB(uint8_t saveOpt);
+void setGraphBuf(pm3_connection* conn, uint8_t *buff, size_t size);
+void save_restoreGB(pm3_connection* conn, uint8_t saveOpt);
 
 bool HasGraphData();
-void DetectHighLowInGraph(int *high, int *low, bool addFuzz); 
+void DetectHighLowInGraph(pm3_connection* conn, int *high, int *low, bool addFuzz); 
 
-// Max graph trace len: 40000 (bigbuf) * 8 (at 1 bit per sample)
-#define MAX_GRAPH_TRACE_LEN (40000 * 8 )
 #define GRAPH_SAVE 1
 #define GRAPH_RESTORE 0
-
-extern int GraphBuffer[MAX_GRAPH_TRACE_LEN];
-extern int GraphTraceLen;
-extern int s_Buff[MAX_GRAPH_TRACE_LEN];
 
 #endif

--- a/client/guidummy.cpp
+++ b/client/guidummy.cpp
@@ -9,8 +9,9 @@
 //-----------------------------------------------------------------------------
 
 #include <stdio.h>
+#include "comms.h"
 
-extern "C" void ShowGraphWindow(void)
+extern "C" void ShowGraphWindow(pm3_connection* conn)
 {
 	static int warned = 0;
 
@@ -20,8 +21,8 @@ extern "C" void ShowGraphWindow(void)
 	}
 }
 
-extern "C" void HideGraphWindow(void) {}
-extern "C" void RepaintGraphWindow(void) {}
+extern "C" void HideGraphWindow(pm3_connection* conn) {}
+extern "C" void RepaintGraphWindow(pm3_connection* conn) {}
 extern "C" void MainGraphics() {}
 extern "C" void InitGraphics(int argc, char **argv) {}
 extern "C" void ExitGraphics(void) {}

--- a/client/guidummy.cpp
+++ b/client/guidummy.cpp
@@ -21,8 +21,8 @@ extern "C" void ShowGraphWindow(pm3_connection* conn)
 	}
 }
 
-extern "C" void HideGraphWindow(pm3_connection* conn) {}
-extern "C" void RepaintGraphWindow(pm3_connection* conn) {}
-extern "C" void MainGraphics() {}
+extern "C" void HideGraphWindow() {}
+extern "C" void RepaintGraphWindow() {}
+extern "C" void MainGraphics(pm3_connection* conn) {}
 extern "C" void InitGraphics(int argc, char **argv) {}
 extern "C" void ExitGraphics(void) {}

--- a/client/mifarehost.c
+++ b/client/mifarehost.c
@@ -113,7 +113,7 @@ static uint32_t nonce2key(uint32_t uid, uint32_t nt, uint32_t nr, uint64_t par_i
 }
 
 
-int mfDarkside(uint64_t *key)
+int mfDarkside(pm3_connection *conn, uint64_t *key)
 {
 	uint32_t uid = 0;
 	uint32_t nt = 0, nr = 0;
@@ -132,8 +132,8 @@ int mfDarkside(uint64_t *key)
 
 
 	while (true) {
-		clearCommandBuffer();
-		SendCommand(&c);
+		clearCommandBuffer(conn);
+		SendCommand(conn, &c);
 
 		//flush queue
 		while (ukbhit()) {
@@ -150,7 +150,7 @@ int mfDarkside(uint64_t *key)
 			}
 
 			UsbCommand resp;
-			if (WaitForResponseTimeout(CMD_ACK, &resp, 1000)) {
+			if (WaitForResponseTimeout(conn, CMD_ACK, &resp, 1000)) {
 				isOK  = resp.arg[0];
 				if (isOK < 0) {
 					return isOK;
@@ -204,7 +204,7 @@ int mfDarkside(uint64_t *key)
 					num_to_bytes(last_keylist[i*max_keys + j], 6, keyBlock);
 				}
 			}
-			if (!mfCheckKeys(0, 0, false, size, keyBlock, key)) {
+			if (!mfCheckKeys(conn, 0, 0, false, size, keyBlock, key)) {
 				break;
 			}
 		}
@@ -224,22 +224,22 @@ int mfDarkside(uint64_t *key)
 }
 
 
-int mfCheckKeys (uint8_t blockNo, uint8_t keyType, bool clear_trace, uint8_t keycnt, uint8_t * keyBlock, uint64_t * key){
+int mfCheckKeys (pm3_connection* conn, uint8_t blockNo, uint8_t keyType, bool clear_trace, uint8_t keycnt, uint8_t * keyBlock, uint64_t * key){
 
 	*key = -1;
 
 	UsbCommand c = {CMD_MIFARE_CHKKEYS, {((blockNo & 0xff) | ((keyType & 0xff) << 8)), clear_trace, keycnt}}; 
 	memcpy(c.d.asBytes, keyBlock, 6 * keycnt);
-	SendCommand(&c);
+	SendCommand(conn, &c);
 
 	UsbCommand resp;
-	if (!WaitForResponseTimeout(CMD_ACK,&resp,3000)) return 1; 
+	if (!WaitForResponseTimeout(conn, CMD_ACK,&resp,3000)) return 1;
 	if ((resp.arg[0] & 0xff) != 0x01) return 2;
 	*key = bytes_to_num(resp.d.asBytes, 6);
 	return 0;
 }
 
-int mfCheckKeysSec(uint8_t sectorCnt, uint8_t keyType, uint8_t timeout14a, bool clear_trace, uint8_t keycnt, uint8_t * keyBlock, sector_t * e_sector){
+int mfCheckKeysSec(pm3_connection* conn, uint8_t sectorCnt, uint8_t keyType, uint8_t timeout14a, bool clear_trace, uint8_t keycnt, uint8_t * keyBlock, sector_t * e_sector){
 
 	uint8_t keyPtr = 0;
 
@@ -248,10 +248,10 @@ int mfCheckKeysSec(uint8_t sectorCnt, uint8_t keyType, uint8_t timeout14a, bool 
 
 	UsbCommand c = {CMD_MIFARE_CHKKEYS, {((sectorCnt & 0xff) | ((keyType & 0xff) << 8)), (clear_trace | 0x02)|((timeout14a & 0xff) << 8), keycnt}}; 
 	memcpy(c.d.asBytes, keyBlock, 6 * keycnt);
-	SendCommand(&c);
+	SendCommand(conn, &c);
 
 	UsbCommand resp;
-	if (!WaitForResponseTimeoutW(CMD_ACK, &resp, MAX(3000, 1000 + 13 * sectorCnt * keycnt * (keyType == 2 ? 2 : 1)), false)) return 1; // timeout: 13 ms / fail auth
+	if (!WaitForResponseTimeoutW(conn, CMD_ACK, &resp, MAX(3000, 1000 + 13 * sectorCnt * keycnt * (keyType == 2 ? 2 : 1)), false)) return 1; // timeout: 13 ms / fail auth
 	if ((resp.arg[0] & 0xff) != 0x01) return 2;
 	
 	bool foundAKey = false;
@@ -309,7 +309,7 @@ void* nested_worker_thread(void *arg)
 	return statelist->head.slhead;
 }
 
-int mfnested(uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_t trgBlockNo, uint8_t trgKeyType, uint8_t *resultKey, bool calibrate)
+int mfnested(pm3_connection* conn, uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_t trgBlockNo, uint8_t trgKeyType, uint8_t *resultKey, bool calibrate) 
 {
 	uint16_t i;
 	uint32_t uid;
@@ -319,13 +319,13 @@ int mfnested(uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_t trgBlockNo,
 	struct Crypto1State *p1, *p2, *p3, *p4;
 
 	// flush queue
-	WaitForResponseTimeout(CMD_ACK, NULL, 100);
+	WaitForResponseTimeout(conn, CMD_ACK, NULL, 100);
 
 	UsbCommand c = {CMD_MIFARE_NESTED, {blockNo + keyType * 0x100, trgBlockNo + trgKeyType * 0x100, calibrate}};
 	memcpy(c.d.asBytes, key, 6);
-	SendCommand(&c);
+	SendCommand(conn, &c);
 
-	if (!WaitForResponseTimeout(CMD_ACK, &resp, 1500)) {
+	if (!WaitForResponseTimeout(conn, CMD_ACK, &resp, 1500)) {
 		return -1;
 	}
 
@@ -408,7 +408,7 @@ int mfnested(uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_t trgBlockNo,
 		crypto1_get_lfsr(statelists[0].head.slhead + i, &key64);
 		num_to_bytes(key64, 6, keyBlock);
 		key64 = 0;
-		if (!mfCheckKeys(statelists[0].blockNo, statelists[0].keyType, false, 1, keyBlock, &key64)) {
+		if (!mfCheckKeys(conn, statelists[0].blockNo, statelists[0].keyType, false, 1, keyBlock, &key64)) {
 			num_to_bytes(key64, 6, resultKey);
 			break;
 		}
@@ -422,33 +422,33 @@ int mfnested(uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_t trgBlockNo,
 
 // EMULATOR
 
-int mfEmlGetMem(uint8_t *data, int blockNum, int blocksCount) {
+int mfEmlGetMem(pm3_connection* conn, uint8_t *data, int blockNum, int blocksCount) {
 	UsbCommand c = {CMD_MIFARE_EML_MEMGET, {blockNum, blocksCount, 0}};
- 	SendCommand(&c);
+ 	SendCommand(conn, &c);
 
   UsbCommand resp;
-	if (!WaitForResponseTimeout(CMD_ACK,&resp,1500)) return 1;
+	if (!WaitForResponseTimeout(conn, CMD_ACK,&resp,1500)) return 1;
 	memcpy(data, resp.d.asBytes, blocksCount * 16);
 	return 0;
 }
 
-int mfEmlSetMem(uint8_t *data, int blockNum, int blocksCount) {
+int mfEmlSetMem(pm3_connection* conn, uint8_t *data, int blockNum, int blocksCount) {
 	UsbCommand c = {CMD_MIFARE_EML_MEMSET, {blockNum, blocksCount, 0}};
-	memcpy(c.d.asBytes, data, blocksCount * 16);
-	SendCommand(&c);
+	memcpy(c.d.asBytes, data, blocksCount * 16); 
+	SendCommand(conn, &c);
 	return 0;
 }
 
 // "MAGIC" CARD
 
-int mfCGetBlock(uint8_t blockNo, uint8_t *data, uint8_t params) {
+int mfCGetBlock(pm3_connection* conn, uint8_t blockNo, uint8_t *data, uint8_t params) {
 	uint8_t isOK = 0;
 
 	UsbCommand c = {CMD_MIFARE_CGETBLOCK, {params, 0, blockNo}};
-	SendCommand(&c);
+	SendCommand(conn, &c);
 
 	UsbCommand resp;
-	if (WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
+	if (WaitForResponseTimeout(conn, CMD_ACK,&resp,1500)) {
 		isOK  = resp.arg[0] & 0xff;
 		memcpy(data, resp.d.asBytes, 16);
 		if (!isOK) return 2;
@@ -459,15 +459,15 @@ int mfCGetBlock(uint8_t blockNo, uint8_t *data, uint8_t params) {
 	return 0;
 }
 
-int mfCSetBlock(uint8_t blockNo, uint8_t *data, uint8_t *uid, bool wantWipe, uint8_t params) {
+int mfCSetBlock(pm3_connection* conn, uint8_t blockNo, uint8_t *data, uint8_t *uid, bool wantWipe, uint8_t params) {
 
 	uint8_t isOK = 0;
 	UsbCommand c = {CMD_MIFARE_CSETBLOCK, {wantWipe, params & (0xFE | (uid == NULL ? 0:1)), blockNo}};
-	memcpy(c.d.asBytes, data, 16);
-	SendCommand(&c);
+	memcpy(c.d.asBytes, data, 16); 
+	SendCommand(conn, &c);
 
 	UsbCommand resp;
-	if (WaitForResponseTimeout(CMD_ACK, &resp, 1500)) {
+	if (WaitForResponseTimeout(conn, CMD_ACK,&resp,1500)) {
 		isOK  = resp.arg[0] & 0xff;
 		if (uid != NULL)
 			memcpy(uid, resp.d.asBytes, 4);
@@ -481,20 +481,20 @@ int mfCSetBlock(uint8_t blockNo, uint8_t *data, uint8_t *uid, bool wantWipe, uin
 	return 0;
 }
 
-int mfCWipe(uint32_t numSectors, bool gen1b, bool wantWipe, bool wantFill) {
+int mfCWipe(pm3_connection* conn, uint32_t numSectors, bool gen1b, bool wantWipe, bool wantFill) {
 	uint8_t isOK = 0;
 	uint8_t cmdParams = wantWipe + wantFill * 0x02 + gen1b * 0x04;
 	UsbCommand c = {CMD_MIFARE_CWIPE, {numSectors, cmdParams, 0}};
-	SendCommand(&c);
+	SendCommand(conn, &c);
 
 	UsbCommand resp;
-	WaitForResponse(CMD_ACK,&resp);
+	WaitForResponse(conn, CMD_ACK,&resp);
 	isOK  = resp.arg[0] & 0xff;
 	
 	return isOK;
 }
 
-int mfCSetUID(uint8_t *uid, uint8_t *atqa, uint8_t *sak, uint8_t *oldUID) {
+int mfCSetUID(pm3_connection* conn, uint8_t *uid, uint8_t *atqa, uint8_t *sak, uint8_t *oldUID) {
 	uint8_t oldblock0[16] = {0x00};
 	uint8_t block0[16] = {0x00};
 	int gen = 0, res;
@@ -508,7 +508,7 @@ int mfCSetUID(uint8_t *uid, uint8_t *atqa, uint8_t *sak, uint8_t *oldUID) {
 		cmdParams = CSETBLOCK_SINGLE_OPER | CSETBLOCK_MAGIC_1B;
 	}
 	
-	res = mfCGetBlock(0, oldblock0, cmdParams);
+	res = mfCGetBlock(conn, 0, oldblock0, cmdParams);
 
 	if (res == 0) {
 		memcpy(block0, oldblock0, 16);
@@ -531,7 +531,7 @@ int mfCSetUID(uint8_t *uid, uint8_t *atqa, uint8_t *sak, uint8_t *oldUID) {
 	}
 	PrintAndLog("new block 0:  %s", sprint_hex(block0, 16));
 
-	res = mfCSetBlock(0, block0, oldUID, false, cmdParams);
+	res = mfCSetBlock(conn, 0, block0, oldUID, false, cmdParams);
 	if (res) {
 		PrintAndLog("Can't set block 0. Error: %d", res);
 		return res;
@@ -540,13 +540,13 @@ int mfCSetUID(uint8_t *uid, uint8_t *atqa, uint8_t *sak, uint8_t *oldUID) {
 	return 0;
 }
 
-int mfCIdentify()
+int mfCIdentify(pm3_connection* conn)
 {
 	UsbCommand c = {CMD_READER_ISO_14443a, {ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0}};
-	SendCommand(&c);
+	SendCommand(conn, &c);
 
 	UsbCommand resp;
-	WaitForResponse(CMD_ACK,&resp);
+	WaitForResponse(conn, CMD_ACK, &resp);
 
 	// iso14a_card_select_t card;
 	// memcpy(&card, (iso14a_card_select_t *)resp.d.asBytes, sizeof(iso14a_card_select_t));
@@ -567,8 +567,8 @@ int mfCIdentify()
 	c.arg[0] = 0;
 	c.arg[1] = 0;
 	c.arg[2] = 0;
-	SendCommand(&c);
-	WaitForResponse(CMD_ACK,&resp);
+	SendCommand(conn, &c);
+	WaitForResponse(conn, CMD_ACK, &resp);
 
 	uint8_t isGeneration = resp.arg[0] & 0xff;
 	switch( isGeneration ){
@@ -582,7 +582,7 @@ int mfCIdentify()
 	c.arg[0] = 0;
 	c.arg[1] = 0;
 	c.arg[2] = 0;
-	SendCommand(&c);
+	SendCommand(conn, &c);
 
 	return (int) isGeneration;
 }

--- a/client/mifarehost.h
+++ b/client/mifarehost.h
@@ -14,6 +14,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "data.h"
+#include "comms.h"
 
 // defaults
 // timeout in units. (ms * 106)/10 or us*0.0106
@@ -36,18 +37,18 @@ typedef struct {
 
 extern char logHexFileName[FILE_PATH_SIZE];
 
-extern int mfDarkside(uint64_t *key);
-extern int mfnested(uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_t trgBlockNo, uint8_t trgKeyType, uint8_t *ResultKeys, bool calibrate);
-extern int mfCheckKeys (uint8_t blockNo, uint8_t keyType, bool clear_trace, uint8_t keycnt, uint8_t *keyBlock, uint64_t *key);
-extern int mfCheckKeysSec(uint8_t sectorCnt, uint8_t keyType, uint8_t timeout14a, bool clear_trace, uint8_t keycnt, uint8_t * keyBlock, sector_t * e_sector);
+extern int mfDarkside(pm3_connection* conn, uint64_t *key);
+extern int mfnested(pm3_connection* conn, uint8_t blockNo, uint8_t keyType, uint8_t *key, uint8_t trgBlockNo, uint8_t trgKeyType, uint8_t *ResultKeys, bool calibrate);
+extern int mfCheckKeys(pm3_connection* conn, uint8_t blockNo, uint8_t keyType, bool clear_trace, uint8_t keycnt, uint8_t *keyBlock, uint64_t *key);
+extern int mfCheckKeysSec(pm3_connection* conn, uint8_t sectorCnt, uint8_t keyType, uint8_t timeout14a, bool clear_trace, uint8_t keycnt, uint8_t * keyBlock, sector_t * e_sector);
 
-extern int mfEmlGetMem(uint8_t *data, int blockNum, int blocksCount);
-extern int mfEmlSetMem(uint8_t *data, int blockNum, int blocksCount);
+extern int mfEmlGetMem(pm3_connection* conn, uint8_t *data, int blockNum, int blocksCount);
+extern int mfEmlSetMem(pm3_connection* conn, uint8_t *data, int blockNum, int blocksCount);
 
-extern int mfCWipe(uint32_t numSectors, bool gen1b, bool wantWipe, bool wantFill);
-extern int mfCSetUID(uint8_t *uid, uint8_t *atqa, uint8_t *sak, uint8_t *oldUID);
-extern int mfCSetBlock(uint8_t blockNo, uint8_t *data, uint8_t *uid, bool wantWipe, uint8_t params);
-extern int mfCGetBlock(uint8_t blockNo, uint8_t *data, uint8_t params);
+extern int mfCWipe(pm3_connection* conn, uint32_t numSectors, bool gen1b, bool wantWipe, bool wantFill);
+extern int mfCSetUID(pm3_connection* conn, uint8_t *uid, uint8_t *atqa, uint8_t *sak, uint8_t *oldUID);
+extern int mfCSetBlock(pm3_connection* conn, uint8_t blockNo, uint8_t *data, uint8_t *uid, bool wantWipe, uint8_t params);
+extern int mfCGetBlock(pm3_connection* conn, uint8_t blockNo, uint8_t *data, uint8_t params);
 
 extern int mfTraceInit(uint8_t *tuid, uint8_t *atqa, uint8_t sak, bool wantSaveToEmlFile);
 extern int mfTraceDecode(uint8_t *data_src, int len, bool wantSaveToEmlFile);

--- a/client/proxgui.cpp
+++ b/client/proxgui.cpp
@@ -65,13 +65,10 @@ extern "C" void MainGraphics(pm3_connection* conn)
 
 extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present, serial_port* port, bool flush_after_write)
 {
-#ifdef Q_WS_X11
-	bool useGUI = getenv("DISPLAY") != 0;
-#else
-	bool useGUI = true;
-#endif
-	if (!useGUI)
+	if (!has_gui()) {
+		printf("Oops, InitGraphics called when we have no GUI!\n");
 		return;
+	}
 
 	gui = new ProxGuiQT(argc, argv);
 	main_loop_thread = new WorkerThread(script_cmds_file, usb_present, port, flush_after_write);

--- a/client/proxgui.cpp
+++ b/client/proxgui.cpp
@@ -11,11 +11,15 @@
 #include "proxgui.h"
 #include "proxguiqt.h"
 #include "proxmark3.h"
+#include "uart.h"
 
 static ProxGuiQT *gui = NULL;
 static WorkerThread *main_loop_thread = NULL;
 
-WorkerThread::WorkerThread(char *script_cmds_file, bool usb_present) : script_cmds_file(script_cmds_file), usb_present(usb_present)
+WorkerThread::WorkerThread(char *script_cmds_file, bool usb_present, serial_port* sp)
+	: script_cmds_file(script_cmds_file), usb_present(usb_present),
+	  sp(sp)
+	
 {
 }
 
@@ -24,7 +28,7 @@ WorkerThread::~WorkerThread()
 }
 
 void WorkerThread::run() {
-	main_loop(script_cmds_file, usb_present);
+	main_loop(script_cmds_file, usb_present, sp);
 }
 
 extern "C" void ShowGraphWindow(void)
@@ -60,7 +64,7 @@ extern "C" void MainGraphics(void)
 	gui->MainLoop();
 }
 
-extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present)
+extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present, serial_port* sp)
 {
 #ifdef Q_WS_X11
 	bool useGUI = getenv("DISPLAY") != 0;
@@ -71,7 +75,7 @@ extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, bool
 		return;
 
 	gui = new ProxGuiQT(argc, argv);
-	main_loop_thread = new WorkerThread(script_cmds_file, usb_present);
+	main_loop_thread = new WorkerThread(script_cmds_file, usb_present, sp);
 	QObject::connect(main_loop_thread, SIGNAL(finished()), main_loop_thread, SLOT(deleteLater()));
 	QObject::connect(main_loop_thread, SIGNAL(finished()), gui, SLOT(_Exit()));
 }

--- a/client/proxgui.cpp
+++ b/client/proxgui.cpp
@@ -16,11 +16,9 @@
 static ProxGuiQT *gui = NULL;
 static WorkerThread *main_loop_thread = NULL;
 
-WorkerThread::WorkerThread(char *script_cmds_file, bool usb_present,
-                           serial_port* sp, bool flush_after_write)
-	: script_cmds_file(script_cmds_file), usb_present(usb_present),
-	  sp(sp), flush_after_write(flush_after_write)
-	
+
+WorkerThread::WorkerThread(char *script_cmds_file, bool usb_present, serial_port* port, bool flush_after_write)
+	: script_cmds_file(script_cmds_file), usb_present(usb_present), port(port), flush_after_write(flush_after_write)
 {
 }
 
@@ -29,7 +27,7 @@ WorkerThread::~WorkerThread()
 }
 
 void WorkerThread::run() {
-	main_loop(script_cmds_file, usb_present, sp, flush_after_write);
+	main_loop(script_cmds_file, usb_present, port, flush_after_write);
 }
 
 extern "C" void ShowGraphWindow(void)
@@ -56,16 +54,16 @@ extern "C" void RepaintGraphWindow(void)
   gui->RepaintGraphWindow();
 }
 
-extern "C" void MainGraphics(void)
+extern "C" void MainGraphics(pm3_connection* conn)
 {
 	if (!gui)
 		return;
 
 	main_loop_thread->start();
-	gui->MainLoop();
+	gui->MainLoop(conn);
 }
 
-extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present, serial_port* sp, bool flush_after_write)
+extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present, serial_port* port, bool flush_after_write)
 {
 #ifdef Q_WS_X11
 	bool useGUI = getenv("DISPLAY") != 0;
@@ -76,7 +74,7 @@ extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, bool
 		return;
 
 	gui = new ProxGuiQT(argc, argv);
-	main_loop_thread = new WorkerThread(script_cmds_file, usb_present, sp, flush_after_write);
+	main_loop_thread = new WorkerThread(script_cmds_file, usb_present, port, flush_after_write);
 	QObject::connect(main_loop_thread, SIGNAL(finished()), main_loop_thread, SLOT(deleteLater()));
 	QObject::connect(main_loop_thread, SIGNAL(finished()), gui, SLOT(_Exit()));
 }

--- a/client/proxgui.cpp
+++ b/client/proxgui.cpp
@@ -16,9 +16,10 @@
 static ProxGuiQT *gui = NULL;
 static WorkerThread *main_loop_thread = NULL;
 
-WorkerThread::WorkerThread(char *script_cmds_file, bool usb_present, serial_port* sp)
+WorkerThread::WorkerThread(char *script_cmds_file, bool usb_present,
+                           serial_port* sp, bool flush_after_write)
 	: script_cmds_file(script_cmds_file), usb_present(usb_present),
-	  sp(sp)
+	  sp(sp), flush_after_write(flush_after_write)
 	
 {
 }
@@ -28,7 +29,7 @@ WorkerThread::~WorkerThread()
 }
 
 void WorkerThread::run() {
-	main_loop(script_cmds_file, usb_present, sp);
+	main_loop(script_cmds_file, usb_present, sp, flush_after_write);
 }
 
 extern "C" void ShowGraphWindow(void)
@@ -64,7 +65,7 @@ extern "C" void MainGraphics(void)
 	gui->MainLoop();
 }
 
-extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present, serial_port* sp)
+extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present, serial_port* sp, bool flush_after_write)
 {
 #ifdef Q_WS_X11
 	bool useGUI = getenv("DISPLAY") != 0;
@@ -75,7 +76,7 @@ extern "C" void InitGraphics(int argc, char **argv, char *script_cmds_file, bool
 		return;
 
 	gui = new ProxGuiQT(argc, argv);
-	main_loop_thread = new WorkerThread(script_cmds_file, usb_present, sp);
+	main_loop_thread = new WorkerThread(script_cmds_file, usb_present, sp, flush_after_write);
 	QObject::connect(main_loop_thread, SIGNAL(finished()), main_loop_thread, SLOT(deleteLater()));
 	QObject::connect(main_loop_thread, SIGNAL(finished()), gui, SLOT(_Exit()));
 }

--- a/client/proxgui.h
+++ b/client/proxgui.h
@@ -14,12 +14,13 @@ extern "C" {
 
 #include <stdint.h>
 #include <string.h>
+#include "uart.h"
 
 void ShowGraphWindow(void);
 void HideGraphWindow(void);
 void RepaintGraphWindow(void);
 void MainGraphics(void);
-void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present);
+void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present, serial_port* sp);
 void ExitGraphics(void);
 
 #define MAX_GRAPH_TRACE_LEN (40000*8)
@@ -30,7 +31,6 @@ extern int s_Buff[MAX_GRAPH_TRACE_LEN];
 extern double CursorScaleFactor;
 extern int PlotGridX, PlotGridY, PlotGridXdefault, PlotGridYdefault, CursorCPos, CursorDPos, GridOffset;
 extern int CommandFinished;
-extern int offline;
 extern bool GridLocked;
 
 //Operations defined in data_operations

--- a/client/proxgui.h
+++ b/client/proxgui.h
@@ -15,39 +15,21 @@ extern "C" {
 #include <stdint.h>
 #include <string.h>
 #include "uart.h"
+#include "comms.h"
 
-void ShowGraphWindow(void);
-void HideGraphWindow(void);
-void RepaintGraphWindow(void);
+void ShowGraphWindow(pm3_connection* conn);
+void HideGraphWindow(pm3_connection* conn);
+void RepaintGraphWindow(pm3_connection* conn);
 void MainGraphics(void);
-void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present, serial_port* sp);
+void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present, serial_port* port, bool flush_after_write);
 void ExitGraphics(void);
-
-#define MAX_GRAPH_TRACE_LEN (40000*8)
-extern int GraphBuffer[MAX_GRAPH_TRACE_LEN];
-extern int GraphTraceLen;
-extern int s_Buff[MAX_GRAPH_TRACE_LEN];
-
-extern double CursorScaleFactor;
-extern int PlotGridX, PlotGridY, PlotGridXdefault, PlotGridYdefault, CursorCPos, CursorDPos, GridOffset;
-extern int CommandFinished;
-extern bool GridLocked;
 
 //Operations defined in data_operations
 //extern int autoCorr(const int* in, int *out, size_t len, int window);
 extern int AskEdgeDetect(const int *in, int *out, int len, int threshold);
 extern int AutoCorrelate(const int *in, int *out, size_t len, int window, bool SaveGrph, bool verbose);
 extern int directionalThreshold(const int* in, int *out, size_t len, int8_t up, int8_t down);
-extern void save_restoreGB(uint8_t saveOpt);
 
-#define GRAPH_SAVE 1
-#define GRAPH_RESTORE 0
-#define MAX_DEMOD_BUF_LEN (1024*128)
-extern uint8_t DemodBuffer[MAX_DEMOD_BUF_LEN];
-extern size_t DemodBufferLen;
-extern size_t g_DemodStartIdx;
-extern bool showDemod;
-extern uint8_t g_debugMode;
 
 #ifdef __cplusplus
 }

--- a/client/proxgui.h
+++ b/client/proxgui.h
@@ -17,10 +17,10 @@ extern "C" {
 #include "uart.h"
 #include "comms.h"
 
-void ShowGraphWindow(pm3_connection* conn);
-void HideGraphWindow(pm3_connection* conn);
-void RepaintGraphWindow(pm3_connection* conn);
-void MainGraphics(void);
+void ShowGraphWindow(void);
+void HideGraphWindow(void);
+void RepaintGraphWindow(void);
+void MainGraphics(pm3_connection* conn);
 void InitGraphics(int argc, char **argv, char *script_cmds_file, bool usb_present, serial_port* port, bool flush_after_write);
 void ExitGraphics(void);
 

--- a/client/proxguiqt.h
+++ b/client/proxguiqt.h
@@ -21,6 +21,7 @@
 #include <QPainter>
 #include <QtGui>
 
+#include "uart.h"
 #include "ui/ui_overlays.h"
 /**
  * @brief The actual plot, black area were we paint the graph
@@ -123,12 +124,13 @@ class ProxGuiQT : public QObject
 class WorkerThread : public QThread {
 	Q_OBJECT;
 public:
-	WorkerThread(char*, bool);
+	WorkerThread(char*, bool, serial_port*);
 	~WorkerThread();
 	void run();
 private:
 	char *script_cmds_file = NULL;
 	bool usb_present;
+	serial_port *sp = NULL;
 };
 
 #endif // PROXGUI_QT

--- a/client/proxguiqt.h
+++ b/client/proxguiqt.h
@@ -24,6 +24,9 @@
 #include "uart.h"
 #include "ui/ui_overlays.h"
 #include "uart.h"
+#include "comms.h"
+
+class ProxGuiQT;
 
 /**
  * @brief The actual plot, black area were we paint the graph
@@ -31,6 +34,7 @@
 class Plot: public QWidget
 {
 private:
+	ProxGuiQT *master;
 	int GraphStart;
 	double GraphPixelsPerPoint;
 	int CursorAPos;
@@ -44,7 +48,7 @@ private:
 	void setMaxAndStart(int *buffer, int len, QRect plotRect);
 	QColor getColor(int graphNum);
 public:
-	Plot(QWidget *parent = 0);
+	Plot(QWidget *parent = 0, ProxGuiQT *master = NULL);
 
 protected:
 	void paintEvent(QPaintEvent *event);
@@ -54,7 +58,6 @@ protected:
 	void keyPressEvent(QKeyEvent *event);
 
 };
-class ProxGuiQT;
 
 /**
  * The window with plot and controls
@@ -101,15 +104,18 @@ class ProxGuiQT : public QObject
 		int argc;
 		char **argv;
 		void (*main_func)(void);
-	
+
 	public:
 		ProxGuiQT(int argc, char **argv);
 		~ProxGuiQT(void);
 		void ShowGraphWindow(void);
 		void RepaintGraphWindow(void);
 		void HideGraphWindow(void);
-		void MainLoop(void);
+		void MainLoop(pm3_connection *conn);
 		void Exit(void);
+		// Shared for ProxWidget
+		pm3_connection *conn;
+
 	private slots:
 		void _ShowGraphWindow(void);
 		void _RepaintGraphWindow(void);
@@ -132,7 +138,7 @@ public:
 private:
 	char *script_cmds_file = NULL;
 	bool usb_present;
-	serial_port *sp = NULL;
+	serial_port *port = NULL;
 	bool flush_after_write = false;
 };
 

--- a/client/proxguiqt.h
+++ b/client/proxguiqt.h
@@ -23,6 +23,8 @@
 
 #include "uart.h"
 #include "ui/ui_overlays.h"
+#include "uart.h"
+
 /**
  * @brief The actual plot, black area were we paint the graph
  */
@@ -124,13 +126,14 @@ class ProxGuiQT : public QObject
 class WorkerThread : public QThread {
 	Q_OBJECT;
 public:
-	WorkerThread(char*, bool, serial_port*);
+	WorkerThread(char*, bool, serial_port*, bool);
 	~WorkerThread();
 	void run();
 private:
 	char *script_cmds_file = NULL;
 	bool usb_present;
 	serial_port *sp = NULL;
+	bool flush_after_write = false;
 };
 
 #endif // PROXGUI_QT

--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -25,80 +25,30 @@
 #include "cmdparser.h"
 #include "cmdhw.h"
 #include "whereami.h"
+#include "comms.h"
 
-
-// a global mutex to prevent interlaced printing from different threads
-pthread_mutex_t print_lock;
-
-static serial_port sp;
-static UsbCommand txcmd;
-volatile static bool txcmd_pending = false;
-
-void SendCommand(UsbCommand *c) {
-	#if 0
-		printf("Sending %d bytes\n", sizeof(UsbCommand));
-	#endif
-
-	if (offline) {
-      PrintAndLog("Sending bytes to proxmark failed - offline");
-      return;
-    }
-  /**
-	The while-loop below causes hangups at times, when the pm3 unit is unresponsive
-	or disconnected. The main console thread is alive, but comm thread just spins here.
-	Not good.../holiman
-	**/
-	while(txcmd_pending);
-	txcmd = *c;
-	txcmd_pending = true;
-}
-
-struct receiver_arg {
-	int run;
-};
-
-byte_t rx[sizeof(UsbCommand)];
-byte_t* prx = rx;
-
-static void *uart_receiver(void *targ) {
-	struct receiver_arg *arg = (struct receiver_arg*)targ;
-	size_t rxlen;
-
-	while (arg->run) {
-		rxlen = 0;
-		if (uart_receive(sp, prx, sizeof(UsbCommand) - (prx-rx), &rxlen)) {
-			prx += rxlen;
-			if (prx-rx < sizeof(UsbCommand)) {
-				continue;
-			}
-			
-			UsbCommandReceived((UsbCommand*)rx);
-		}
-		prx = rx;
-
-		if(txcmd_pending) {
-			if (!uart_send(sp, (byte_t*) &txcmd, sizeof(UsbCommand))) {
-				PrintAndLog("Sending bytes to proxmark failed");
-			}
-			txcmd_pending = false;
-		}
-	}
-
-	pthread_exit(NULL);
-	return NULL;
-}
-
-
-void main_loop(char *script_cmds_file, bool usb_present) {
-	struct receiver_arg rarg;
+void main_loop(char *script_cmds_file, bool usb_present, serial_port* sp) {
+	receiver_arg conn;
 	char *cmd = NULL;
 	pthread_t reader_thread;
+	memset(&conn, 0, sizeof(receiver_arg));
+	pthread_mutex_init(&conn.recv_lock, NULL);
+
+	// TODO: Move this into comms.c
+	PlotGridXdefault = 64;
+	PlotGridYdefault = 64;
+	showDemod = true;
+	CursorScaleFactor = 1;
 
 	if (usb_present) {
-		rarg.run = 1;
-		pthread_create(&reader_thread, NULL, &uart_receiver, &rarg);
+		conn.run = true;
+		SetSerialPort(sp);
+		SetOffline(false);
+		pthread_create(&reader_thread, NULL, &uart_receiver, &conn);
 		// cache Version information now:
 		CmdVersion(NULL);
+	} else {
+		SetOffline(true);
 	}
 
 	FILE *script_file = NULL;
@@ -113,7 +63,7 @@ void main_loop(char *script_cmds_file, bool usb_present) {
 
 	read_history(".history");
 
-	while(1)  {
+	while (1) {
 
 		// If there is a script file
 		if (script_file)
@@ -163,7 +113,7 @@ void main_loop(char *script_cmds_file, bool usb_present) {
 	write_history(".history");
   
 	if (usb_present) {
-		rarg.run = 0;
+		conn.run = false;
 		pthread_join(reader_thread, NULL);
 	}
 	
@@ -172,6 +122,7 @@ void main_loop(char *script_cmds_file, bool usb_present) {
 		script_file = NULL;
 	}
 
+	pthread_mutex_destroy(&conn.recv_lock);
 }
 
 static void dumpAllHelp(int markdown)
@@ -240,19 +191,18 @@ int main(int argc, char* argv[]) {
 	
 	bool usb_present = false;
 	char *script_cmds_file = NULL;
+
+	g_debugMode = 0;
   
-	sp = uart_open(argv[1]);
+	serial_port *sp = uart_open(argv[1]);
 	if (sp == INVALID_SERIAL_PORT) {
 		printf("ERROR: invalid serial port\n");
 		usb_present = false;
-		offline = 1;
 	} else if (sp == CLAIMED_SERIAL_PORT) {
 		printf("ERROR: serial port is claimed by another process\n");
 		usb_present = false;
-		offline = 1;
 	} else {
 		usb_present = true;
-		offline = 0;
 	}
 
 	// If the user passed the filename of the 'script' to execute, get it
@@ -275,23 +225,23 @@ int main(int argc, char* argv[]) {
 
 #ifdef HAVE_GUI
 #ifdef _WIN32
-	InitGraphics(argc, argv, script_cmds_file, usb_present);
+	InitGraphics(argc, argv, script_cmds_file, usb_present, sp);
 	MainGraphics();
 #else
 	char* display = getenv("DISPLAY");
 
 	if (display && strlen(display) > 1)
 	{
-		InitGraphics(argc, argv, script_cmds_file, usb_present);
+		InitGraphics(argc, argv, script_cmds_file, usb_present, sp);
 		MainGraphics();
 	}
 	else
 	{
-		main_loop(script_cmds_file, usb_present);
+		main_loop(script_cmds_file, usb_present, sp);
 	}
 #endif
 #else
-	main_loop(script_cmds_file, usb_present);
+	main_loop(script_cmds_file, usb_present, sp);
 #endif	
 
 	// Clean up the port

--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -56,6 +56,11 @@ void main_loop(char *script_cmds_file, bool usb_present, serial_port* port, bool
 		conn.offline = true;
 	}
 
+#ifdef HAVE_GUI
+	// Setup GUI with reference to our connection struct.
+	MainGraphics(&conn);
+#endif
+
 	FILE *script_file = NULL;
 	char script_cmd_buf[256];  // iceman, needs lua script the same file_path_buffer as the rest
 
@@ -234,14 +239,12 @@ int main(int argc, char* argv[]) {
 #ifdef HAVE_GUI
 #ifdef _WIN32
 	InitGraphics(argc, argv, script_cmds_file, usb_present, sp, flush_after_write);
-	MainGraphics();
 #else
 	char* display = getenv("DISPLAY");
 
 	if (display && strlen(display) > 1)
 	{
 		InitGraphics(argc, argv, script_cmds_file, usb_present, sp, flush_after_write);
-		MainGraphics();
 	}
 	else
 	{
@@ -249,7 +252,7 @@ int main(int argc, char* argv[]) {
 	}
 #endif
 #else
-	main_loop(script_cmds_file, usb_present, sp);
+	main_loop(script_cmds_file, usb_present, sp, flush_after_write);
 #endif	
 
 	// Clean up the port

--- a/client/proxmark3.h
+++ b/client/proxmark3.h
@@ -12,6 +12,7 @@
 #ifndef PROXMARK3_H__
 #define PROXMARK3_H__
 
+#include "uart.h"
 #include "usb_cmd.h"
 #include "uart.h"
 
@@ -21,10 +22,9 @@
 extern "C" {
 #endif
 
-void SendCommand(UsbCommand *c);
 const char *get_my_executable_path(void);
 const char *get_my_executable_directory(void);
-void main_loop(char *script_cmds_file, bool usb_present, serial_port* sp);
+void main_loop(char *script_cmds_file, bool usb_present, serial_port* port, bool flush_after_write);
 
 #ifdef __cplusplus
 }

--- a/client/proxmark3.h
+++ b/client/proxmark3.h
@@ -22,6 +22,7 @@
 extern "C" {
 #endif
 
+bool has_gui();
 const char *get_my_executable_path(void);
 const char *get_my_executable_directory(void);
 void main_loop(char *script_cmds_file, bool usb_present, serial_port* port, bool flush_after_write);

--- a/client/proxmark3.h
+++ b/client/proxmark3.h
@@ -13,6 +13,7 @@
 #define PROXMARK3_H__
 
 #include "usb_cmd.h"
+#include "uart.h"
 
 #define PROXPROMPT "proxmark3> "
 
@@ -23,7 +24,7 @@ extern "C" {
 void SendCommand(UsbCommand *c);
 const char *get_my_executable_path(void);
 const char *get_my_executable_directory(void);
-void main_loop(char *script_cmds_file, bool usb_present);
+void main_loop(char *script_cmds_file, bool usb_present, serial_port* sp);
 
 #ifdef __cplusplus
 }

--- a/client/scripting.h
+++ b/client/scripting.h
@@ -11,6 +11,7 @@
 #define SCRIPTING_H__
 
 #include <lua.h>
+#include "comms.h"
 
 #define LUA_LIBRARIES_DIRECTORY 	"lualibs/"
 #define LUA_SCRIPTS_DIRECTORY 		"scripts/"
@@ -22,6 +23,6 @@
  * @param L
  */
 
-int set_pm3_libraries(lua_State *L);
+int set_pm3_libraries(lua_State *L, pm3_connection* conn);
 
 #endif

--- a/client/ui.c
+++ b/client/ui.c
@@ -21,7 +21,7 @@
 double CursorScaleFactor = 1;
 int PlotGridX=0, PlotGridY=0, PlotGridXdefault= 64, PlotGridYdefault= 64, CursorCPos= 0, CursorDPos= 0;
 int offline;
-int flushAfterWrite = 0;  //buzzy
+bool flushAfterWrite = false;  //buzzy
 int GridOffset = 0;
 bool GridLocked = false;
 bool showDemod = true;
@@ -62,7 +62,6 @@ void PrintAndLog(char *fmt, ...)
 	}
 #else
 	// We are using libedit (OSX), which doesn't support this flag.
-	int need_hack = 0;
 #endif
 	
 	va_start(argptr, fmt);
@@ -72,6 +71,9 @@ void PrintAndLog(char *fmt, ...)
 	va_end(argptr);
 	printf("\n");
 
+	// This needs to be wrapped in ifdefs, as this if optimisation is disabled,
+	// this block won't be removed, and it'll fail at the linker.
+#ifdef RL_STATE_READCMD
 	if (need_hack) {
 		rl_restore_prompt();
 		rl_replace_line(saved_line, 0);
@@ -79,6 +81,7 @@ void PrintAndLog(char *fmt, ...)
 		rl_redisplay();
 		free(saved_line);
 	}
+#endif
 	
 	if (logging && logfile) {
 		vfprintf(logfile, fmt, argptr2);
@@ -100,3 +103,8 @@ void SetLogFilename(char *fn)
 {
   logfilename = fn;
 }
+
+void SetFlushAfterWrite(bool flush_after_write) {
+	flushAfterWrite = flush_after_write;
+}
+

--- a/client/ui.c
+++ b/client/ui.c
@@ -18,23 +18,17 @@
 
 #include "ui.h"
 
-double CursorScaleFactor = 1;
-int PlotGridX=0, PlotGridY=0, PlotGridXdefault= 64, PlotGridYdefault= 64, CursorCPos= 0, CursorDPos= 0;
-int offline;
-bool flushAfterWrite = false;  //buzzy
-int GridOffset = 0;
-bool GridLocked = false;
-bool showDemod = true;
-
 extern pthread_mutex_t print_lock;
 
 static char *logfilename = "proxmark3.log";
+static bool flushAfterWrite = false;
 
 void PrintAndLog(char *fmt, ...)
 {
 	char *saved_line;
 	int saved_point;
 	va_list argptr, argptr2;
+	// TODO: stash these elsewhere
 	static FILE *logfile = NULL;
 	static int logging=1;
 
@@ -90,14 +84,9 @@ void PrintAndLog(char *fmt, ...)
 	}
 	va_end(argptr2);
 
-	if (flushAfterWrite == 1)  //buzzy
-	{
-		fflush(NULL);
-	}
 	//release lock
 	pthread_mutex_unlock(&print_lock);  
 }
-
 
 void SetLogFilename(char *fn)
 {

--- a/client/ui.h
+++ b/client/ui.h
@@ -13,6 +13,11 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <pthread.h>
+
+// a global mutex to prevent interlaced printing from different threads
+pthread_mutex_t print_lock;
+extern uint8_t g_debugMode;
 
 void ShowGui(void);
 void HideGraphWindow(void);
@@ -23,8 +28,7 @@ void SetLogFilename(char *fn);
 
 extern double CursorScaleFactor;
 extern int PlotGridX, PlotGridY, PlotGridXdefault, PlotGridYdefault, CursorCPos, CursorDPos, GridOffset;
-extern int offline;
-extern int flushAfterWrite;   //buzzy
+extern bool flushAfterWrite;   //buzzy
 extern bool GridLocked;
 extern bool showDemod;
 

--- a/client/ui.h
+++ b/client/ui.h
@@ -14,22 +14,18 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <pthread.h>
+#include "comms.h"
 
 // a global mutex to prevent interlaced printing from different threads
 pthread_mutex_t print_lock;
 extern uint8_t g_debugMode;
 
 void ShowGui(void);
-void HideGraphWindow(void);
-void ShowGraphWindow(void);
-void RepaintGraphWindow(void);
+void HideGraphWindow(pm3_connection* conn);
+void ShowGraphWindow(pm3_connection* conn);
+void RepaintGraphWindow(pm3_connection* conn);
 void PrintAndLog(char *fmt, ...);
 void SetLogFilename(char *fn);
-
-extern double CursorScaleFactor;
-extern int PlotGridX, PlotGridY, PlotGridXdefault, PlotGridYdefault, CursorCPos, CursorDPos, GridOffset;
-extern bool flushAfterWrite;   //buzzy
-extern bool GridLocked;
-extern bool showDemod;
+void SetFlushAfterWrite(bool flush_after_write);
 
 #endif

--- a/client/ui.h
+++ b/client/ui.h
@@ -21,9 +21,9 @@ pthread_mutex_t print_lock;
 extern uint8_t g_debugMode;
 
 void ShowGui(void);
-void HideGraphWindow(pm3_connection* conn);
-void ShowGraphWindow(pm3_connection* conn);
-void RepaintGraphWindow(pm3_connection* conn);
+void HideGraphWindow();
+void ShowGraphWindow();
+void RepaintGraphWindow();
 void PrintAndLog(char *fmt, ...);
 void SetLogFilename(char *fn);
 void SetFlushAfterWrite(bool flush_after_write);

--- a/common/iso15693tools.c
+++ b/common/iso15693tools.c
@@ -50,8 +50,9 @@ int Iso15693AddCrc(uint8_t *req, int n) {
 	return n+2;
 }
 
-
+#ifdef ON_DEVICE
 int sprintf(char *str, const char *format, ...);
+#endif
 
 // returns a string representation of the UID
 // UID is transmitted and stored LSB first, displayed MSB first

--- a/common/iso15693tools.c
+++ b/common/iso15693tools.c
@@ -10,7 +10,11 @@
 #include "proxmark3.h"
 #include <stdint.h>
 #include <stdlib.h>
-//#include "iso15693tools.h"
+#include "iso15693tools.h"
+
+#ifdef ON_DEVICE
+#include "../armsrc/printf.h"   // for sprintf
+#endif
 
 #define POLY 0x8408
 

--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -44,16 +44,22 @@
 #define LOWEST_DEFAULT_CLOCK 32
 #define FSK_PSK_THRESHOLD   123
 
-//to allow debug print calls when used not on device
+#ifdef ON_DEVICE
+// We're code running on the device.
+
+// To allow debug print calls when used not on device
 void dummy(char *fmt, ...){}
-#ifndef ON_DEVICE
+
+#define g_debugMode 0
+#define prnt dummy
+	
+#else
+// We're the proxmark client.
 #include "ui.h"
 #include "cmdparser.h"
 #include "cmddata.h"
 #define prnt PrintAndLog
-#else 
-	uint8_t g_debugMode=0;
-#define prnt dummy
+
 #endif
 
 uint8_t justNoise(uint8_t *BitStream, size_t size) {

--- a/include/usb_cmd.h
+++ b/include/usb_cmd.h
@@ -212,6 +212,8 @@ typedef struct{
 #define CMD_HF_SNIFFER                                                    0x0800
 
 #define CMD_UNKNOWN                                                       0xFFFF
+
+// Special mode for WaitForResponse: listens for any command in response.
 #define CMD_ANY                                               0xFFFFFFFFFFFFFFFF
 
 //Mifare simulation flags

--- a/include/usb_cmd.h
+++ b/include/usb_cmd.h
@@ -212,7 +212,7 @@ typedef struct{
 #define CMD_HF_SNIFFER                                                    0x0800
 
 #define CMD_UNKNOWN                                                       0xFFFF
-
+#define CMD_ANY                                               0xFFFFFFFFFFFFFFFF
 
 //Mifare simulation flags
 #define FLAG_INTERACTIVE      0x01

--- a/liblua/lstate.h
+++ b/liblua/lstate.h
@@ -145,6 +145,9 @@ typedef struct global_State {
   TString *memerrmsg;  /* memory-error message */
   TString *tmname[TM_N];  /* array with tag-method names */
   struct Table *mt[LUA_NUMTAGS];  /* metatables for basic types */
+  
+  // Pointer to additional context storage.
+  void* user_context;
 } global_State;
 
 

--- a/uart/uart.h
+++ b/uart/uart.h
@@ -39,7 +39,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-typedef unsigned char byte_t;
+#include "common.h"
 
 /* serial_port is declared as a void*, which you should cast to whatever type
  * makes sense to your connection method. Both the posix and win32
@@ -61,11 +61,11 @@ typedef void* serial_port;
  *
  * On errors, this method returns INVALID_SERIAL_PORT or CLAIMED_SERIAL_PORT.
  */
-serial_port uart_open(const char* pcPortName);
+serial_port* uart_open(const char* pcPortName);
 
 /* Closes the given port.
  */
-void uart_close(const serial_port sp);
+void uart_close(serial_port* sp);
 
 /* Reads from the given serial port for up to 30ms.
  *   pbtRx: A pointer to a buffer for the returned data to be written to.
@@ -78,21 +78,21 @@ void uart_close(const serial_port sp);
  * partial read may have completed into the buffer by the corresponding
  * implementation, so pszRxLen should be checked to see if any data was written. 
  */
-bool uart_receive(const serial_port sp, byte_t* pbtRx, size_t pszMaxRxLen, size_t* pszRxLen);
+bool uart_receive(serial_port* sp, byte_t* pbtRx, size_t pszMaxRxLen, size_t* pszRxLen);
 
 /* Sends a buffer to a given serial port.
  *   pbtTx: A pointer to a buffer containing the data to send.
  *   szTxLen: The amount of data to be sent.
  */
-bool uart_send(const serial_port sp, const byte_t* pbtTx, const size_t szTxLen);
+bool uart_send(serial_port* sp, const byte_t* pbtTx, const size_t szTxLen);
 
 /* Sets the current speed of the serial port, in baud.
  */
-bool uart_set_speed(serial_port sp, const uint32_t uiPortSpeed);
+bool uart_set_speed(serial_port* sp, const uint32_t uiPortSpeed);
 
 /* Gets the current speed of the serial port, in baud.
  */
-uint32_t uart_get_speed(const serial_port sp);
+uint32_t uart_get_speed(serial_port* sp);
 
 #endif // _PM3_UART_H_
 

--- a/uart/uart_win32.c
+++ b/uart/uart_win32.c
@@ -57,7 +57,7 @@ void upcase(char *p) {
   }
 }
 
-serial_port uart_open(const char* pcPortName) {
+serial_port* uart_open(const char* pcPortName) {
   char acPortName[255];
   serial_port_windows* sp = malloc(sizeof(serial_port_windows));
   
@@ -102,30 +102,30 @@ serial_port uart_open(const char* pcPortName) {
   return sp;
 }
 
-void uart_close(const serial_port sp) {
+void uart_close(serial_port* sp) {
   CloseHandle(((serial_port_windows*)sp)->hPort);
   free(sp);
 }
 
-bool uart_receive(const serial_port sp, byte_t* pbtRx, size_t pszMaxRxLen, size_t* pszRxLen) {
+bool uart_receive(serial_port* sp, byte_t* pbtRx, size_t pszMaxRxLen, size_t* pszRxLen) {
   ReadFile(((serial_port_windows*)sp)->hPort,pbtRx,pszMaxRxLen,(LPDWORD)pszRxLen,NULL);
   return (*pszRxLen != 0);
 }
 
-bool uart_send(const serial_port sp, const byte_t* pbtTx, const size_t szTxLen) {
+bool uart_send(serial_port* sp, const byte_t* pbtTx, const size_t szTxLen) {
   DWORD dwTxLen = 0;
   return WriteFile(((serial_port_windows*)sp)->hPort,pbtTx,szTxLen,&dwTxLen,NULL);
   return (dwTxLen != 0);
 }
 
-bool uart_set_speed(serial_port sp, const uint32_t uiPortSpeed) {
+bool uart_set_speed(serial_port* sp, const uint32_t uiPortSpeed) {
   serial_port_windows* spw;
   spw = (serial_port_windows*)sp;
   spw->dcb.BaudRate = uiPortSpeed;
   return SetCommState(spw->hPort, &spw->dcb);
 }
 
-uint32_t uart_get_speed(const serial_port sp) {
+uint32_t uart_get_speed(serial_port* sp) {
   const serial_port_windows* spw = (serial_port_windows*)sp;
   if (!GetCommState(spw->hPort, (serial_port)&spw->dcb)) {
     return spw->dcb.BaudRate;


### PR DESCRIPTION
This is related to cleanup work in #334.  This includes PR #341, so should wait until that is merged.  It is quite large, and not finished or tested as much as I'd like yet, but will give you an early preview.

It:

- Refactors a bunch of global state so that it is stored in a new `pm3_connection` structure.
- Refactors PM3 communications into a new `comms.c` module.
- The flasher now uses the same code paths for communicating with the PM3 as the main client.

Caveats:

- The client does not make use of the ability to start up multiple connections.
- These changes do not permit the Lua bindings to use multiple connections. This stuffs a reference to the `pm3_connection` structure inside Lua's global state, and then all the methods just read off that.
- There's a bunch of buffers that I've stashed in the `pm3_connection` struct for lack of a better place.
- `save_restore{DB,GB}` have a "global" stash which all connections can access.

TODO:

- Get the GUI working.
- `CMD_DOWNLOADED_RAW_ADC_SAMPLES_125K` and the mechanisms around it need improvement -- it is possible to use it overwrite arbitrary memory within the memory space of the client. I'm still working out a good way to handle this without breaking too much stuff, because as far as I can tell, it's intended as a one way DMA.
- Cleanup the startup process, so that it can be shared between the flasher and client, and other things could embed it without writing a bunch of boilerplate.
- Make the debug level selection global again.
- Fix the flasher.
- Write some tests.
- Do some more testing.
- Rebase and squash commits down.