### PR TITLE
Fixing liblua issues

### DIFF
--- a/client/pm3_binlib.c
+++ b/client/pm3_binlib.c
@@ -107,7 +107,8 @@ static int l_unpack(lua_State *L) 		/** unpack(f,s, [init]) */
  size_t len;
  const char *s=luaL_checklstring(L,2,&len); /* switched s and f */
  const char *f=luaL_checkstring(L,1);
- int i_read = luaL_optint(L,3,1)-1;
+ int i_read = luaL_optinteger(L,3,1)-1;
+ // int i_read = luaL_optint(L,3,1)-1;
  unsigned int i;
  if (i_read >= 0) {
    i = i_read;
@@ -347,4 +348,3 @@ int set_bin_library (lua_State *L) {
    lua_pop(L, 1);
   return 1;
 }
-


### PR DESCRIPTION
On MacOS might have issues with compilation. This should fix it in a case where liblua used is not the built in one. Issue #428 .