### PR TITLE
Fixes 2 bugs in mifare simulate

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -2352,18 +2352,6 @@ void ReaderMifare(bool first_try)
 	set_tracing(false);
 }
 
-typedef struct {
-  uint32_t cuid;
-  uint8_t  sector;
-  uint8_t  keytype;
-  uint32_t nonce;
-  uint32_t ar;
-  uint32_t nr;
-  uint32_t nonce2;
-  uint32_t ar2;
-  uint32_t nr2;
-} nonces_t;
-
 /**
   *MIFARE 1K simulate.
   *
@@ -2562,7 +2550,10 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 				LED_A_ON();
 			}
 		}
-		if (cardSTATE == MFEMUL_NOFIELD) continue;
+		if (cardSTATE == MFEMUL_NOFIELD) {
+			button_pushed = BUTTON_PRESS();
+			continue;
+		}
 
 		//Now, get data
 		res = EmGetCmd(receivedCmd, &len, receivedCmd_par);

--- a/client/mfkey.c
+++ b/client/mfkey.c
@@ -10,6 +10,7 @@
 // MIFARE Darkside hack
 //-----------------------------------------------------------------------------
 
+#include "mifare.h"
 #include "mfkey.h"
 
 #include "crapto1/crapto1.h"

--- a/client/mfkey.h
+++ b/client/mfkey.h
@@ -16,19 +16,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-typedef struct {
-			  uint32_t cuid;
-			  uint8_t  sector;
-			  uint8_t  keytype;
-			  uint32_t nonce;
-			  uint32_t ar;
-			  uint32_t nr;
-			  uint32_t at;
-			  uint32_t nonce2;
-			  uint32_t ar2;
-			  uint32_t nr2;
-			} nonces_t;
-
 extern bool mfkey32(nonces_t data, uint64_t *outputkey);
 extern bool mfkey32_moebius(nonces_t data, uint64_t *outputkey);
 extern int mfkey64(nonces_t data, uint64_t *outputkey);

--- a/include/mifare.h
+++ b/include/mifare.h
@@ -37,4 +37,17 @@ typedef enum ISO14A_COMMAND {
 	ISO14A_TOPAZMODE =			(1 << 8)
 } iso14a_command_t;
 
+typedef struct {
+	uint32_t cuid;
+	uint8_t  sector;
+	uint8_t  keytype;
+	uint32_t nonce;
+	uint32_t ar;
+	uint32_t nr;
+	uint32_t at;
+	uint32_t nonce2;
+	uint32_t ar2;
+	uint32_t nr2;
+} nonces_t;
+
 #endif // _MIFARE_H_


### PR DESCRIPTION
After pwpiwi's suggestion I develope a better patch for resolve the issue #377

Fixes 2 bugs in mifare simulate

- Check button press when there is NOFIELD, so we can exit also without FIELD
- struct nonces_t is moved to include/mifare.h so client and arm has the same definition