### PR TITLE
Don't try to display the GUI when running in textmode

### DIFF
--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -274,8 +274,17 @@ int main(int argc, char* argv[]) {
 	pthread_mutex_init(&print_lock, NULL);
 
 #ifdef HAVE_GUI
-	InitGraphics(argc, argv, script_cmds_file, usb_present);
-	MainGraphics();
+	char* display = getenv("DISPLAY");
+
+	if (display && strlen(display) > 1)
+	{
+		InitGraphics(argc, argv, script_cmds_file, usb_present);
+		MainGraphics();
+	}
+	else
+	{
+		main_loop(script_cmds_file, usb_present);
+	}
 #else
 	main_loop(script_cmds_file, usb_present);
 #endif	

--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -274,6 +274,10 @@ int main(int argc, char* argv[]) {
 	pthread_mutex_init(&print_lock, NULL);
 
 #ifdef HAVE_GUI
+#ifdef _WIN32
+	InitGraphics(argc, argv, script_cmds_file, usb_present);
+	MainGraphics();
+#else
 	char* display = getenv("DISPLAY");
 
 	if (display && strlen(display) > 1)
@@ -285,6 +289,7 @@ int main(int argc, char* argv[]) {
 	{
 		main_loop(script_cmds_file, usb_present);
 	}
+#endif
 #else
 	main_loop(script_cmds_file, usb_present);
 #endif	


### PR DESCRIPTION
When running without X (i.e. in a console or remotely via SSH) proxmark crashes with

$ ./proxmark3 /dev/ttyACM0
proxmark3> QXcbConnection: Could not connect to display 
Aborted (core dumped)
$ 

This commit causes proxmark to look at the $DISPLAY environmental variable and run in text-only mode if it's empty or unset.