### PR TITLE
small fix #416

### DIFF
--- a/armsrc/iso14443b.h
+++ b/armsrc/iso14443b.h
@@ -7,7 +7,7 @@
 // at your option, any later version. See the LICENSE.txt file for the text of
 // the license.
 //-----------------------------------------------------------------------------
-// Routines to support ISO 14443 type A.
+// Routines to support ISO 14443 type B.
 //-----------------------------------------------------------------------------
 
 #ifndef __ISO14443B_H


### PR DESCRIPTION
small fix #416 
I dont see why we need to move function definitions to iso14443b.h. When it needs-feel free to do that))))