### PR TITLE
Allow non-root access on Android devices

### DIFF
--- a/common/usb_cdc.c
+++ b/common/usb_cdc.c
@@ -183,12 +183,17 @@ static const char StrDescManufacturer[] = {
 };
 
 static const char StrDescProduct[] = {
-  9,			// Length
+  20,			// Length
   0x03,			// Type is string
-  'P', 0x00,
-  'M', 0x00,
-  '3', 0x00,
-   0x00
+  'p', 0x00,
+  'r', 0x00,
+  'o', 0x00,
+  'x', 0x00,
+  'm', 0x00,
+  'a', 0x00,
+  'r', 0x00,
+  'k', 0x00,
+  '3', 0x00
 };
 
 const char* getStringDescriptor(uint8_t idx)

--- a/common/usb_cdc.c
+++ b/common/usb_cdc.c
@@ -183,7 +183,7 @@ static const char StrDescManufacturer[] = {
 };
 
 static const char StrDescProduct[] = {
-  8,			// Length
+  4,			// Length
   0x03,			// Type is string
   'P', 0x00,
   'M', 0x00,
@@ -550,16 +550,15 @@ void AT91F_CDC_Enumerate() {
 			AT91F_USB_SendData(pUdp, devDescriptor, MIN(sizeof(devDescriptor), wLength));
 		else if (wValue == 0x200)  // Return Configuration Descriptor
 			AT91F_USB_SendData(pUdp, cfgDescriptor, MIN(sizeof(cfgDescriptor), wLength));
-		else if ((wValue & 0x300) == 0x300)  // Return Manufacturer Descriptor - this is needed by Android
-			AT91F_USB_SendData(pUdp, StrDescManufacturer, MIN(sizeof(StrDescManufacturer), wLength));
 		else if ((wValue & 0xF00) == 0x300) { // Return String Descriptor
 			const char *strDescriptor = getStringDescriptor(wValue & 0xff);
 			if (strDescriptor != NULL) {
 				AT91F_USB_SendData(pUdp, strDescriptor, MIN(strDescriptor[0], wLength));
 			} else {
-				AT91F_USB_SendStall(pUdp);
+				AT91F_USB_SendData(pUdp, StrDescManufacturer, MIN(sizeof(StrDescManufacturer), wLength));
 			}
 		}
+		
 		else
 			AT91F_USB_SendStall(pUdp);
 		break;

--- a/common/usb_cdc.c
+++ b/common/usb_cdc.c
@@ -555,10 +555,9 @@ void AT91F_CDC_Enumerate() {
 			if (strDescriptor != NULL) {
 				AT91F_USB_SendData(pUdp, strDescriptor, MIN(strDescriptor[0], wLength));
 			} else {
-				AT91F_USB_SendData(pUdp, StrDescManufacturer, MIN(sizeof(StrDescManufacturer), wLength));
+				AT91F_USB_SendStall(pUdp);
 			}
 		}
-		
 		else
 			AT91F_USB_SendStall(pUdp);
 		break;

--- a/common/usb_cdc.c
+++ b/common/usb_cdc.c
@@ -156,6 +156,28 @@ static const char cfgDescriptor[] = {
 	0x00,
 	0x00    // bInterval
 };
+const char BOSDescriptor[] = {
+	// BOS descriptor header
+	0x05, 0x0F, 0x39, 0x00, 0x02,
+
+	// Microsoft OS 2.0 Platform Capability Descriptor
+	0x1C,  // Descriptor size (28 bytes)
+	0x10,  // Descriptor type (Device Capability)
+	0x05,  // Capability type (Platform)
+	0x00,  // Reserved
+
+	// MS OS 2.0 Platform Capability ID (D8DD60DF-4589-4CC7-9CD2-659D9E648A9F)
+	0xDF, 0x60, 0xDD, 0xD8,
+	0x89, 0x45,
+	0xC7, 0x4C,
+	0x9C, 0xD2,
+	0x65, 0x9D, 0x9E, 0x64, 0x8A, 0x9F,
+
+	0x00, 0x00, 0x03, 0x06,    // Windows version (8.1) (0x06030000)
+	0x1e, 0x00,
+	252,	// Vendor-assigned bMS_VendorCode
+	0x00	// Doesn’t support alternate enumeration
+};
 
 static const char StrDescLanguageCodes[] = {
   4,			// Length
@@ -550,6 +572,10 @@ void AT91F_CDC_Enumerate() {
 			AT91F_USB_SendData(pUdp, devDescriptor, MIN(sizeof(devDescriptor), wLength));
 		else if (wValue == 0x200)  // Return Configuration Descriptor
 			AT91F_USB_SendData(pUdp, cfgDescriptor, MIN(sizeof(cfgDescriptor), wLength));
+		else if ((wValue & 0xF00) == 0xF00)  // Return BOS Descriptor
+			AT91F_USB_SendData(pUdp, BOSDescriptor, MIN(sizeof(BOSDescriptor), wLength));
+		else if ((wValue & 0x300) == 0x300)  // Return Manufacturer Descriptor - this is needed by Android
+			AT91F_USB_SendData(pUdp, StrDescManufacturer, MIN(sizeof(StrDescManufacturer), wLength));
 		else if ((wValue & 0xF00) == 0x300) { // Return String Descriptor
 			const char *strDescriptor = getStringDescriptor(wValue & 0xff);
 			if (strDescriptor != NULL) {

--- a/common/usb_cdc.c
+++ b/common/usb_cdc.c
@@ -156,28 +156,6 @@ static const char cfgDescriptor[] = {
 	0x00,
 	0x00    // bInterval
 };
-const char BOSDescriptor[] = {
-	// BOS descriptor header
-	0x05, 0x0F, 0x39, 0x00, 0x02,
-
-	// Microsoft OS 2.0 Platform Capability Descriptor
-	0x1C,  // Descriptor size (28 bytes)
-	0x10,  // Descriptor type (Device Capability)
-	0x05,  // Capability type (Platform)
-	0x00,  // Reserved
-
-	// MS OS 2.0 Platform Capability ID (D8DD60DF-4589-4CC7-9CD2-659D9E648A9F)
-	0xDF, 0x60, 0xDD, 0xD8,
-	0x89, 0x45,
-	0xC7, 0x4C,
-	0x9C, 0xD2,
-	0x65, 0x9D, 0x9E, 0x64, 0x8A, 0x9F,
-
-	0x00, 0x00, 0x03, 0x06,    // Windows version (8.1) (0x06030000)
-	0x1e, 0x00,
-	252,	// Vendor-assigned bMS_VendorCode
-	0x00	// Doesn’t support alternate enumeration
-};
 
 static const char StrDescLanguageCodes[] = {
   4,			// Length
@@ -572,8 +550,6 @@ void AT91F_CDC_Enumerate() {
 			AT91F_USB_SendData(pUdp, devDescriptor, MIN(sizeof(devDescriptor), wLength));
 		else if (wValue == 0x200)  // Return Configuration Descriptor
 			AT91F_USB_SendData(pUdp, cfgDescriptor, MIN(sizeof(cfgDescriptor), wLength));
-		else if ((wValue & 0xF00) == 0xF00)  // Return BOS Descriptor
-			AT91F_USB_SendData(pUdp, BOSDescriptor, MIN(sizeof(BOSDescriptor), wLength));
 		else if ((wValue & 0x300) == 0x300)  // Return Manufacturer Descriptor - this is needed by Android
 			AT91F_USB_SendData(pUdp, StrDescManufacturer, MIN(sizeof(StrDescManufacturer), wLength));
 		else if ((wValue & 0xF00) == 0x300) { // Return String Descriptor

--- a/common/usb_cdc.c
+++ b/common/usb_cdc.c
@@ -183,11 +183,12 @@ static const char StrDescManufacturer[] = {
 };
 
 static const char StrDescProduct[] = {
-  4,			// Length
+  9,			// Length
   0x03,			// Type is string
   'P', 0x00,
   'M', 0x00,
-  '3', 0x00
+  '3', 0x00,
+   0x00
 };
 
 const char* getStringDescriptor(uint8_t idx)


### PR DESCRIPTION
Add the BOS USB descriptor. This tells the OS the device supports extended commands, on Android this means the OS allows apps to interact with the device using the Android USB Host API. i.e. apps can communicate with the PM3 without needing root.