### PR TITLE
allow common makefile options-defines

### DIFF
--- a/armsrc/Makefile
+++ b/armsrc/Makefile
@@ -10,10 +10,16 @@ APP_INCLUDES = apps.h
 
 #remove one of the following defines and comment out the relevant line
 #in the next section to remove that particular feature from compilation
-APP_CFLAGS	= -DWITH_ISO14443a_StandAlone -DWITH_LF -DWITH_ISO15693 -DWITH_ISO14443a -DWITH_ISO14443b -DWITH_ICLASS -DWITH_LEGICRF -DWITH_HITAG  -DWITH_CRC -DON_DEVICE -DWITH_HFSNOOP \
-				-fno-strict-aliasing -ffunction-sections -fdata-sections
-#-DWITH_LCD
+APP_CFLAGS  = -DON_DEVICE \
+        -fno-strict-aliasing -ffunction-sections -fdata-sections
 
+include ../common/Makefile_Enabled_Options.common
+
+ifneq (,$(findstring LCD,$(APP_CFLAGS)))
+        SRC_LCD = fonts.c LCD.c
+else
+        SRC_LCD = 
+endif
 #SRC_LCD = fonts.c LCD.c
 SRC_LF = lfops.c hitag2.c hitagS.c lfsampling.c pcf7931.c lfdemod.c protocols.c
 SRC_ISO15693 = iso15693.c iso15693tools.c
@@ -21,7 +27,11 @@ SRC_ISO14443a = epa.c iso14443a.c mifareutil.c mifarecmd.c mifaresniff.c mifares
 SRC_ISO14443b = iso14443b.c
 SRC_CRAPTO1 = crypto1.c des.c
 SRC_CRC = iso14443crc.c crc.c crc16.c crc32.c parity.c
-
+ifneq (,$(findstring SMARTCARD,$(APP_CFLAGS)))
+	SRC_SMARTCARD = i2c.c
+else
+	SRC_SMARTCARD = 
+endif
 #the FPGA bitstream files. Note: order matters!
 FPGA_BITSTREAMS = fpga_lf.bit fpga_hf.bit
 
@@ -39,6 +49,7 @@ THUMBSRC = start.c \
 	$(SRC_ISO15693) \
 	$(SRC_LF) \
 	$(SRC_ZLIB) \
+	$(SRC_SMARTCARD) \
 	appmain.c \
 	printf.c \
 	util.c \

--- a/armsrc/Makefile
+++ b/armsrc/Makefile
@@ -16,7 +16,7 @@ APP_CFLAGS  = -DON_DEVICE \
 include ../common/Makefile_Enabled_Options.common
 
 ifneq (,$(findstring LCD,$(APP_CFLAGS)))
-        SRC_LCD = fonts.c LCD.c
+        SRC_LCD = #fonts.c LCD.c
 else
         SRC_LCD = 
 endif
@@ -27,11 +27,6 @@ SRC_ISO14443a = epa.c iso14443a.c mifareutil.c mifarecmd.c mifaresniff.c mifares
 SRC_ISO14443b = iso14443b.c
 SRC_CRAPTO1 = crypto1.c des.c
 SRC_CRC = iso14443crc.c crc.c crc16.c crc32.c parity.c
-ifneq (,$(findstring SMARTCARD,$(APP_CFLAGS)))
-	SRC_SMARTCARD = i2c.c
-else
-	SRC_SMARTCARD = 
-endif
 #the FPGA bitstream files. Note: order matters!
 FPGA_BITSTREAMS = fpga_lf.bit fpga_hf.bit
 
@@ -49,7 +44,6 @@ THUMBSRC = start.c \
 	$(SRC_ISO15693) \
 	$(SRC_LF) \
 	$(SRC_ZLIB) \
-	$(SRC_SMARTCARD) \
 	appmain.c \
 	printf.c \
 	util.c \

--- a/armsrc/Makefile
+++ b/armsrc/Makefile
@@ -16,7 +16,7 @@ APP_CFLAGS  = -DON_DEVICE \
 include ../common/Makefile_Enabled_Options.common
 
 ifneq (,$(findstring LCD,$(APP_CFLAGS)))
-        SRC_LCD = #fonts.c LCD.c
+        SRC_LCD = fonts.c LCD.c
 else
         SRC_LCD = 
 endif

--- a/client/Makefile
+++ b/client/Makefile
@@ -26,11 +26,6 @@ CXXFLAGS = -I../include -Wall -O3
 APP_CFLAGS =
 include ../common/Makefile_Enabled_Options.common
 CFLAGS += $(APP_CFLAGS)
-ifneq (,$(findstring WITH_SMARTCARD,$(APP_CFLAGS)))
-	SRC_SMARTCARD = cmdsmartcard.c
-else
-	SRC_SMARTCARD = 
-endif
 
 LUAPLATFORM = generic
 platform = $(shell uname)
