### PR TITLE
Fix Open/CloseProxmark issues in PR#607

### DIFF
--- a/client/comms.h
+++ b/client/comms.h
@@ -25,7 +25,8 @@
 void SetOffline(bool new_offline);
 bool IsOffline();
 
-bool OpenProxmark(void *port, bool wait_for_port, int timeout, bool flash_mode);
+bool OpenProxmark(char *portname, bool wait_for_port, int timeout, bool flash_mode);
+void StartProxmark(serial_port port, bool block_after_ack);
 void CloseProxmark(void);
 
 void SendCommand(UsbCommand *c);


### PR DESCRIPTION
Since #463 has been closed with #607 billed as it's replacement, and it doesn't fully address my concerns, this is a new PR to fix [issues that impact making Android support work from Proxmark master](https://github.com/Proxmark/proxmark3/pull/607#issuecomment-394138980):

- StartProxmark split from OpenProxmark, to make it easier to start up the USB communication thread and set the serial port, without also having PM3 try to open the serial port for us. This is useful when PM3 doesn't have a path to a real device, such as with tests with a simulated device, and on Android).

- OpenProxmark now doesn't mutate global state until it has successfully finished.

- CloseProxmark now puts PM3 in offline mode, and clears global state.

- CloseProxmark now checks for a non-null serial_port before calling uart_close, to avoid unintentional double-free'ing serial_port. This fixes a crash-on-exit on OSX.

Things that are _not required or used for Android support,_ but that are related and included in this PR:

- main now calls CloseProxmark once. This fixes a crash-on-exit on OSX.

- OpenProxmark now takes a `char*` argument again, because `CloseProxmark` treats `serial_port_name` as a `char*`.

As I've mentioned before, I'm not looking to replace `comms.c` on Android, and this was never my intent when first submitting the file.  Several pieces of important global state (such as `sp`, `offline`, and `uart_communication`) are stored in this file.

At present, `CloseProxmark` still blindly calls `unlink` on Android, because `#ifdef _LINUX_` still triggers on Android, and this is the only way to shut down the USB communication thread.