### PR TITLE
mfu read block: retry block with bad CRC

### DIFF
--- a/armsrc/mifarecmd.c
+++ b/armsrc/mifarecmd.c
@@ -310,8 +310,6 @@ void MifareUReadCard(uint8_t arg0, uint16_t arg1, uint8_t arg2, uint8_t *datain)
 		}
 	}
 
-	#define MFU_MAX_CRC_RETRIES 5
-	unsigned int retries = 0;
 	for (int i = 0; i < blocks; i++){
 		if ((i*4) + 4 >= CARD_MEMORY_SIZE) {
 			Dbprintf("Data exceeds buffer!!");
@@ -322,22 +320,15 @@ void MifareUReadCard(uint8_t arg0, uint16_t arg1, uint8_t arg2, uint8_t *datain)
 
 		if (len) {
 			if (MF_DBGLEVEL >= MF_DBG_ERROR) Dbprintf("Read block %d error",i);
-
-			if (retries >= MFU_MAX_CRC_RETRIES) {
-				// if no blocks read - error out
-				if (i==0) {
-					OnError(2);
-					return;
-				} else {
-					//stop at last successful read block and return what we got
-					break;
-				}
+			// if no blocks read - error out
+			if (i==0){
+				OnError(2);
+				return;
 			} else {
-				retries++;
-				i--;
+				//stop at last successful read block and return what we got
+				break;
 			}
 		} else {
-			retries = 0;
 			countblocks++;
 		}
 	}

--- a/armsrc/mifareutil.c
+++ b/armsrc/mifareutil.c
@@ -405,31 +405,48 @@ int mifare_ultra_auth(uint8_t *keybytes){
 	return 1;
 }
 
+
+#define MFU_MAX_RETRIES 5
 int mifare_ultra_readblock(uint8_t blockNo, uint8_t *blockData)
 {
 	uint16_t len;
 	uint8_t	bt[2];
 	uint8_t receivedAnswer[MAX_FRAME_SIZE];
 	uint8_t receivedAnswerPar[MAX_PARITY_SIZE];
-	
+	uint8_t retries;
+	int result = 0;
 
-	len = mifare_sendcmd_short(NULL, 1, 0x30, blockNo, receivedAnswer, receivedAnswerPar, NULL);
-	if (len == 1) {
-		if (MF_DBGLEVEL >= MF_DBG_ERROR) Dbprintf("Cmd Error: %02x", receivedAnswer[0]);
-		return 1;
+	for (retries = 0; retries < MFU_MAX_RETRIES; retries++) {
+		len = mifare_sendcmd_short(NULL, 1, 0x30, blockNo, receivedAnswer, receivedAnswerPar, NULL);
+		if (len == 1) {
+			if (MF_DBGLEVEL >= MF_DBG_ERROR) Dbprintf("Cmd Error: %02x", receivedAnswer[0]);
+			result = 1;
+			continue;
+		}
+		if (len != 18) {
+			if (MF_DBGLEVEL >= MF_DBG_ERROR) Dbprintf("Cmd Error: card timeout. len: %x", len);
+			result = 2;
+			continue;
+		}
+
+		memcpy(bt, receivedAnswer + 16, 2);
+		AppendCrc14443a(receivedAnswer, 16);
+		if (bt[0] != receivedAnswer[16] || bt[1] != receivedAnswer[17]) {
+			if (MF_DBGLEVEL >= MF_DBG_ERROR) Dbprintf("Cmd CRC response error.");
+			result = 3;
+			continue;
+		}
+
+		// No errors encountered; don't retry
+		result = 0;
+		break;
 	}
-	if (len != 18) {
-		if (MF_DBGLEVEL >= MF_DBG_ERROR) Dbprintf("Cmd Error: card timeout. len: %x", len);
-		return 2;
+
+	if (result != 0) {
+		Dbprintf("Cmd Error: too many retries; read failed");
+		return result;
 	}
-    
-	memcpy(bt, receivedAnswer + 16, 2);
-	AppendCrc14443a(receivedAnswer, 16);
-	if (bt[0] != receivedAnswer[16] || bt[1] != receivedAnswer[17]) {
-		if (MF_DBGLEVEL >= MF_DBG_ERROR) Dbprintf("Cmd CRC response error.");
-		return 3;
-	}
-	
+
 	memcpy(blockData, receivedAnswer, 14);
 	return 0;
 }


### PR DESCRIPTION
Retry block reads a few times if the CRC is bad instead of bailing immediately