### PR TITLE
Fixes a double-free issue in CloseProxmark

### DIFF
--- a/client/comms.c
+++ b/client/comms.c
@@ -334,13 +334,21 @@ bool OpenProxmark(void *port, bool wait_for_port, int timeout, bool flash_mode) 
 void CloseProxmark(void) {
 	conn.run = false;
 	pthread_join(USB_communication_thread, NULL);
-	uart_close(sp);
+
+	if (sp) {
+		uart_close(sp);
+	}
+
 #ifdef __linux__
 	// Fix for linux, it seems that it is extremely slow to release the serial port file descriptor /dev/*
 	if (serial_port_name) {
 		unlink(serial_port_name);
 	}
 #endif
+
+	// Clean up our state
+	sp = NULL;
+	serial_port_name = NULL;
 }
 
 

--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -131,10 +131,6 @@ main_loop(char *script_cmds_file, char *script_cmd, bool usb_present) {
 	}
 
 	write_history(".history");
-
-	if (usb_present) {
-		CloseProxmark();
-	}
 	
 	if (script_file) {
 		fclose(script_file);


### PR DESCRIPTION
- CloseProxmark now clears global state (`sp` and `serial_port_name`).
- CloseProxmark now checks for a non-null `sp` before calling uart_close, to avoid unintentional double-free'ing `sp`.
- main now calls CloseProxmark once.

This fixes a crash-on-exit on OSX. This was split from #615.