### PR TITLE
FIX: Mark uart parameters and `sp` as non-const pointers.

### DIFF
--- a/client/comms.c
+++ b/client/comms.c
@@ -20,7 +20,7 @@
 // Declare globals.
 
 // Serial port that we are communicating with the PM3 on.
-static serial_port sp;
+static serial_port* sp = NULL;
 
 // If TRUE, then there is no active connection to the PM3, and we will drop commands sent.
 static bool offline;

--- a/uart/uart.h
+++ b/uart/uart.h
@@ -69,11 +69,11 @@ typedef void* serial_port;
  *
  * On errors, this method returns INVALID_SERIAL_PORT or CLAIMED_SERIAL_PORT.
  */
-serial_port uart_open(const char* pcPortName);
+serial_port* uart_open(const char* pcPortName);
 
 /* Closes the given port.
  */
-void uart_close(const serial_port sp);
+void uart_close(serial_port* sp);
 
 /* Reads from the given serial port for up to 30ms.
  *   pbtRx: A pointer to a buffer for the returned data to be written to.
@@ -86,21 +86,21 @@ void uart_close(const serial_port sp);
  * partial read may have completed into the buffer by the corresponding
  * implementation, so pszRxLen should be checked to see if any data was written. 
  */
-bool uart_receive(const serial_port sp, uint8_t* pbtRx, size_t pszMaxRxLen, size_t* pszRxLen);
+bool uart_receive(serial_port* sp, uint8_t* pbtRx, size_t pszMaxRxLen, size_t* pszRxLen);
 
 /* Sends a buffer to a given serial port.
  *   pbtTx: A pointer to a buffer containing the data to send.
  *   szTxLen: The amount of data to be sent.
  */
-bool uart_send(const serial_port sp, const uint8_t* pbtTx, const size_t szTxLen);
+bool uart_send(serial_port* sp, const uint8_t* pbtTx, const size_t szTxLen);
 
 /* Sets the current speed of the serial port, in baud.
  */
-bool uart_set_speed(serial_port sp, const uint32_t uiPortSpeed);
+bool uart_set_speed(serial_port* sp, const uint32_t uiPortSpeed);
 
 /* Gets the current speed of the serial port, in baud.
  */
-uint32_t uart_get_speed(const serial_port sp);
+uint32_t uart_get_speed(serial_port* sp);
 
 #endif // _PM3_UART_H_
 

--- a/uart/uart_win32.c
+++ b/uart/uart_win32.c
@@ -57,7 +57,7 @@ void upcase(char *p) {
   }
 }
 
-serial_port uart_open(const char* pcPortName) {
+serial_port* uart_open(const char* pcPortName) {
   char acPortName[255];
   serial_port_windows* sp = malloc(sizeof(serial_port_windows));
   
@@ -68,7 +68,7 @@ serial_port uart_open(const char* pcPortName) {
   // Try to open the serial port
   sp->hPort = CreateFileA(acPortName,GENERIC_READ|GENERIC_WRITE,0,NULL,OPEN_EXISTING,0,NULL);
   if (sp->hPort == INVALID_HANDLE_VALUE) {
-    uart_close(sp);
+    uart_close((serial_port*)sp);
     return INVALID_SERIAL_PORT;
   }
   
@@ -76,13 +76,13 @@ serial_port uart_open(const char* pcPortName) {
   memset(&sp->dcb, 0, sizeof(DCB));
   sp->dcb.DCBlength = sizeof(DCB);
   if(!BuildCommDCBA("baud=9600 data=8 parity=N stop=1",&sp->dcb)) {
-    uart_close(sp);
+    uart_close((serial_port*)sp);
     return INVALID_SERIAL_PORT;
   }
   
   // Update the active serial port
   if(!SetCommState(sp->hPort,&sp->dcb)) {
-    uart_close(sp);
+    uart_close((serial_port*)sp);
     return INVALID_SERIAL_PORT;
   }
   
@@ -93,38 +93,38 @@ serial_port uart_open(const char* pcPortName) {
   sp->ct.WriteTotalTimeoutConstant   = 30;
   
   if(!SetCommTimeouts(sp->hPort,&sp->ct)) {
-    uart_close(sp);
+    uart_close((serial_port*)sp);
     return INVALID_SERIAL_PORT;
   }
   
   PurgeComm(sp->hPort, PURGE_RXABORT | PURGE_RXCLEAR);
   
-  return sp;
+  return (serial_port*)sp;
 }
 
-void uart_close(const serial_port sp) {
+void uart_close(serial_port* sp) {
   CloseHandle(((serial_port_windows*)sp)->hPort);
   free(sp);
 }
 
-bool uart_receive(const serial_port sp, uint8_t *pbtRx, size_t pszMaxRxLen, size_t *pszRxLen) {
+bool uart_receive(serial_port* sp, uint8_t *pbtRx, size_t pszMaxRxLen, size_t *pszRxLen) {
   return ReadFile(((serial_port_windows*)sp)->hPort, pbtRx, pszMaxRxLen, (LPDWORD)pszRxLen, NULL);
 }
 
-bool uart_send(const serial_port sp, const uint8_t* pbtTx, const size_t szTxLen) {
+bool uart_send(serial_port* sp, const uint8_t* pbtTx, const size_t szTxLen) {
   DWORD dwTxLen = 0;
   return WriteFile(((serial_port_windows*)sp)->hPort, pbtTx, szTxLen, &dwTxLen, NULL);
 }
 
-bool uart_set_speed(serial_port sp, const uint32_t uiPortSpeed) {
+bool uart_set_speed(serial_port* sp, const uint32_t uiPortSpeed) {
   serial_port_windows* spw;
   spw = (serial_port_windows*)sp;
   spw->dcb.BaudRate = uiPortSpeed;
   return SetCommState(spw->hPort, &spw->dcb);
 }
 
-uint32_t uart_get_speed(const serial_port sp) {
-  const serial_port_windows* spw = (serial_port_windows*)sp;
+uint32_t uart_get_speed(serial_port* sp) {
+  serial_port_windows* spw = (serial_port_windows*)sp;
   if (!GetCommState(spw->hPort, (serial_port)&spw->dcb)) {
     return spw->dcb.BaudRate;
   }


### PR DESCRIPTION
Internally, the `uart_*` implementations treat their parameter as a pointer.

While the C compiler technically doesn't have a way to enforce that you're not modifying memory referred to by a `const` pointer, there's not a good reason to prohibit an implementation of `uart` from doing so, if it makes sense for that platform or environment.

PM3 also fairly consistently casts the value to a non-const pointer anyway.

This also explicitly sets `sp` to NULL, which should cause an uninitialized use of `sp` to dereference a null pointer (generally crashing with a segfault, as the program tries to reference unmapped memory), rather than reading some nearby program memory (and have undefined behaviour).

That will make it very obvious in a debugger, when something has gone wrong. For example:

```
* thread #1: tid = 32727, 0x0000555555556e1b flasher`uart_send(sp=0x0000000000000000, pbtTx="", szTxLen=544) + 123 at uart_posix.c:204, name = 'flasher', stop reason = signal SIGSEGV: invalid address (fault address: 0x0)
    frame #0: 0x0000555555556e1b flasher`uart_send(sp=0x0000000000000000, pbtTx="", szTxLen=544) + 123 at uart_posix.c:204
```

This should address a number of compiler warnings on uart files.