### PR TITLE
Cleanup USB string descriptor handling, add note about ModemManager on manufacturer string

### DIFF
--- a/common/usb_cdc.c
+++ b/common/usb_cdc.c
@@ -44,6 +44,11 @@
 #define AT91C_EP_OUT_SIZE 0x40
 #define AT91C_EP_IN_SIZE  0x40
 
+// Language must always be 0.
+#define STR_LANGUAGE_CODES 0x00
+#define STR_MANUFACTURER   0x01
+#define STR_PRODUCT        0x02
+
 static const char devDescriptor[] = {
 	/* Device descriptor */
 	0x12,      // bLength
@@ -56,8 +61,8 @@ static const char devDescriptor[] = {
 	0xc4,0x9a, // Vendor ID (0x9ac4 = J. Westhues)
 	0x8f,0x4b, // Product ID (0x4b8f = Proxmark-3 RFID Instrument)
 	0x01,0x00, // Device release number (0001)
-	0x01,      // iManufacturer
-	0x02,      // iProduct
+	STR_MANUFACTURER,  // iManufacturer
+	STR_PRODUCT,       // iProduct
 	0x00,      // iSerialNumber
 	0x01       // bNumConfigs
 };
@@ -157,7 +162,9 @@ static const char StrDescLanguageCodes[] = {
   0x03,			// Type is string
   0x09, 0x04	// supported language Code 0 = 0x0409 (English)
 };
-	
+
+// Note: ModemManager (Linux) ignores Proxmark3 devices by matching the
+// manufacturer string "proxmark.org". Don't change this.
 static const char StrDescManufacturer[] = {
   26,			// Length
   0x03,			// Type is string
@@ -182,20 +189,18 @@ static const char StrDescProduct[] = {
   'M', 0x00,
   '3', 0x00
 };
-	
-static const char* const pStrings[] =
-{
-    StrDescLanguageCodes,
-    StrDescManufacturer,
-	StrDescProduct
-};
 
 const char* getStringDescriptor(uint8_t idx)
 {
-    if(idx >= (sizeof(pStrings) / sizeof(pStrings[0]))) {
-        return(NULL);
-	} else {
-		return(pStrings[idx]);
+	switch (idx) {
+		case STR_LANGUAGE_CODES:
+			return StrDescLanguageCodes;
+		case STR_MANUFACTURER:
+			return StrDescManufacturer;
+		case STR_PRODUCT:
+			return StrDescProduct;
+		default:
+			return NULL;
 	}
 }
 


### PR DESCRIPTION
- Fix reporting of string descriptors.

- Report device subclass as CDC ACM, to allow driverless operation on Win10+.  Reference:

  https://msdn.microsoft.com/en-us/library/windows/hardware/dn707976%28v=vs.85%29.aspx

- Report interface protocol as "None", so we still get picked up as a USB-CDC device while also not being mistaken for a modem (according to the USB spec, but sadly not according to ModemManager).

- Add note [about ModemManager and the manufacturer string](https://lists.freedesktop.org/archives/modemmanager-devel/2016-February/002705.html), so that can be locked in.

There's also some history on #287 on this which is relevant.  I tried using this on Ubuntu, OSX and Windows, though with Windows I only tested that it registered with a COM port.