### PR TITLE
fix gui (plot) bugs

### DIFF
--- a/client/proxguiqt.cpp
+++ b/client/proxguiqt.cpp
@@ -269,6 +269,7 @@ int Plot::xCoordOf(int i, QRect r )
 int Plot::yCoordOf(int v, QRect r, int maxVal)
 {
 	int z = (r.bottom() - r.top())/2;
+	if ( maxVal == 0 ) maxVal++;
 	return -(z * v) / maxVal + z;
 }
 
@@ -579,6 +580,8 @@ Plot::Plot(QWidget *parent) : QWidget(parent), GraphStart(0), GraphPixelsPerPoin
 	CursorBPos = 0;
 
 	setWindowTitle(tr("Sliders"));
+
+	master = parent;
 }
 
 void Plot::closeEvent(QCloseEvent *event)
@@ -688,7 +691,7 @@ void Plot::keyPressEvent(QKeyEvent *event)
 			break;
 
 		case Qt::Key_Q:
-			this->hide();
+			master->hide();
 			break;
 
 		default:

--- a/client/proxguiqt.h
+++ b/client/proxguiqt.h
@@ -28,6 +28,7 @@
 class Plot: public QWidget
 {
 private:
+	QWidget *master;
 	int GraphStart;
 	double GraphPixelsPerPoint;
 	int CursorAPos;


### PR DESCRIPTION
G keypress event would cause a crash if no data
Q keypress didn't work.

Thanks to @iceman1001 for identifying and providing the fixes.