### PR TITLE
Debug&Improvement of HW TUNE

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -205,7 +205,7 @@ void MeasureAntennaTuningLfOnly(int *vLf125, int *vLf134, int *peakf, int *peakv
 		}
 	}
 
-	for (i=0; i <= 18; i++) LF_Results[i] = 0;
+	for (i=18; i >= 0; i--) LF_Results[i] = 0;
 
 	return;
 }


### PR DESCRIPTION
Command 'hw tune lf'(/ 'hw tune') resulted in the watchdog killing the cpu, because the loop at the end of 'MeasureAntennaTuningLfOnly' never finished.
Also the client should not print the data/warnings of the not selected antenna ('hw tune lf' results in a message stating that the hf antenna is unuseable).