### PR TITLE
USB comms: part 4 towards @micolous PR #463

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -82,7 +82,9 @@ POSTCOMPILE = $(MV) -f $(OBJDIR)/$*.Td $(OBJDIR)/$*.d
 CORESRCS = 	uart_posix.c \
 			uart_win32.c \
 			util.c \
-			util_posix.c
+			util_posix.c \
+			ui.c \
+			comms.c
 
 CMDSRCS = 	crapto1/crapto1.c\
 			crapto1/crypto1.c\
@@ -106,7 +108,6 @@ CMDSRCS = 	crapto1/crapto1.c\
 			iso14443crc.c \
 			iso15693tools.c \
 			graph.c \
-			ui.c \
 			cmddata.c \
 			lfdemod.c \
 			emv/crypto_polarssl.c\
@@ -169,8 +170,7 @@ CMDSRCS = 	crapto1/crapto1.c\
 			cmdscript.c\
 			pm3_binlib.c\
 			pm3_bitlib.c\
-			protocols.c\
-			comms.c
+			protocols.c
 
 cpu_arch = $(shell uname -m)
 ifneq ($(findstring 86, $(cpu_arch)), )

--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -8,14 +8,15 @@
 // Data and Graph commands
 //-----------------------------------------------------------------------------
 
+#include "cmddata.h"
+
 #include <stdio.h>    // also included in util.h
 #include <string.h>   // also included in util.h
 #include <inttypes.h>
 #include <limits.h>   // for CmdNorm INT_MIN && INT_MAX
-#include "cmddata.h"
 #include "util.h"
 #include "cmdmain.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"       // for show graph controls
 #include "graph.h"    // for graph data
 #include "cmdparser.h"// already included in cmdmain.h

--- a/client/cmdhf.c
+++ b/client/cmdhf.c
@@ -9,17 +9,18 @@
 // High frequency commands
 //-----------------------------------------------------------------------------
 
+#include "cmdhf.h"
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "util.h"
 #include "ui.h"
 #include "iso14443crc.h"
 #include "parity.h"
 #include "cmdmain.h"
 #include "cmdparser.h"
-#include "cmdhf.h"
 #include "cmdhf14a.h"
 #include "cmdhf14b.h"
 #include "cmdhf15.h"

--- a/client/cmdhf14a.c
+++ b/client/cmdhf14a.c
@@ -20,7 +20,7 @@
 #include "util.h"
 #include "util_posix.h"
 #include "iso14443crc.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "cmdparser.h"
 #include "common.h"

--- a/client/cmdhf14b.c
+++ b/client/cmdhf14b.c
@@ -8,18 +8,19 @@
 // High frequency ISO14443B commands
 //-----------------------------------------------------------------------------
 
+#include "cmdhf14b.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
 #include <stdint.h>
 #include "iso14443crc.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "graph.h"
 #include "util.h"
 #include "ui.h"
 #include "cmdparser.h"
-#include "cmdhf14b.h"
 #include "cmdmain.h"
 #include "cmdhf14a.h"
 

--- a/client/cmdhf14b.h
+++ b/client/cmdhf14b.h
@@ -11,6 +11,8 @@
 #ifndef CMDHF14B_H__
 #define CMDHF14B_H__
 
+#include <stdbool.h>
+
 int CmdHF14B(const char *Cmd);
 int CmdHF14BList(const char *Cmd);
 int CmdHF14BInfo(const char *Cmd);

--- a/client/cmdhf15.c
+++ b/client/cmdhf15.c
@@ -22,17 +22,18 @@
 // the client. Signal Processing & decoding is done on the pc. This is the slowest
 // variant, but offers the possibility to analyze the waveforms directly. 
 
+#include "cmdhf15.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
 
-#include "proxmark3.h"
+#include "comms.h"
 #include "graph.h"
 #include "ui.h"
 #include "util.h"
 #include "cmdparser.h"
-#include "cmdhf15.h"
 #include "iso15693tools.h"
 #include "cmdmain.h"
 

--- a/client/cmdhf15.h
+++ b/client/cmdhf15.h
@@ -11,6 +11,8 @@
 #ifndef CMDHF15_H__
 #define CMDHF15_H__
 