@@ -98,8 +93,7 @@ CORESRCS = 	uart_posix.c \
 			ui.c \
 			comms.c
 
-CMDSRCS = 	$(SRC_SMARTCARD) \
-			crapto1/crapto1.c\
+CMDSRCS = 	crapto1/crapto1.c\
 			crapto1/crypto1.c\
 			polarssl/des.c \
 			polarssl/aes.c\

--- a/client/Makefile
+++ b/client/Makefile
@@ -23,6 +23,15 @@ LDFLAGS = $(ENV_LDFLAGS)
 CFLAGS = $(ENV_CFLAGS) -std=c99 -D_ISOC99_SOURCE -I. -I../include -I../common -I../common/polarssl -I../zlib -I../uart -I/opt/local/include -I../liblua -Wall -g -O3
 CXXFLAGS = -I../include -Wall -O3
 
+APP_CFLAGS =
+include ../common/Makefile_Enabled_Options.common
+CFLAGS += $(APP_CFLAGS)
+ifneq (,$(findstring WITH_SMARTCARD,$(APP_CFLAGS)))
+	SRC_SMARTCARD = cmdsmartcard.c
+else
+	SRC_SMARTCARD = 
+endif
+
 LUAPLATFORM = generic
 platform = $(shell uname)
 ifneq (,$(findstring MINGW,$(platform)))
@@ -37,32 +46,34 @@ else
 	endif
 endif
 
-# Check for correctly configured Qt5
-QTINCLUDES = $(shell pkg-config --cflags Qt5Core Qt5Widgets 2>/dev/null)
-QTLDLIBS = $(shell pkg-config --libs Qt5Core Qt5Widgets 2>/dev/null)
-MOC = $(shell pkg-config --variable=host_bins Qt5Core)/moc
-UIC = $(shell pkg-config --variable=host_bins Qt5Core)/uic
-ifeq ($(QTINCLUDES), )
-# if Qt5 not found check for correctly configured Qt4	
-	QTINCLUDES = $(shell pkg-config --cflags QtCore QtGui 2>/dev/null)
-	QTLDLIBS = $(shell pkg-config --libs QtCore QtGui 2>/dev/null)
-	MOC = $(shell pkg-config --variable=moc_location QtCore)
-	UIC = $(shell pkg-config --variable=uic_location QtCore)
-else
-	CXXFLAGS += -std=c++11 -fPIC
-endif
-ifeq ($(QTINCLUDES), )
-# if both pkg-config commands failed, search in common places
-	ifneq ($(QTDIR), )
-		QTINCLUDES = -I$(QTDIR)/include -I$(QTDIR)/include/QtCore -I$(QTDIR)/include/QtGui
-		QTLDLIBS = -L$(QTDIR)/lib -lQtCore4 -lQtGui4
-		ifneq ($(wildcard $(QTDIR)/include/QtWidgets),)
-			QTINCLUDES += -I$(QTDIR)/include/QtWidgets
-			QTLDLIBS = -L$(QTDIR)/lib -lQt5Widgets -lQt5Gui -lQt5Core
-			CXXFLAGS += -std=c++11 -fPIC
+ifneq (,$(findstring WITH_GUI,$(APP_CFLAGS)))
+	# Check for correctly configured Qt5
+	QTINCLUDES = $(shell pkg-config --cflags Qt5Core Qt5Widgets 2>/dev/null)
+	QTLDLIBS = $(shell pkg-config --libs Qt5Core Qt5Widgets 2>/dev/null)
+	MOC = $(shell pkg-config --variable=host_bins Qt5Core)/moc
+	UIC = $(shell pkg-config --variable=host_bins Qt5Core)/uic
+	ifeq ($(QTINCLUDES), )
+	# if Qt5 not found check for correctly configured Qt4	
+		QTINCLUDES = $(shell pkg-config --cflags QtCore QtGui 2>/dev/null)
+		QTLDLIBS = $(shell pkg-config --libs QtCore QtGui 2>/dev/null)
+		MOC = $(shell pkg-config --variable=moc_location QtCore)
+		UIC = $(shell pkg-config --variable=uic_location QtCore)
+	else
+		CXXFLAGS += -std=c++11 -fPIC
+	endif
+	ifeq ($(QTINCLUDES), )
+	# if both pkg-config commands failed, search in common places
+		ifneq ($(QTDIR), )
+			QTINCLUDES = -I$(QTDIR)/include -I$(QTDIR)/include/QtCore -I$(QTDIR)/include/QtGui
+			QTLDLIBS = -L$(QTDIR)/lib -lQtCore4 -lQtGui4
+			ifneq ($(wildcard $(QTDIR)/include/QtWidgets),)
+				QTINCLUDES += -I$(QTDIR)/include/QtWidgets
+				QTLDLIBS = -L$(QTDIR)/lib -lQt5Widgets -lQt5Gui -lQt5Core
+				CXXFLAGS += -std=c++11 -fPIC
+			endif
+			MOC = $(QTDIR)/bin/moc
+			UIC = $(QTDIR)/bin/uic
 		endif
