### PR TITLE
fix timeout set in #481 and fix printf in util.c warning

### DIFF
--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -660,8 +660,8 @@ int ExchangeAPDU14a(uint8_t *datain, int datainlen, bool activateField, bool lea
 	// "Command APDU" length should be 5+255+1, but javacard's APDU buffer might be smaller - 133 bytes
 	// https://stackoverflow.com/questions/32994936/safe-max-java-card-apdu-data-command-and-respond-size
 	// here length USB_CMD_DATA_SIZE=512
-	// timeout timeout14a * 1.06 / 100, true, size, &keyBlock[6 * c], e_sector); // timeout is (ms * 106)/10 or us*0.0106
-	UsbCommand c = {CMD_READER_ISO_14443a, {ISO14A_APDU | ISO14A_SET_TIMEOUT | cmdc, (datainlen & 0xFFFF), 1000 * 1000 * 1.06 / 100}}; 
+	// timeout must be authomatically set by "get ATS"
+	UsbCommand c = {CMD_READER_ISO_14443a, {ISO14A_APDU | cmdc, (datainlen & 0xFFFF), 0}}; 
 	memcpy(c.d.asBytes, datain, datainlen);
 	SendCommand(&c);
 	

--- a/client/util.c
+++ b/client/util.c
@@ -541,7 +541,7 @@ int param_getstr(const char *line, int paramnum, char * str, size_t buffersize)
 
 	// Prevent out of bounds errors
 	if (en - bg + 1 >= buffersize) {
-		printf("out of bounds error: want %d bytes have %d bytes\n", en - bg + 1 + 1, buffersize);
+		printf("out of bounds error: want %d bytes have %zd bytes\n", en - bg + 1 + 1, buffersize);
 		return 0;
 	}
 	

--- a/client/util.c
+++ b/client/util.c
@@ -541,7 +541,7 @@ int param_getstr(const char *line, int paramnum, char * str, size_t buffersize)
 
 	// Prevent out of bounds errors
 	if (en - bg + 1 >= buffersize) {
-		printf("out of bounds error: want %lu bytes have %lu bytes\n", en - bg + 1 + 1, buffersize);
+		printf("out of bounds error: want %d bytes have %d bytes\n", en - bg + 1 + 1, buffersize);
 		return 0;
 	}
 	


### PR DESCRIPTION
fix timeout set in #481 and fix printf in util.c warning here
```
	// Prevent out of bounds errors
	if (en - bg + 1 >= buffersize) {
		printf("out of bounds error: want %d bytes have %d bytes\n", en - bg + 1 + 1, buffersize);
                                                                     ^^^^            ^^^^^
		return 0;
	}

```