### PR TITLE
client: lf hid - parity completed, native long-tag support in pack/unpack/clone

### DIFF
--- a/client/cmdlfhid.h
+++ b/client/cmdlfhid.h
@@ -14,7 +14,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-// Structure for unpacked "short" (<38 bits) HID Prox tags.
+// Structure for unpacked HID Prox tags.
 typedef struct {
   // Format length, in bits.
   uint8_t fmtLen;
@@ -23,20 +23,21 @@ typedef struct {
   uint32_t fc;
 
   // Card number.
-  uint32_t cardnum;
+  uint64_t cardnum;
 
   // Parity validity.
   //
-  // When used with pack_short_hid, this determines if we should calculate
+  // When used with pack_hid, this determines if we should calculate
   // parity values for the ID.
   //
-  // When used with unpack_short_hid, this indicates if we got valid parity
+  // When used with unpack_hid, this indicates if we got valid parity
   // values for the ID.
   bool parityValid;
-} short_hid_info;
+} hid_info;
 
-bool pack_short_hid(/* out */ uint32_t *hi, /* out */ uint32_t *lo, /* in */ const short_hid_info *info);
-bool unpack_short_hid(short_hid_info* out, uint32_t hi, uint32_t lo);
+bool pack_hid(/* out */ uint32_t *hi2, /* out */ uint32_t *hi, /* out */ uint32_t *lo, /* in */ const hid_info *info);
+bool unpack_hid(hid_info* out, uint32_t hi2, uint32_t hi, uint32_t lo);
+
 
 int CmdLFHID(const char *Cmd);
 int CmdFSKdemodHID(const char *Cmd);


### PR DESCRIPTION
Included in this update:

* Parity calculation has been completed for all HID formats previously programmed.
* Support for packing/unpacking long-tag HID Corporate 1000 48-bit has been added.
* Removal of the 'l' (long) flag on clone (now autodetected)

Please note that simulation of long HID tags is still not directly supported, as that feature requires a change to the embedded firmware in addition to client updates.