### PR TITLE
First try at disconnect/reconnect detection

### DIFF
--- a/client/cmdhw.c
+++ b/client/cmdhw.c
@@ -405,10 +405,18 @@ int CmdTune(const char *Cmd)
 
 int CmdVersion(const char *Cmd)
 {
+	return CmdVersionC(Cmd, false);
+}
 
-	clearCommandBuffer();
+int CmdVersionC(const char *Cmd, const bool no_cache)
+{
 	UsbCommand c = {CMD_VERSION};
 	static UsbCommand resp = {0, {0, 0, 0}};
+
+	if( no_cache )
+		memset( &resp, 0, sizeof(resp) );
+	else
+		clearCommandBuffer();
 
 	if (resp.arg[0] == 0 && resp.arg[1] == 0) { // no cached information available
 		SendCommand(&c);

--- a/client/cmdhw.h
+++ b/client/cmdhw.h
@@ -23,5 +23,6 @@ int CmdSetDivisor(const char *Cmd);
 int CmdSetMux(const char *Cmd);
 int CmdTune(const char *Cmd);
 int CmdVersion(const char *Cmd);
+int CmdVersionC(const char *Cmd, const bool no_cache);
 
 #endif

--- a/uart/uart_posix.c
+++ b/uart/uart_posix.c
@@ -141,7 +141,7 @@ bool uart_receive(const serial_port sp, byte_t* pbtRx, size_t pszMaxRxLen, size_
   
   // Reset the output count
   *pszRxLen = 0;
-  
+
   do {
     // Reset file descriptor
     FD_ZERO(&rfds);
@@ -153,12 +153,12 @@ bool uart_receive(const serial_port sp, byte_t* pbtRx, size_t pszMaxRxLen, size_
     if (res < 0) {
       return false;
     }
- 
+
     // Read time-out
     if (res == 0) {
       if (*pszRxLen == 0) {
         // Error, we received no data
-        return false;
+        return true;
       } else {
         // We received some data, but nothing more is available
         return true;
@@ -168,7 +168,7 @@ bool uart_receive(const serial_port sp, byte_t* pbtRx, size_t pszMaxRxLen, size_
     // Retrieve the count of the incoming bytes
     res = ioctl(((serial_port_unix*)sp)->fd, FIONREAD, &byteCount);
     if (res < 0) return false;
-    
+
     // Cap the number of bytes, so we don't overrun the buffer
     if (pszMaxRxLen - (*pszRxLen) < byteCount) {
     	byteCount = pszMaxRxLen - (*pszRxLen);
@@ -178,8 +178,8 @@ bool uart_receive(const serial_port sp, byte_t* pbtRx, size_t pszMaxRxLen, size_
     res = read(((serial_port_unix*)sp)->fd, pbtRx+(*pszRxLen), byteCount);
 
     // Stop if the OS has some troubles reading the data
-    if (res <= 0) return false;
- 
+    if (res < 0) return false;
+
     *pszRxLen += res;
 
     if (*pszRxLen == pszMaxRxLen) {


### PR DESCRIPTION
No idea if it's going to work on WIN32...  If ReadFile() returns True on a no-data timeout then it'll work, otherwise we'll need to call GetLastError() and check what error was returned.  Can someone running WIN32 try and let me know?