### PR TITLE
fix for swapped parity bits

### DIFF
--- a/client/scripts/lf_bulk_program.lua
+++ b/client/scripts/lf_bulk_program.lua
@@ -61,8 +61,8 @@ local function cardHex(i,f)
 
 	--As the function defaults to even parity and returns a boolean,
 	--perform a 'not' function to get odd parity
-	high = evenparity(string.sub(stream,0,12)) and 1 or 0
-	low = not evenparity(string.sub(stream,13)) and 1 or 0
+	high = not evenparity(string.sub(stream,0,12)) and 1 or 0
+	low =  evenparity(string.sub(stream,13)) and 1 or 0
 	bits = bit32.bor(bit32.lshift(id,1), low)
 	bits = bit32.bor(bits, bit32.lshift(high,25))
 


### PR DESCRIPTION
Just programmed a few hundred cards using this script and discovered this.  Facility and Site code are not effected by swapping the parity bits but the full hex value is. Some of the systems at my workplace - photocopiers etc.. actually rely on the hex value and not the WG26 decimal numbers this issue became obvious fast.