### PR TITLE
fix lf search bugs when no tag is on antenna  …

### DIFF
--- a/armsrc/lfops.c
+++ b/armsrc/lfops.c
@@ -1159,7 +1159,7 @@ void T55xxResetRead(void) {
 	TurnReadLFOn(READ_GAP);
 
 	// Acquisition
-	DoPartialAcquisition(0, true, BigBuf_max_traceLen());
+	DoPartialAcquisition(0, true, BigBuf_max_traceLen(), 0);
 
 	// Turn the field off
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
@@ -1291,7 +1291,7 @@ void T55xxReadBlock(uint16_t arg0, uint8_t Block, uint32_t Pwd) {
 
 	// Acquisition
 	// Now do the acquisition
-	DoPartialAcquisition(0, true, 12000);
+	DoPartialAcquisition(0, true, 12000, 0);
 
 	// Turn the field off
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
@@ -1690,7 +1690,7 @@ void EM4xReadWord(uint8_t Address, uint32_t Pwd, uint8_t PwdMode) {
 	SendForward(fwd_bit_count);
 	WaitUS(400);
 	// Now do the acquisition
-	DoPartialAcquisition(20, true, 6000);
+	DoPartialAcquisition(20, true, 6000, 1000);
 	
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
 	LED_A_OFF();
@@ -1723,7 +1723,7 @@ void EM4xWriteWord(uint32_t flag, uint32_t Data, uint32_t Pwd) {
 
 	WaitUS(6500);
 	//Capture response if one exists
-	DoPartialAcquisition(20, true, 6000);
+	DoPartialAcquisition(20, true, 6000, 1000);
 
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF); // field off
 	LED_A_OFF();

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -334,7 +334,7 @@ uint32_t doCotagAcquisitionManchester() {
 	uint16_t sample_counter = 0, period = 0;
 	uint8_t curr = 0, prev = 0;
 	uint16_t noise_counter = 0;
-	while (!BUTTON_PRESS() && !usb_poll_validate_length() && (sample_counter < bufsize) && (noiseCounter < (COTAG_T1<<1)) ) {
+	while (!BUTTON_PRESS() && !usb_poll_validate_length() && (sample_counter < bufsize) && (noise_counter < (COTAG_T1<<1)) ) {
 		WDT_HIT();
 		if (AT91C_BASE_SSC->SSC_SR & AT91C_SSC_TXRDY) {
 			AT91C_BASE_SSC->SSC_THR = 0x43;

--- a/armsrc/lfsampling.c
+++ b/armsrc/lfsampling.c
@@ -119,7 +119,7 @@ void LFSetupFPGAForADC(int divisor, bool lf_field)
  * @param silent - is true, now outputs are made. If false, dbprints the status
  * @return the number of bits occupied by the samples.
  */
-uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averaging, int trigger_threshold, bool silent, int bufsize)
+uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averaging, int trigger_threshold, bool silent, int bufsize, int cancel_after)
 {
 	//.
 	uint8_t *dest = BigBuf_get_addr();
@@ -140,6 +140,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
 	uint32_t sample_sum =0 ;
 	uint32_t sample_total_numbers =0 ;
 	uint32_t sample_total_saved =0 ;
+	uint32_t cancel_counter = 0;
 
 	while(!BUTTON_PRESS() && !usb_poll_validate_length() ) {
 		WDT_HIT();
@@ -151,9 +152,11 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
 			sample = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
 			LED_D_OFF();
 			// threshold either high or low values 128 = center 0.  if trigger = 178 
-			if ((trigger_threshold > 0) && (sample < (trigger_threshold+128)) && (sample > (128-trigger_threshold))) // 
+			if ((trigger_threshold > 0) && (sample < (trigger_threshold+128)) && (sample > (128-trigger_threshold))) { // 
+				if (cancel_after > 0) cancel_counter++;
+				if (cancel_after == cancel_counter) break;
 				continue;
-		
+			}
 			trigger_threshold = 0;
 			sample_total_numbers++;
 
@@ -213,7 +216,7 @@ uint32_t DoAcquisition(uint8_t decimation, uint32_t bits_per_sample, bool averag
  */
 uint32_t DoAcquisition_default(int trigger_threshold, bool silent)
 {
-	return DoAcquisition(1,8,0,trigger_threshold,silent,0);
+	return DoAcquisition(1,8,0,trigger_threshold,silent,0,0);
 }
 uint32_t DoAcquisition_config(bool silent, int sample_size)
 {
@@ -222,11 +225,12 @@ uint32_t DoAcquisition_config(bool silent, int sample_size)
 				  ,config.averaging
 				  ,config.trigger_threshold
 				  ,silent
-				  ,sample_size);
+				  ,sample_size
+				  ,0);
 }
 
-uint32_t DoPartialAcquisition(int trigger_threshold, bool silent, int sample_size) {
-	return DoAcquisition(1,8,0,trigger_threshold,silent,sample_size);
+uint32_t DoPartialAcquisition(int trigger_threshold, bool silent, int sample_size, int cancel_after) {
+	return DoAcquisition(1,8,0,trigger_threshold,silent,sample_size,cancel_after);
 }
 
 uint32_t ReadLF(bool activeField, bool silent, int sample_size)
@@ -329,8 +333,8 @@ uint32_t doCotagAcquisitionManchester() {
 	uint8_t sample = 0, firsthigh = 0, firstlow = 0; 
 	uint16_t sample_counter = 0, period = 0;
 	uint8_t curr = 0, prev = 0;
-
-	while (!BUTTON_PRESS() && !usb_poll_validate_length() && (sample_counter < bufsize) ) {
+	uint16_t noise_counter = 0;
+	while (!BUTTON_PRESS() && !usb_poll_validate_length() && (sample_counter < bufsize) && (noiseCounter < (COTAG_T1<<1)) ) {
 		WDT_HIT();
 		if (AT91C_BASE_SSC->SSC_SR & AT91C_SSC_TXRDY) {
 			AT91C_BASE_SSC->SSC_THR = 0x43;
@@ -343,14 +347,20 @@ uint32_t doCotagAcquisitionManchester() {
 
 			// find first peak
 			if ( !firsthigh ) {
-				if (sample < COTAG_ONE_THRESHOLD) 
+				if (sample < COTAG_ONE_THRESHOLD) {
+					noise_counter++;
 					continue;
+				}
+				noise_counter = 0;
 				firsthigh = 1;
 			}
 
 			if ( !firstlow ){
-				if (sample > COTAG_ZERO_THRESHOLD )
+				if (sample > COTAG_ZERO_THRESHOLD ) {
+					noise_counter++;
 					continue;
+				}
+				noise_counter=0;
 				firstlow = 1;
 			}
 

--- a/armsrc/lfsampling.h
+++ b/armsrc/lfsampling.h
@@ -21,7 +21,7 @@ uint32_t SampleLF(bool silent, int sample_size);
 uint32_t SnoopLF();
 
 // adds sample size to default options
-uint32_t DoPartialAcquisition(int trigger_threshold, bool silent, int sample_size);
+uint32_t DoPartialAcquisition(int trigger_threshold, bool silent, int sample_size, int cancel_after);
 
 /**
  * @brief Does sample acquisition, ignoring the config values set in the sample_config.

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -945,7 +945,7 @@ int CmdLFfind(const char *Cmd)
 				PrintAndLog("\nValid EM4x05/EM4x69 Chip Found\nUse lf em 4x05readword/dump commands to read\n");
 				return 1;
 			}
-			ans=CmdLFHitagReader("26");
+			ans=CmdLFHitagReader("26"); // 26 = RHT2F_UID_ONLY
 			if (ans==0) {
 				return 1;
 			}

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -950,7 +950,6 @@ int EM4x05ReadWord_ext(uint8_t addr, uint32_t pwd, bool usePwd, uint32_t *wordDa
 	}
 	int testLen = (GraphTraceLen < 1000) ? GraphTraceLen : 1000;
 	if (graphJustNoise(GraphBuffer, testLen)) {
-		PrintAndLog("no tag not found");
 		return -1;
 	}
 	//attempt demod:

--- a/client/cmdlfhitag.c
+++ b/client/cmdlfhitag.c
@@ -239,6 +239,7 @@ int CmdLFHitagReader(const char *Cmd) {
 	c.arg[0] = htf;
 
 	// Send the command to the proxmark
+	clearCommandBuffer();
 	SendCommand(&c);
 
 	UsbCommand resp;


### PR DESCRIPTION
cotag read could enter endless loop, now cancels if the next bit doesn't
appear

em4x05 detection would loop due to a threshold never being met, now has
a dump out after 1000 samples tested.

fixed some indenting in hitag2 while i was reviewing that code for
potential endless loops...