### PR TITLE
Improved long HID support; Added 48 bit card and parity for 35 and 48 bit cards.

### DIFF
--- a/client/cmdlfhid.h
+++ b/client/cmdlfhid.h
@@ -14,7 +14,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-// Structure for unpacked "short" (<38 bits) HID Prox tags.
+// Structure for unpacked HID Prox tags.
 typedef struct {
   // Format length, in bits.
   uint8_t fmtLen;
@@ -23,43 +23,20 @@ typedef struct {
   uint32_t fc;
 
   // Card number.
-  uint32_t cardnum;
-
-  // Parity validity.
-  //
-  // When used with pack_short_hid, this determines if we should calculate
-  // parity values for the ID.
-  //
-  // When used with unpack_short_hid, this indicates if we got valid parity
-  // values for the ID.
-  bool parityValid;
-} short_hid_info;
-
-// Structure for unpacked "long" (>37 bits) HID Prox tags.
-typedef struct {
-  // Format length, in bits.
-  uint8_t fmtLen;
-
-  // Facility code.
-  uint64_t fc;
-
-  // Card number.
   uint64_t cardnum;
 
   // Parity validity.
   //
-  // When used with pack_long_hid, this determines if we should calculate
+  // When used with pack_hid, this determines if we should calculate
   // parity values for the ID.
   //
-  // When used with unpack_long_hid, this indicates if we got valid parity
+  // When used with unpack_hid, this indicates if we got valid parity
   // values for the ID.
   bool parityValid;
-} long_hid_info;
+} hid_info;
 
-bool pack_short_hid(/* out */ uint32_t *hi, /* out */ uint32_t *lo, /* in */ const short_hid_info *info);
-bool pack_long_hid(/* out */ uint32_t *hi2, /* out */ uint32_t *hi, /* out */ uint32_t *lo, /* in */ const long_hid_info *info);
-bool unpack_short_hid(short_hid_info* out, uint32_t hi, uint32_t lo);
-bool unpack_long_hid(long_hid_info* out, uint32_t hi2, uint32_t hi, uint32_t lo);
+bool pack_hid(/* out */ uint32_t *hi2, /* out */ uint32_t *hi, /* out */ uint32_t *lo, /* in */ const hid_info *info);
+bool unpack_hid(hid_info* out, uint32_t hi2, uint32_t hi, uint32_t lo);
 
 
 int CmdLFHID(const char *Cmd);

--- a/client/cmdlfhid.h
+++ b/client/cmdlfhid.h
@@ -35,8 +35,32 @@ typedef struct {
   bool parityValid;
 } short_hid_info;
 
+// Structure for unpacked "long" (>37 bits) HID Prox tags.
+typedef struct {
+  // Format length, in bits.
+  uint8_t fmtLen;
+
+  // Facility code.
+  uint64_t fc;
+
+  // Card number.
+  uint64_t cardnum;
+
+  // Parity validity.
+  //
+  // When used with pack_long_hid, this determines if we should calculate
+  // parity values for the ID.
+  //
+  // When used with unpack_long_hid, this indicates if we got valid parity
+  // values for the ID.
+  bool parityValid;
+} long_hid_info;
+
 bool pack_short_hid(/* out */ uint32_t *hi, /* out */ uint32_t *lo, /* in */ const short_hid_info *info);
+bool pack_long_hid(/* out */ uint32_t *hi2, /* out */ uint32_t *hi, /* out */ uint32_t *lo, /* in */ const long_hid_info *info);
 bool unpack_short_hid(short_hid_info* out, uint32_t hi, uint32_t lo);
+bool unpack_long_hid(long_hid_info* out, uint32_t hi2, uint32_t hi, uint32_t lo);
+
 
 int CmdLFHID(const char *Cmd);
 int CmdFSKdemodHID(const char *Cmd);


### PR DESCRIPTION
Since I've been seeing more > 37-bit tags in use, I think it makes sense to add better support for them. In that regard, I've adapted the code to properly identify and parse long tags seamlessly alongside short tags. 

Parity support has been added for 35-bit (HID Corporate 1000) and 48-bit (HID Corporate 1000) tags as well as the ability to pack and unpack the latter. This set of updates also does away with the "l" flag for cloning HID tags, since the routine now automatically detects if the long format is necessary based on the packed data. Packing does not prepend the 0x09e... header for long tags, since this information must be stripped prior to the clone operation anyway.

This set of changes does not address the inability to simulate long HID tags, as this would also require a firmware update.

**Patch testing**
     I've tested the updated client with multiple card types including the added cards. Generated 35 and 48 bit tags (on T5557 cards) are read correctly and reliably by HID card readers.
