### PR TITLE
Fix offset Indala UID display

### DIFF
--- a/common/lfdemod.c
+++ b/common/lfdemod.c
@@ -1780,6 +1780,7 @@ int IOdemodFSK(uint8_t *dest, size_t size, int *waveStartIdx) {
 // indala id decoding
 int indala64decode(uint8_t *bitStream, size_t *size, uint8_t *invert) {
 	//standard 64 bit indala formats including 26 bit 40134 format
+	// Note: these start with 3 bits from the end of one UID; the rest are from a subsequent one
 	uint8_t preamble64[] = {1,0,1,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 1};
 	uint8_t preamble64_i[] = {0,1,0,1, 1,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1, 0};
 	size_t startidx = 0;
@@ -1791,6 +1792,10 @@ int indala64decode(uint8_t *bitStream, size_t *size, uint8_t *invert) {
 		*invert ^= 1;
 	}
 	if (found_size != 64) return -2;
+
+	// Skip the aforementioned 3 bits from the previous UID
+	startidx += 3;
+
 	if (*invert==1)
 		for (size_t i = startidx; i < found_size + startidx; i++) 
 			bitStream[i] ^= 1;


### PR DESCRIPTION
Commit 1dae9811f22b7f2cea340cee6945cb349046129d extended the amount of fixed bits searched for when decoding 64-bit Indala. These additional bits come from the end of one UID, and therefore need to be skipped past when actually retrieving the UID.

Before:
```
proxmark3> lf indala clone 6effff795
Cloning 64bit tag with UID 6effff795
proxmark3> #db# DONE!

proxmark3> lf indala read
BitLen: 64
Indala UID=1010000000000000
0000000000000000
1101110111111111
1111111011110010
 (a0000000ddfffef2)
```

After:
```
proxmark3> lf indala clone 6effff795
Cloning 64bit tag with UID 6effff795
proxmark3> #db# DONE!

proxmark3> lf indala read
BitLen: 64
Indala UID=0000000000000000
0000000000000110
1110111111111111
1111011110010101
 (6effff795)
```