### PR TITLE
fix: USB Power requirements

### DIFF
--- a/common/usb_cdc.c
+++ b/common/usb_cdc.c
@@ -77,8 +77,8 @@ static const char cfgDescriptor[] = {
 	0x02,   // CbNumInterfaces
 	0x01,   // CbConfigurationValue
 	0x00,   // CiConfiguration
-	0xC0,   // CbmAttributes (Self Powered - for those with a battery)
-	0x4B,   // CMaxPower (150mA max current drawn from bus without battery)
+	0x80,   // CbmAttributes (Bus Powered)
+	0x4B,   // CMaxPower (150mA max current drawn from bus)
 
 	/* Interface 0 Descriptor: Communication Class Interface */
 	0x09, // bLength

--- a/common/usb_cdc.c
+++ b/common/usb_cdc.c
@@ -77,8 +77,8 @@ static const char cfgDescriptor[] = {
 	0x02,   // CbNumInterfaces
 	0x01,   // CbConfigurationValue
 	0x00,   // CiConfiguration
-	0xC0,   // CbmAttributes 0xA0
-	0xFA,   // CMaxPower
+	0xC0,   // CbmAttributes (Self Powered - for those with a battery)
+	0x4B,   // CMaxPower (150mA max current drawn from bus without battery)
 
 	/* Interface 0 Descriptor: Communication Class Interface */
 	0x09, // bLength


### PR DESCRIPTION
* correctly indicate the maximum current drawn from the USB bus (150mA instead of 500mA)
* should fix the error "[14651.188644] usb 3-13.2: device descriptor read/64, error -110" observed in issue #283 