### PR TITLE
OSX: Multiple libedit/readline fixes

### DIFF
--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -287,9 +287,6 @@ int main(int argc, char* argv[]) {
 	bool addLuaExec = false;
 	char *script_cmds_file = NULL;
 	char *script_cmd = NULL;
-
-	// Must be before the first PrintAndLog call, for rl_redisplay
-	rl_initialize();
   
 	if (argc < 2) {
 		show_help(true, argv[0]);

--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -132,7 +132,7 @@ main_loop(char *script_cmds_file, char *script_cmd, bool usb_present) {
 			printf("executing commands from file: %s\n", script_cmds_file);
 		}
 	}
-	
+
 	read_history(".history");
 
 	while(1)  {
@@ -287,6 +287,9 @@ int main(int argc, char* argv[]) {
 	bool addLuaExec = false;
 	char *script_cmds_file = NULL;
 	char *script_cmd = NULL;
+
+	// Must be before the first PrintAndLog call, for rl_redisplay
+	rl_initialize();
   
 	if (argc < 2) {
 		show_help(true, argv[0]);


### PR DESCRIPTION
Extracted from PR #463, this addresses issues when using libedit's compatibility mode for readline, which is used on BSD and OSX.  This patch set has been tested with Linux (using GNU readline), OSX 10.13 (using both libedit and GNU readline).

Using libedit over readline avoids needing to swap in readline over the top of system libraries (`brew link --force readline`), and removes the need to explicitly install readline (as libedit is included on OSX).

1. If compiler optimisations are disabled in OSX, and the user is using libedit, then a link failure occurs, as the second `if (need_hack)` is no longer optimised out.

   I've got another branch where I've been attempting to get libedit to have the same functionality as GNU readline.  It mostly works, but arrow keys don't work correctly after a `PrintAndLog` output. See: https://github.com/Proxmark/proxmark3/compare/master...micolous:osx-libedit-compat

   There have been other changes to libedit recently, and in particular [NetBSD PR/51518](https://mail-index.netbsd.org/netbsd-bugs/2017/09/01/msg053438.html) may be enable resolving this issue properly.

2. _Reverted per @iceman1001 in #497_ ~Explicitly initialise readline on application start.  This avoids a null pointer dereference using libedit (exposed in branch `osx-libedit-compat`).~

3. Adds documentation about what the `need_hack` actually does, and what expected behaviour is.

**Test instructions (OSX):**

* To produce a libedit based build, run `brew unlink readline`
* To produce a GNU readline based build, run `brew link --force readline`

**Other platforms:**

Build as normal.