+#include <stdbool.h>
+
 int CmdHF15(const char *Cmd);
 
 int CmdHF15Demod(const char *Cmd);

--- a/client/cmdhfepa.c
+++ b/client/cmdhfepa.c
@@ -17,7 +17,7 @@
 #include <stdio.h>
 #include "util.h"
 #include "util_posix.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "cmdparser.h"
 #include "common.h"

--- a/client/cmdhficlass.c
+++ b/client/cmdhficlass.c
@@ -16,7 +16,7 @@
 #include <sys/stat.h>
 #include <ctype.h>
 #include "iso14443crc.h" // Can also be used for iClass, using 0xE012 as CRC-type
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "cmdparser.h"
 #include "cmdhficlass.h"

--- a/client/cmdhflegic.c
+++ b/client/cmdhflegic.c
@@ -8,15 +8,17 @@
 // High frequency Legic commands
 //-----------------------------------------------------------------------------
 
+#include "cmdhflegic.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "cmdparser.h"
-#include "cmdhflegic.h"
 #include "cmdmain.h"
 #include "util.h"
+
 static int CmdHelp(const char *Cmd);
 
 static command_t CommandTable[] = 

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "cmdmain.h"
 #include "cmdhfmfhard.h"
 #include "parity.h"

--- a/client/cmdhfmfhard.c
+++ b/client/cmdhfmfhard.c
@@ -25,6 +25,7 @@
 #include <locale.h>
 #include <math.h>
 #include "proxmark3.h"
+#include "comms.h"
 #include "cmdmain.h"
 #include "ui.h"
 #include "util.h"

--- a/client/cmdhfmfu.c
+++ b/client/cmdhfmfu.c
@@ -12,7 +12,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "usb_cmd.h"
 #include "cmdmain.h"
 #include "ui.h"

--- a/client/cmdhftopaz.c
+++ b/client/cmdhftopaz.c
@@ -8,17 +8,18 @@
 // High frequency Topaz (NFC Type 1) commands
 //-----------------------------------------------------------------------------
 
+#include "cmdhftopaz.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include "cmdmain.h"
 #include "cmdparser.h"
-#include "cmdhftopaz.h"
 #include "cmdhf14a.h"
 #include "ui.h"
 #include "mifare.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "iso14443crc.h"
 #include "protocols.h"
 

--- a/client/cmdhw.c
+++ b/client/cmdhw.c
@@ -8,14 +8,15 @@
 // Hardware commands
 //-----------------------------------------------------------------------------
 
+#include "cmdhw.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
 #include "ui.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "cmdparser.h"
-#include "cmdhw.h"
 #include "cmdmain.h"
 #include "cmddata.h"
 

--- a/client/cmdlf.c
+++ b/client/cmdlf.c
@@ -8,14 +8,15 @@
 // Low frequency commands
 //-----------------------------------------------------------------------------
 
+#include "cmdlf.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include "proxmark3.h"
-#include "cmdlf.h"
+#include "comms.h"
 #include "lfdemod.h"     // for psk2TOpsk1
 #include "util.h"        // for parsing cli command utils
 #include "ui.h"          // for show graph controls

--- a/client/cmdlfawid.c
+++ b/client/cmdlfawid.c
@@ -11,10 +11,11 @@
 // FSK2a, RF/50, 96 bits (complete)
 //-----------------------------------------------------------------------------
 
+#include "cmdlfawid.h"
+
 #include <string.h>
 #include <stdio.h>      // sscanf
-#include "proxmark3.h"  // Definitions, USB controls, etc
-#include "cmdlfawid.h"
+#include "comms.h"      // Definitions, USB controls, etc
 #include "ui.h"         // PrintAndLog
 #include "cmdparser.h"  // CmdsParse, CmdsHelp
 #include "lfdemod.h"    // parityTest +

--- a/client/cmdlfcotag.c
+++ b/client/cmdlfcotag.c
@@ -7,13 +7,15 @@
 //-----------------------------------------------------------------------------
 // Low frequency COTAG commands
 //-----------------------------------------------------------------------------
