### PR TITLE
fix bug if -DWITH_ISO14443a_StandAlone is removed from makefile

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -31,7 +31,7 @@
 #endif
 
 // Craig Young - 14a stand-alone code
-#ifdef WITH_ISO14443a_StandAlone
+#ifdef WITH_ISO14443a
  #include "iso14443a.h"
 #endif
 


### PR DESCRIPTION
reported at http://www.proxmark.org/forum/viewtopic.php?pid=32031#p32031
