### PR TITLE
Update fpgaloader.c

### DIFF
--- a/armsrc/fpgaloader.c
+++ b/armsrc/fpgaloader.c
@@ -434,6 +434,9 @@ void FpgaDownloadAndGo(int bitstream_version)
 
 	inflateEnd(&compressed_fpga_stream);
 	
+	// turn off antenna
+	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
+	
 	// free eventually allocated BigBuf memory
 	BigBuf_free(); BigBuf_Clear_ext(false);	
 }	


### PR DESCRIPTION
This address part1 in issue https://github.com/Proxmark/proxmark3/issues/499

Device power out 13.56Mhz when started (initialised). This output is not stopped until arbitary command is sent.