+
+#include "cmdlfcotag.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "cmddata.h"
-#include "cmdlfcotag.h"
 #include "lfdemod.h"
 #include "usb_cmd.h"
 #include "cmdmain.h"

--- a/client/cmdlfem4x.c
+++ b/client/cmdlfem4x.c
@@ -8,11 +8,12 @@
 // Low frequency EM4x commands
 //-----------------------------------------------------------------------------
 
+#include "cmdlfem4x.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
-#include "cmdlfem4x.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "util.h"
 #include "graph.h"

--- a/client/cmdlffdx.c
+++ b/client/cmdlffdx.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include <string.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"         // for PrintAndLog
 #include "util.h"
 #include "cmdparser.h"

--- a/client/cmdlfhid.c
+++ b/client/cmdlfhid.c
@@ -8,10 +8,11 @@
 // Low frequency HID commands (known)
 //-----------------------------------------------------------------------------
 
+#include "cmdlfhid.h"
+
 #include <stdio.h>
 #include <string.h>
-#include "cmdlfhid.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "graph.h"
 #include "cmdparser.h"

--- a/client/cmdlfhitag.c
+++ b/client/cmdlfhitag.c
@@ -8,10 +8,12 @@
 // Low frequency Hitag support
 //-----------------------------------------------------------------------------
 
+#include "cmdlfhitag.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "cmdparser.h"
 #include "common.h"

--- a/client/cmdlfindala.c
+++ b/client/cmdlfindala.c
@@ -8,10 +8,11 @@
 // PSK1, rf/32, 64 or 224 bits (known)
 //-----------------------------------------------------------------------------
 
+#include "cmdlfindala.h"
+
 #include <stdio.h>
 #include <string.h>
-#include "cmdlfindala.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "graph.h"
 #include "cmdparser.h"

--- a/client/cmdlfio.c
+++ b/client/cmdlfio.c
@@ -8,13 +8,14 @@
 // FSK2a, rf/64, 64 bits (complete)
 //-----------------------------------------------------------------------------
 
+#include "cmdlfio.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
 #include <limits.h>
-#include "cmdlfio.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "graph.h"
 #include "ui.h"
 #include "cmdparser.h"

--- a/client/cmdlfjablotron.c
+++ b/client/cmdlfjablotron.c
@@ -9,10 +9,11 @@
 //-----------------------------------------------------------------------------
 
 #include "cmdlfjablotron.h"
+
 #include <string.h>
 #include <inttypes.h>
 #include <stdbool.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "util.h"
 #include "graph.h"

--- a/client/cmdlfnexwatch.c
+++ b/client/cmdlfnexwatch.c
@@ -7,12 +7,14 @@
 // Low frequency Honeywell NexWatch tag commands
 // PSK1 RF/16, RF/2, 128 bits long (known)
 //-----------------------------------------------------------------------------
+
+#include "cmdlfnexwatch.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
 #include <stdbool.h>
-#include "cmdlfnexwatch.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "util.h"
 #include "graph.h"

--- a/client/cmdlfnoralsy.c
+++ b/client/cmdlfnoralsy.c
@@ -7,11 +7,13 @@
 // Low frequency Noralsy tag commands
 // ASK/Manchester, STT, RF/32, 96 bits long (some bits unknown)
 //-----------------------------------------------------------------------------
+
 #include "cmdlfnoralsy.h"
+
 #include <string.h>
 #include <inttypes.h>
 #include <math.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "util.h"
 #include "graph.h"

--- a/client/cmdlfpac.c
+++ b/client/cmdlfpac.c
@@ -7,10 +7,12 @@
 // Low frequency Stanley/PAC tag commands
 // NRZ, RF/32, 128 bits long (unknown cs)
 //-----------------------------------------------------------------------------
+
 #include "cmdlfpac.h"
+
 #include <string.h>
 #include <inttypes.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "util.h"
 #include "graph.h"

--- a/client/cmdlfpcf7931.c
+++ b/client/cmdlfpcf7931.c
@@ -8,9 +8,12 @@
 //-----------------------------------------------------------------------------
 // Low frequency PCF7931 commands
 //-----------------------------------------------------------------------------
