### PR TITLE
Flush stdout when waiting for /dev/ttyACM0

### DIFF
--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -355,11 +355,13 @@ int main(int argc, char* argv[]) {
 		sp = uart_open(argv[1]);
 	} else {
 		printf("Waiting for Proxmark to appear on %s ", argv[1]);
+		fflush(stdout);
 		int openCount = 0;
 		do {
 			sp = uart_open(argv[1]);
 			msleep(1000);
 			printf(".");
+			fflush(stdout);
 		} while(++openCount < 20 && (sp == INVALID_SERIAL_PORT || sp == CLAIMED_SERIAL_PORT));
 		printf("\n");
 	}


### PR DESCRIPTION
Simple patch to see the waiting message properly when using the new option "-w"