### PR TITLE
fix: hf mf hardnested failed with new WUPA timing

### DIFF
--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -189,13 +189,13 @@ void iso14a_set_trigger(bool enable) {
 
 
 void iso14a_set_timeout(uint32_t timeout) {
-	iso14a_timeout = timeout - (DELAY_AIR2ARM_AS_READER + DELAY_ARM2AIR_AS_READER)/(16*8);
+	iso14a_timeout = timeout - (DELAY_AIR2ARM_AS_READER + DELAY_ARM2AIR_AS_READER)/(16*8) + 2;
 	if(MF_DBGLEVEL >= 3) Dbprintf("ISO14443A Timeout set to %ld (%dms)", timeout, timeout / 106);
 }
 
 
 uint32_t iso14a_get_timeout(void) {
-	return iso14a_timeout + (DELAY_AIR2ARM_AS_READER + DELAY_ARM2AIR_AS_READER)/(16*8);
+	return iso14a_timeout + (DELAY_AIR2ARM_AS_READER + DELAY_ARM2AIR_AS_READER)/(16*8) - 2;
 }
 
 //-----------------------------------------------------------------------------
@@ -1955,9 +1955,9 @@ int iso14_apdu(uint8_t *cmd, uint16_t cmd_len, void *data) {
 	} else{
 		// S-Block WTX 
 		while((data_bytes[0] & 0xF2) == 0xF2) {
-			uint32_t save_iso14a_timeout = iso14a_timeout;
+			uint32_t save_iso14a_timeout = iso14a_get_timeout();
 			// temporarily increase timeout
-			iso14a_timeout = MAX((data_bytes[1] & 0x3f) * iso14a_timeout, MAX_ISO14A_TIMEOUT);
+			iso14a_set_timeout(MAX((data_bytes[1] & 0x3f) * save_iso14a_timeout, MAX_ISO14A_TIMEOUT));
 			// Transmit WTX back 
 			// byte1 - WTXM [1..59]. command FWT=FWT*WTXM
 			data_bytes[1] = data_bytes[1] & 0x3f; // 2 high bits mandatory set to 0b
@@ -1969,7 +1969,7 @@ int iso14_apdu(uint8_t *cmd, uint16_t cmd_len, void *data) {
 			len = ReaderReceive(data, parity);
 			data_bytes = data;
 			// restore timeout
-			iso14a_timeout = save_iso14a_timeout;
+			iso14a_set_timeout(save_iso14a_timeout);
 		}
 
 		// if we received an I- or R(ACK)-Block with a block number equal to the

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -189,13 +189,14 @@ void iso14a_set_trigger(bool enable) {
 
 
 void iso14a_set_timeout(uint32_t timeout) {
-	iso14a_timeout = timeout - (DELAY_AIR2ARM_AS_READER + DELAY_ARM2AIR_AS_READER)/(16*8) + 2;
+	// adjust timeout by FPGA delays and 2 additional ssp_frames to detect SOF
+	iso14a_timeout = timeout + (DELAY_AIR2ARM_AS_READER + DELAY_ARM2AIR_AS_READER)/(16*8) + 2;
 	if(MF_DBGLEVEL >= 3) Dbprintf("ISO14443A Timeout set to %ld (%dms)", timeout, timeout / 106);
 }
 
 
 uint32_t iso14a_get_timeout(void) {
-	return iso14a_timeout + (DELAY_AIR2ARM_AS_READER + DELAY_ARM2AIR_AS_READER)/(16*8) - 2;
+	return iso14a_timeout - (DELAY_AIR2ARM_AS_READER + DELAY_ARM2AIR_AS_READER)/(16*8) - 2;
 }
 
 //-----------------------------------------------------------------------------

--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -694,10 +694,9 @@ void MifareAcquireEncryptedNonces(uint32_t arg0, uint32_t arg1, uint32_t flags, 
 			continue;
 		}
 
-		// send a dummy byte as reader response in order to trigger the cards authentication timeout
-		uint8_t dummy_answer = 0;
-		ReaderTransmit(&dummy_answer, 1, NULL);
-		timeout = GetCountSspClk() + AUTHENTICATION_TIMEOUT;
+		// send a dummy response in order to trigger the cards authentication failure timeout
+		uint8_t dummy_answer[8] = {0};
+		ReaderTransmit(dummy_answer, 8, NULL);
 
 		num_nonces++;
 		if (num_nonces % 2) {
@@ -709,9 +708,6 @@ void MifareAcquireEncryptedNonces(uint32_t arg0, uint32_t arg1, uint32_t flags, 
 			memcpy(buf+i+8, &nt_par_enc, 1);
 			i += 9;
 		}
-
-		// wait for the card to become ready again
-		while(GetCountSspClk() < timeout);
 
 	}
 


### PR DESCRIPTION
* allow additional 2 ssp_frame cycles to detect SOF
* use only respective functions to get/set iso14a_timeout
* remove waiting time in MifareAcquireEncryptedNonces(). This is covered by GetATQA() now.