### PR TITLE
#447 part 1

### DIFF
--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -134,35 +134,75 @@ int CmdHF14AList(const char *Cmd)
 }
 
 int CmdHF14AReader(const char *Cmd) {
-	UsbCommand c = {CMD_READER_ISO_14443a, {ISO14A_CONNECT, 0, 0}};
+	uint32_t cm = ISO14A_CONNECT;
+	bool disconnectAfter = false;
+	
+	int cmdp = 0;
+	while(param_getchar(Cmd, cmdp) != 0x00) {
+		switch(param_getchar(Cmd, cmdp)) {
+		case 'h':
+		case 'H':
+			PrintAndLog("Usage: hf 14a reader [d] [3]");
+			PrintAndLog("       d    drop the signal field after command executed");
+			PrintAndLog("       x    just drop the signal field");
+			PrintAndLog("       3    ISO14443-3 select only (skip RATS)");
+			return 0;
+		case '3':
+			cm |= ISO14A_NO_RATS; 
+			break;
+		case 'd':
+		case 'D':
+			disconnectAfter = true;
+			break;
+		case 'x':
+		case 'X':
+			disconnectAfter = true;
+			cm = cm - ISO14A_CONNECT;
+			break;
+		default:
+			PrintAndLog("Unknown command.");
+			return 1;
+		}	
+		
+		cmdp++;
+	}
+
+	if (!disconnectAfter)
+		cm |= ISO14A_NO_DISCONNECT; 
+	
+	UsbCommand c = {CMD_READER_ISO_14443a, {cm, 0, 0}};
 	SendCommand(&c);
 
-	UsbCommand resp;
-	WaitForResponse(CMD_ACK,&resp);
-	
-	iso14a_card_select_t card;
-	memcpy(&card, (iso14a_card_select_t *)resp.d.asBytes, sizeof(iso14a_card_select_t));
+	if (ISO14A_CONNECT & cm) {
+		UsbCommand resp;
+		WaitForResponse(CMD_ACK,&resp);
+		
+		iso14a_card_select_t card;
+		memcpy(&card, (iso14a_card_select_t *)resp.d.asBytes, sizeof(iso14a_card_select_t));
 
-	uint64_t select_status = resp.arg[0];		// 0: couldn't read, 1: OK, with ATS, 2: OK, no ATS, 3: proprietary Anticollision
-	
-	if(select_status == 0) {
-		PrintAndLog("iso14443a card select failed");
-		return 1;
-	}
+		uint64_t select_status = resp.arg[0];		// 0: couldn't read, 1: OK, with ATS, 2: OK, no ATS, 3: proprietary Anticollision
+		
+		if(select_status == 0) {
+			PrintAndLog("iso14443a card select failed");
+			return 1;
+		}
 
-	if(select_status == 3) {
-		PrintAndLog("Card doesn't support standard iso14443-3 anticollision");
+		if(select_status == 3) {
+			PrintAndLog("Card doesn't support standard iso14443-3 anticollision");
+			PrintAndLog("ATQA : %02x %02x", card.atqa[1], card.atqa[0]);
+			return 1;
+		}
+
+		PrintAndLog(" UID : %s", sprint_hex(card.uid, card.uidlen));
 		PrintAndLog("ATQA : %02x %02x", card.atqa[1], card.atqa[0]);
-		return 1;
+		PrintAndLog(" SAK : %02x [%d]", card.sak, resp.arg[0]);
+		if(card.ats_len >= 3) {			// a valid ATS consists of at least the length byte (TL) and 2 CRC bytes
+			PrintAndLog(" ATS : %s", sprint_hex(card.ats, card.ats_len));
+		}
+		PrintAndLog("Card is selected. You can now start sending commands");
+	} else {
+		PrintAndLog("Field dropped.");
 	}
-
-	PrintAndLog(" UID : %s", sprint_hex(card.uid, card.uidlen));
-	PrintAndLog("ATQA : %02x %02x", card.atqa[1], card.atqa[0]);
-	PrintAndLog(" SAK : %02x [%d]", card.sak, resp.arg[0]);
-	if(card.ats_len >= 3) {			// a valid ATS consists of at least the length byte (TL) and 2 CRC bytes
-		PrintAndLog(" ATS : %s", sprint_hex(card.ats, card.ats_len));
-	}
-	PrintAndLog("For more info execute command `hf 14a info`");
 	return 0;
 }
 
@@ -788,7 +828,7 @@ static command_t CommandTable[] =
 {
   {"help",   CmdHelp,              1, "This help"},
   {"list",   CmdHF14AList,         0, "[Deprecated] List ISO 14443a history"},
-  {"reader", CmdHF14AReader,       0, "Act like an ISO14443 Type A reader"},
+  {"reader", CmdHF14AReader,       0, "Start acting like an ISO14443 Type A reader"},
   {"info",   CmdHF14AInfo,         0, "Reads card and shows information about it"},
   {"cuids",  CmdHF14ACUIDs,        0, "<n> Collect n>0 ISO14443 Type A UIDs in one go"},
   {"sim",    CmdHF14ASim,          0, "<UID> -- Simulate ISO 14443a tag"},

--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -133,7 +133,40 @@ int CmdHF14AList(const char *Cmd)
 	return 0;
 }
 
-int CmdHF14AReader(const char *Cmd)
+int CmdHF14AReader(const char *Cmd) {
+	UsbCommand c = {CMD_READER_ISO_14443a, {ISO14A_CONNECT, 0, 0}};
+	SendCommand(&c);
+
+	UsbCommand resp;
+	WaitForResponse(CMD_ACK,&resp);
+	
+	iso14a_card_select_t card;
+	memcpy(&card, (iso14a_card_select_t *)resp.d.asBytes, sizeof(iso14a_card_select_t));
+
+	uint64_t select_status = resp.arg[0];		// 0: couldn't read, 1: OK, with ATS, 2: OK, no ATS, 3: proprietary Anticollision
+	
+	if(select_status == 0) {
+		PrintAndLog("iso14443a card select failed");
+		return 1;
+	}
+
+	if(select_status == 3) {
+		PrintAndLog("Card doesn't support standard iso14443-3 anticollision");
+		PrintAndLog("ATQA : %02x %02x", card.atqa[1], card.atqa[0]);
+		return 1;
+	}
+
+	PrintAndLog(" UID : %s", sprint_hex(card.uid, card.uidlen));
+	PrintAndLog("ATQA : %02x %02x", card.atqa[1], card.atqa[0]);
+	PrintAndLog(" SAK : %02x [%d]", card.sak, resp.arg[0]);
+	if(card.ats_len >= 3) {			// a valid ATS consists of at least the length byte (TL) and 2 CRC bytes
+		PrintAndLog(" ATS : %s", sprint_hex(card.ats, card.ats_len));
+	}
+	PrintAndLog("For more info execute command `hf 14a info`");
+	return 0;
+}
+
+int CmdHF14AInfo(const char *Cmd)
 {
 	UsbCommand c = {CMD_READER_ISO_14443a, {ISO14A_CONNECT | ISO14A_NO_DISCONNECT, 0, 0}};
 	SendCommand(&c);
@@ -756,6 +789,7 @@ static command_t CommandTable[] =
   {"help",   CmdHelp,              1, "This help"},
   {"list",   CmdHF14AList,         0, "[Deprecated] List ISO 14443a history"},
   {"reader", CmdHF14AReader,       0, "Act like an ISO14443 Type A reader"},
+  {"info",   CmdHF14AInfo,         0, "Reads card and shows information about it"},
   {"cuids",  CmdHF14ACUIDs,        0, "<n> Collect n>0 ISO14443 Type A UIDs in one go"},
   {"sim",    CmdHF14ASim,          0, "<UID> -- Simulate ISO 14443a tag"},
   {"snoop",  CmdHF14ASnoop,        0, "Eavesdrop ISO 14443 Type A"},


### PR DESCRIPTION
added command `hf 14a info`, 
copy functionality from `hf 14a reader` to `hf 14a info`, 
added command `hf 14a reader` with simple anticollision-select procedure
part of #447