### PR TITLE
Moved include mifare.h to mfkey.h instead mfkey.c

### DIFF
--- a/client/mfkey.c
+++ b/client/mfkey.c
@@ -10,7 +10,6 @@
 // MIFARE Darkside hack
 //-----------------------------------------------------------------------------
 
-#include "mifare.h"
 #include "mfkey.h"
 
 #include "crapto1/crapto1.h"

--- a/client/mfkey.h
+++ b/client/mfkey.h
@@ -15,6 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "mifare.h"
 
 extern bool mfkey32(nonces_t data, uint64_t *outputkey);
 extern bool mfkey32_moebius(nonces_t data, uint64_t *outputkey);

--- a/tools/mfkey/Makefile
+++ b/tools/mfkey/Makefile
@@ -1,7 +1,7 @@
 VPATH = ../../common ../../common/crapto1 ../../client
 CC = gcc
 LD = gcc
-CFLAGS = -std=c99 -D_ISOC99_SOURCE -I../../common -I../../client -Wall -O3
+CFLAGS = -std=c99 -D_ISOC99_SOURCE -I../../common -I../../client -I../../include -Wall -O3
 LDFLAGS =
 
 OBJS = crypto1.o crapto1.o parity.o util_posix.o mfkey.o


### PR DESCRIPTION
After my patch for issue #380 I maked an issue on tool mfkey, so I changed the makefile and moved include mifare.h from mfkey.c to mfkey.h. Now mfkey compile and work without problems.
Sorry for that.
