### PR TITLE
- Check button press when you have NOFIELD

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2359,6 +2359,7 @@ typedef struct {
   uint32_t nonce;
   uint32_t ar;
   uint32_t nr;
+  uint32_t at;
   uint32_t nonce2;
   uint32_t ar2;
   uint32_t nr2;
@@ -2562,7 +2563,10 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 				LED_A_ON();
 			}
 		}
-		if (cardSTATE == MFEMUL_NOFIELD) continue;
+		if (cardSTATE == MFEMUL_NOFIELD) {
+			button_pushed = BUTTON_PRESS();
+			continue;
+		}
 
 		//Now, get data
 		res = EmGetCmd(receivedCmd, &len, receivedCmd_par);


### PR DESCRIPTION
Fixes 2 bug in mifare simulate
- Check button press when there is NOFIELD, so we can exit also without FIELD
- struct nonces_t has the same define client and arm, so mfkey is working