-		MOC = $(QTDIR)/bin/moc
-		UIC = $(QTDIR)/bin/uic
 	endif
 endif
 
@@ -79,6 +90,7 @@ DEPFLAGS = -MT $@ -MMD -MP -MF $(OBJDIR)/$*.Td
 # make temporary to final dependeny files after successful compilation
 POSTCOMPILE = $(MV) -f $(OBJDIR)/$*.Td $(OBJDIR)/$*.d
 
+
 CORESRCS = 	uart_posix.c \
 			uart_win32.c \
 			util.c \
@@ -86,7 +98,8 @@ CORESRCS = 	uart_posix.c \
 			ui.c \
 			comms.c
 
-CMDSRCS = 	crapto1/crapto1.c\
+CMDSRCS = 	$(SRC_SMARTCARD) \
+			crapto1/crapto1.c\
 			crapto1/crypto1.c\
 			polarssl/des.c \
 			polarssl/aes.c\
@@ -302,6 +315,7 @@ $(OBJDIR)/%.o : %.cpp $(OBJDIR)/%.d
 DEPENDENCY_FILES = $(patsubst %.c, $(OBJDIR)/%.d, $(CORESRCS) $(CMDSRCS) $(ZLIBSRCS) $(MULTIARCHSRCS)) \
 	$(patsubst %.cpp, $(OBJDIR)/%.d, $(QTGUISRCS)) \
 	$(OBJDIR)/proxmark3.d $(OBJDIR)/flash.d $(OBJDIR)/flasher.d $(OBJDIR)/fpga_compress.d
+
 
 $(DEPENDENCY_FILES): ;
 .PRECIOUS: $(DEPENDENCY_FILES)

--- a/common/Makefile_Enabled_Options.common
+++ b/common/Makefile_Enabled_Options.common
@@ -1,0 +1,40 @@
+#NOTES: 
+#  Do not put any comments inside the definition below (before the final flag)
+#  All definition lines except the last must end in a \
+#  
+#BEGIN
+APP_CFLAGS += -DWITH_ISO14443a_StandAlone \
+        -DWITH_ISO15693 \
+        -DWITH_ISO14443a \
+        -DWITH_ISO14443b \
+        -DWITH_ICLASS \
+        -DWITH_LEGICRF \
+        -DWITH_HITAG \
+        -DWITH_CRC \
+        -DWITH_HFSNOOP \
+        -DWITH_GUI
+#END
+
+#-DWITH_LCD
+        
+### Standalone modes:
+#-DWITH_ISO14443a_StandAlone
+#-DWITH_LF
+#
+# if both WITH_LF and WITH_ISO4443a_StandAlone are defined
+#   ISO14443a_StandAlone will be the only one that runs 
+#   You must remove it and define WITH_LF for LF standalone mode
+
+### Other options:
+#-DWITH_ISO15693  \ Include ISO15693 support in build
+#-DWITH_ISO14443a \ include ISO14443a support in build
+#-DWITH_ISO14443b \ include ISO14443b support in build
+#-DWITH_ICLASS    \ include ICLASS support in build
+#-DWITH_LEGICRF   \ include LEGIC support in build
+#-DWITH_HITAG     \ include HITAG support in build
+#-DWITH_CRC       \ include CRC support in build
+#-DWITH_HFSNOOP   \ include HFSNOOP support in build
+#-DWITH_SMARTCARD \ include SMARTCARD support in build
+#-DWITH_GUI       \ include QT GUI/Graph support in build
+
+#marshmellow NOTE: tested GUI, and SMARTCARD removal only...

--- a/common/Makefile_Enabled_Options.common
+++ b/common/Makefile_Enabled_Options.common
@@ -15,7 +15,6 @@ APP_CFLAGS += -DWITH_ISO14443a_StandAlone \
         -DWITH_GUI
 #END
 
-#-DWITH_LCD
         
 ### Standalone modes:
 #-DWITH_ISO14443a_StandAlone
@@ -36,5 +35,6 @@ APP_CFLAGS += -DWITH_ISO14443a_StandAlone \
 #-DWITH_HFSNOOP   \ include HFSNOOP support in build
 #-DWITH_SMARTCARD \ include SMARTCARD support in build
 #-DWITH_GUI       \ include QT GUI/Graph support in build
+#-DWITH_LCD       \ include LCD support in build (experimental?)
 
 #marshmellow NOTE: tested GUI, and SMARTCARD removal only...


### PR DESCRIPTION
this is so the client also knows what features are available after compile.  
makes it easier to turn on and off features if and when needed.

this will come more in handy as alternative hardware continues to pop up (RV4).  we can create features that are only available for specific hardware and include or exclude them in the new Makefile_Enabled_Options.common file.

one example is smartcard addon that the RV4 has.