### PR TITLE
Allow disabling unlink() with -DNO_UNLINK.

### DIFF
--- a/client/comms.c
+++ b/client/comms.c
@@ -12,7 +12,7 @@
 #include "comms.h"
 
 #include <pthread.h>
-#ifdef __linux__
+#if defined(__linux__) && !defined(NO_UNLINK)
 #include <unistd.h>		// for unlink()
 #endif
 #include "uart.h"
@@ -339,8 +339,10 @@ void CloseProxmark(void) {
 		uart_close(sp);
 	}
 
-#ifdef __linux__
+#if defined(__linux__) && !defined(NO_UNLINK)
 	// Fix for linux, it seems that it is extremely slow to release the serial port file descriptor /dev/*
+	//
+	// This may be disabled at compile-time with -DNO_UNLINK (used for a JNI-based serial port on Android).
 	if (serial_port_name) {
 		unlink(serial_port_name);
 	}


### PR DESCRIPTION
This replaces #615, implementing the method of disabling unlink that @pwpiwi suggested in https://github.com/Proxmark/proxmark3/pull/615#issuecomment-398987420.

**Test method:** (using standard Linux build)

Normal build:

```
$ strings client/proxmark3 | grep -c unlink
3
```

Build with `-DNO_UNLINK` appended to `CFLAGS` in `client/Makefile`:

```
$ strings client/proxmark3 | grep -c unlink
0
```