+
+#include "cmdlfpcf7931.h"
+
 #include <stdio.h>
 #include <string.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "util.h"
 #include "graph.h"
@@ -18,7 +21,6 @@
 #include "cmddata.h"
 #include "cmdmain.h"
 #include "cmdlf.h"
-#include "cmdlfpcf7931.h"
 
 static int CmdHelp(const char *Cmd);
 

--- a/client/cmdlfpcf7931.h
+++ b/client/cmdlfpcf7931.h
@@ -12,6 +12,8 @@
 #ifndef CMDLFPCF7931_H__
 #define CMDLFPCF7931_H__
 
+#include <stdint.h>
+
 struct pcf7931_config{
 	uint8_t Pwd[7];
 	uint16_t InitDelay;

--- a/client/cmdlfpresco.c
+++ b/client/cmdlfpresco.c
@@ -7,11 +7,13 @@
 // Low frequency Presco tag commands
 // ASK/Manchester, rf/32, 128 bits (complete)
 //-----------------------------------------------------------------------------
+
+#include "cmdlfpresco.h"
+
 #include <string.h>
 #include <inttypes.h>
 #include <stdio.h>
-#include "cmdlfpresco.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "util.h"
 #include "graph.h"

--- a/client/cmdlfpyramid.c
+++ b/client/cmdlfpyramid.c
@@ -7,11 +7,13 @@
 // Low frequency Farpoint / Pyramid tag commands
 // FSK2a, rf/50, 128 bits (complete)
 //-----------------------------------------------------------------------------
+
+#include "cmdlfpyramid.h"
+
 #include <string.h>
 #include <inttypes.h>
 #include <stdio.h>
-#include "cmdlfpyramid.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "util.h"
 #include "graph.h"

--- a/client/cmdlfsecurakey.c
+++ b/client/cmdlfsecurakey.c
@@ -7,11 +7,13 @@
 // Low frequency Securakey tag commands
 // ASK/Manchester, RF/40, 96 bits long (unknown cs)
 //-----------------------------------------------------------------------------
+
 #include "cmdlfsecurakey.h"
+
 #include <string.h>
 #include <inttypes.h>
 #include <math.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "util.h"
 #include "graph.h"

--- a/client/cmdlft55xx.c
+++ b/client/cmdlft55xx.c
@@ -7,19 +7,20 @@
 // Low frequency T55xx commands
 //-----------------------------------------------------------------------------
 
+#include "cmdlft55xx.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
 #include <ctype.h>
 #include <time.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "graph.h"
 #include "cmdmain.h"
 #include "cmdparser.h"
 #include "cmddata.h"
 #include "cmdlf.h"
-#include "cmdlft55xx.h"
 #include "util.h"
 #include "lfdemod.h"
 #include "cmdhf14a.h" //for getTagInfo

--- a/client/cmdlft55xx.h
+++ b/client/cmdlft55xx.h
@@ -10,6 +10,9 @@
 #ifndef CMDLFT55XX_H__
 #define CMDLFT55XX_H__
 
+#include <stdint.h>
+#include <stdbool.h>
+
 typedef struct {
 	uint32_t bl1;
 	uint32_t bl2; 

--- a/client/cmdlfti.c
+++ b/client/cmdlfti.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <inttypes.h>
 #include "crc16.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "graph.h"
 #include "cmdparser.h"

--- a/client/cmdlfviking.c
+++ b/client/cmdlfviking.c
@@ -7,11 +7,13 @@
 // Low frequency Viking tag commands (AKA FDI Matalec Transit)
 // ASK/Manchester, RF/32, 64 bits (complete)
 //-----------------------------------------------------------------------------
+
+#include "cmdlfviking.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
-#include "proxmark3.h"
-#include "cmdlfviking.h"
+#include "comms.h"
 #include "ui.h"
 #include "util.h"
 #include "graph.h"

--- a/client/cmdlfvisa2000.c
+++ b/client/cmdlfvisa2000.c
@@ -13,7 +13,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "proxmark3.h"
+#include "comms.h"
 #include "ui.h"
 #include "util.h"
 #include "graph.h"

--- a/client/cmdmain.c
+++ b/client/cmdmain.c
@@ -50,13 +50,13 @@ command_t* getTopLevelCommandTable()
   return CommandTable;
 }
 
-int CmdHelp(const char *Cmd)
+static int CmdHelp(const char *Cmd)
 {
   CmdsHelp(CommandTable);
   return 0;
 }
 
-int CmdQuit(const char *Cmd)
+static int CmdQuit(const char *Cmd)
 {
   return 99;
 }

--- a/client/cmdmain.h
+++ b/client/cmdmain.h
@@ -11,12 +11,7 @@
 #ifndef CMDMAIN_H__
 #define CMDMAIN_H__
 
-#include <stdint.h>
-#include <stddef.h>
-#include "usb_cmd.h"
 #include "cmdparser.h"
-#include "comms.h"
-
 
 extern int CommandReceived(char *Cmd);
 extern command_t* getTopLevelCommandTable();

--- a/client/comms.h
+++ b/client/comms.h
@@ -22,24 +22,14 @@
 #define CMD_BUFFER_SIZE 50
 #endif
 
-typedef struct {
-	// If TRUE, continue running the uart_receiver thread
-	bool run;
-
-	// Lock around serial port receives
-	pthread_mutex_t recv_lock;
-} receiver_arg;
-
-
 void SetOffline(bool new_offline);
 bool IsOffline();
 
-bool OpenProxmark(char *portname, bool waitCOMPort, int timeout);
+bool OpenProxmark(char *portname, bool waitCOMPort, int timeout, bool flash_mode);
 void CloseProxmark(void);
 
 void SendCommand(UsbCommand *c);
 
-void *uart_receiver(void *targ);
 void clearCommandBuffer();
 bool WaitForResponseTimeoutW(uint32_t cmd, UsbCommand* response, size_t ms_timeout, bool show_warning);
 bool WaitForResponseTimeout(uint32_t cmd, UsbCommand* response, size_t ms_timeout);

--- a/client/flash.h
+++ b/client/flash.h
@@ -10,8 +10,7 @@
 #define __FLASH_H__
 
 #include <stdint.h>
-#include "elf.h"
-#include "uart.h"
+#include <stdbool.h>
 
 typedef struct {
 	void *data;
@@ -26,14 +25,10 @@ typedef struct {
 	flash_seg_t *segments;
 } flash_file_t;
 
-int flash_load(flash_file_t *ctx, const char *name, int can_write_bl);
+int flash_load(flash_file_t *ctx, const char *name, bool can_write_bl);
 int flash_start_flashing(int enable_bl_writes, char *serial_port_name);
 int flash_write(flash_file_t *ctx);
 void flash_free(flash_file_t *ctx);
 int flash_stop_flashing(void);
-void CloseProxmark(const char *serial_port_name);
-bool OpenProxmark(size_t i, const char *serial_port_name);
-
-extern serial_port sp;
 #endif
 

--- a/client/mifarehost.c
+++ b/client/mifarehost.c
@@ -16,7 +16,7 @@
 #include <pthread.h>
 
 #include "crapto1/crapto1.h"
-#include "proxmark3.h"
+#include "comms.h"
 #include "usb_cmd.h"
 #include "cmdmain.h"
 #include "ui.h"

--- a/client/proxmark3.h
+++ b/client/proxmark3.h
@@ -20,7 +20,6 @@
 extern "C" {
 #endif
 
-void SendCommand(UsbCommand *c);
 const char *get_my_executable_path(void);
 const char *get_my_executable_directory(void);
 void main_loop(char *script_cmds_file, char *script_cmd, bool usb_present);

--- a/client/scripting.c
+++ b/client/scripting.c
@@ -15,6 +15,7 @@
 #include <lualib.h>
 #include <lauxlib.h>
 #include "proxmark3.h"
+#include "comms.h"
 #include "usb_cmd.h"
 #include "cmdmain.h"
 #include "util.h"


### PR DESCRIPTION
* make uart_communication() static in comms.c
* move receiver thread creation and respective mutexes to comms.c
* add mutex and signal for tx buffer
* use comms.c for flasher as well
* remove comm functions from client/proxmark3.h
* this completes isolating all USB communication related functions in comms.c