### PR TITLE
Allow externalisation of PrintAndLog

### DIFF
--- a/client/ui.c
+++ b/client/ui.c
@@ -9,12 +9,14 @@
 // UI utilities
 //-----------------------------------------------------------------------------
 
-#include <stdarg.h>
+#include <stdbool.h>
+#ifndef EXTERNAL_PRINTANDLOG
 #include <stdlib.h>
 #include <stdio.h>
-#include <stdbool.h>
+#include <stdarg.h>
 #include <readline/readline.h>
 #include <pthread.h>
+#endif
 
 #include "ui.h"
 
@@ -26,9 +28,11 @@ int GridOffset = 0;
 bool GridLocked = false;
 bool showDemod = true;
 
-extern pthread_mutex_t print_lock;
-
 static char *logfilename = "proxmark3.log";
+
+#ifndef EXTERNAL_PRINTANDLOG
+// Declared in proxmark3.c
+extern pthread_mutex_t print_lock;
 
 void PrintAndLog(char *fmt, ...)
 {
@@ -94,7 +98,7 @@ void PrintAndLog(char *fmt, ...)
 	//release lock
 	pthread_mutex_unlock(&print_lock);  
 }
-
+#endif
 
 void SetLogFilename(char *fn)
 {


### PR DESCRIPTION
On Android, we handle stdout and logging a little differently.  stdout is also sent to `/dev/null`.  However, there are a number of global variables declared in `ui.c` which are useful for the rest of the application.

This adds a define `EXTERNAL_PRINTANDLOG` which will disable the stock `PrintAndLog` implementation in proxmark3.  If defined, this would require that an implementer bring their own `PrintAndLog` function that implements the same API.

Example implementation for Android given below, which will push logs into the `INFO` log for the application (accessible via Logcat).  A better implementation of this would pull it into the rest of the application's UI.

```c
#include <android/log.h>
#define APPNAME "natives::PrintAndLog"

void PrintAndLog(char *fmt, ...)
{
    va_list argptr;
    va_start(argptr, fmt);
    __android_log_vprint(ANDROID_LOG_INFO, APPNAME, fmt, argptr);
}
```