### PR TITLE
Legic: rewrite reader to use xcorrelation and precise timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Changed `hf 14a reader` to just reqest-anticilission-select sequence (Merlok)
 - Changed `hf 14a raw` - works with LED's and some exchange logic (Merlok)
 - Changed TLV parser messages to more convenient (Merlok)
+- Rewritten Legic Prime reader (`hf legic reader`, `write` and `fill`) - it is using xcorrelation now (AntiCat)
 
 ### Fixed
 - Changed start sequence in Qt mode (fix: short commands hangs main Qt thread) (Merlok)

--- a/armsrc/legicrf.c
+++ b/armsrc/legicrf.c
@@ -141,7 +141,7 @@ static inline int32_t sample_power() {
 static inline bool rx_bit_as_reader() {
   int32_t power;
 
-  for(size_t i = 0; i<5; ++i) {
+  for(size_t i = 0; i<3; ++i) {
     power = sample_power();
   }
 
@@ -216,6 +216,7 @@ static uint32_t rx_frame_as_reader(uint8_t len) {
 
     // rx_bit_as_reader runs only 95us, resync to TAG_BIT_PERIOD
     last_frame_end += TAG_BIT_PERIOD;
+    while(GET_TICKS < last_frame_end) { };
   }
 
   return frame;
@@ -239,6 +240,7 @@ static bool rx_ack_as_reader() {
 
     // rx_bit_as_reader runs only 95us, resync to TAG_BIT_PERIOD
     last_frame_end += TAG_BIT_PERIOD;
+    while(GET_TICKS < last_frame_end) { };
 
     // check if it was an ACK
     if(ack) {

--- a/armsrc/legicrf.c
+++ b/armsrc/legicrf.c
@@ -107,45 +107,46 @@ static inline uint8_t rx_byte_from_fpga() {
 // Demodulation (Reader)
 //-----------------------------------------------------------------------------
 
-// Returns am aproximated power measurement
+// Returns a demedulated bit
 //
 // The FPGA running xcorrelation samples the subcarrier at ~13.56 MHz. The mode
 // was initialy designed to receive BSPK/2-PSK. Hance, it reports an I/Q pair
-// every 4.7us (8 bits i and 8 bits q). We use the average of 4 samples.
+// every 4.7us (8 bits i and 8 bits q).
 //
 // The subcarrier amplitude can be calculated using Pythagoras sqrt(i^2 + q^2).
 // To reduce CPU time the amplitude is approximated by using linear functions:
 //   am = MAX(ABS(i),ABS(q)) + 1/2*MIN(ABS(i),ABSq))
 //
 // Note: The SSC receiver is never synchronized the calculation my be performed
-// on a i/q pair from two subsequent correlations, but does not matter.
-static inline int32_t sample_power() {
+// on a I/Q pair from two subsequent correlations, but does not matter.
+//
+// The bit time is 99.1us (21 I/Q pairs). The receiver skips the first 5 samples
+// and averages the next (most stable) 8 samples. The final 8 samples are dropped
+// also.
+//
+// The demedulated should be alligned to the bit periode by the caller. This is
+// done in rx_bit_as_reader and rx_ack_as_reader.
+static inline bool rx_bit_as_reader() {
   int32_t cq = 0;
   int32_t ci = 0;
 
-  for(size_t i = 0; i<4; i++) {
+  // skip first 5 I/Q pairs
+  for(size_t i = 0; i<5; ++i) {
+    (int8_t)rx_byte_from_fpga();
+    (int8_t)rx_byte_from_fpga();
+  }
+
+  // sample next 8 I/Q pairs
+  for(size_t i = 0; i<8; ++i) {
     cq += (int8_t)rx_byte_from_fpga();
     ci += (int8_t)rx_byte_from_fpga();
   }
 
-  return (MAX(ABS(ci), ABS(cq)) + (MIN(ABS(ci), ABS(cq)) >> 1)) >> 2;
-}
+  // calculate power
+  int32_t power = (MAX(ABS(ci), ABS(cq)) + (MIN(ABS(ci), ABS(cq)) >> 1));
 
-// Returns a demedulated bit
-//
-// An aproximated power measurement is available every 18.9us. The bit time
-// is 100us. The code samples 5 times and uses the last (most stable) sample.
-//
-// Note: The demodulator would be drifting (18.9us * 5 != 100us), rx_frame_as_reader
-// has a delay loop that aligns rx_bit_as_reader calls to the TAG tx timeslots.
-static inline bool rx_bit_as_reader() {
-  int32_t power;
-
-  for(size_t i = 0; i<3; ++i) {
-    power = sample_power();
-  }
-
-  return (power > INPUT_THRESHOLD);
+  // compare average (power / 8) to threshold
+  return ((power >> 3) > INPUT_THRESHOLD);
 }
 
 //-----------------------------------------------------------------------------

--- a/armsrc/legicrf.c
+++ b/armsrc/legicrf.c
@@ -1,5 +1,7 @@
 //-----------------------------------------------------------------------------
 // (c) 2009 Henryk Plötz <henryk@ploetzli.ch>
+//     2016 Iceman
+//     2018 AntiCat (rwd rewritten)
 //
 // This code is licensed to you under the terms of the GNU GPL, version 2 or,
 // at your option, any later version. See the LICENSE.txt file for the text of
@@ -15,6 +17,7 @@
 
 #include "legicrf.h"
 #include "legic_prng.h"
+#include "legic.h"
 #include "crc.h"
 
 static struct legic_frame {
@@ -40,6 +43,457 @@ static int      legic_reqresp_drift;
 AT91PS_TC timer;
 AT91PS_TC prng_timer;
 
+static legic_card_select_t card;/* metadata of currently selected card */
+
+//-----------------------------------------------------------------------------
+// Frame timing and pseudorandom number generator
+//
+// The Prng is forwarded every 100us (TAG_BIT_PERIOD), except when the reader is
+// transmitting. In that case the prng has to be forwarded every bit transmitted:
+//  - 60us for a 0 (RWD_TIME_0)
+//  - 100us for a 1 (RWD_TIME_1)
+//
+// The data dependent timing makes writing comprehensible code significantly
+// harder. The current aproach forwards the prng data based if there is data on
+// air and time based, using GET_TICKS, during computational and wait periodes.
+//
+// To not have the necessity to calculate/guess exection time dependend timeouts
+// tx_frame and rx_frame use a shared timestamp to coordinate tx and rx timeslots.
+//-----------------------------------------------------------------------------
+
+static uint32_t last_frame_end; /* ts of last bit of previews rx or tx frame */
+
+#define RWD_TIME_PAUSE       30 /* 20us */
+#define RWD_TIME_1          150 /* READER_TIME_PAUSE 20us off + 80us on = 100us */
+#define RWD_TIME_0           90 /* READER_TIME_PAUSE 20us off + 40us on = 60us */
+#define RWD_FRAME_WAIT      330 /* 220us from TAG frame end to READER frame start */
+#define TAG_FRAME_WAIT      495 /* 330us from READER frame end to TAG frame start */
+#define TAG_BIT_PERIOD      150 /* 100us */
+#define TAG_WRITE_TIMEOUT    60 /* 40 * 100us (write should take at most 3.6ms) */
+
+#define SIM_DIVISOR         586 /* prng_time/DIV count prng needs to be forwared */
+#define SIM_SHIFT           900 /* prng_time+SHIFT shift of delayed start */
+#define RWD_TIME_FUZZ        20 /* rather generous 13us, since the peak detector
+                                /+ hysteresis fuzz quite a bit */
+
+#define LEGIC_READ         0x01 /* Read Command */
+#define LEGIC_WRITE        0x00 /* Write Command */
+
+#define SESSION_IV         0x55 /* An arbitrary chose session IV, all shoud work */
+#define OFFSET_LOG         1024 /* The largest Legic Prime card is 1k */
+#define WRITE_LOWERLIMIT      4 /* UID and MCC are not writable */
+
+#define INPUT_THRESHOLD       8 /* heuristically determined, lower values */
+                                /* lead to detecting false ack during write */
+
+#define FUZZ_EQUAL(value, target, fuzz) ((value) > ((target)-(fuzz)) && (value) < ((target)+(fuzz)))
+
+//-----------------------------------------------------------------------------
+// I/O interface abstraction (FPGA -> ARM)
+//-----------------------------------------------------------------------------
+
+static inline uint8_t rx_byte_from_fpga() {
+  for(;;) {
+    WDT_HIT();
+
+    // wait for byte be become available in rx holding register
+    if(AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_RXRDY)) {
+      return AT91C_BASE_SSC->SSC_RHR;
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+// Demodulation (Reader)
+//-----------------------------------------------------------------------------
+
+// Returns am aproximated power measurement
+//
+// The FPGA running xcorrelation samples the subcarrier at ~13.56 MHz. The mode
+// was initialy designed to receive BSPK/2-PSK. Hance, it reports an I/Q pair
+// every 4.7us (8 bits i and 8 bits q). We use the average of 4 samples.
+//
+// The subcarrier amplitude can be calculated using Pythagoras sqrt(i^2 + q^2).
+// To reduce CPU time the amplitude is approximated by using linear functions:
+//   am = MAX(ABS(i),ABS(q)) + 1/2*MIN(ABS(i),ABSq))
+//
+// Note: The SSC receiver is never synchronized the calculation my be performed
+// on a i/q pair from two subsequent correlations, but does not matter.
+static inline int32_t sample_power() {
+  int32_t cq = 0;
+  int32_t ci = 0;
+
+  for(size_t i = 0; i<4; i++) {
+    cq += (int8_t)rx_byte_from_fpga();
+    ci += (int8_t)rx_byte_from_fpga();
+  }
+
+  return (MAX(ABS(ci), ABS(cq)) + (MIN(ABS(ci), ABS(cq)) >> 1)) >> 2;
+}
+
+// Returns a demedulated bit
+//
+// An aproximated power measurement is available every 18.9us. The bit time
+// is 100us. The code samples 5 times and uses the last (most stable) sample.
+//
+// Note: The demodulator would be drifting (18.9us * 5 != 100us), rx_frame_as_reader
+// has a delay loop that aligns rx_bit_as_reader calls to the TAG tx timeslots.
+static inline bool rx_bit_as_reader() {
+  int32_t power;
+
+  for(size_t i = 0; i<5; ++i) {
+    power = sample_power();
+  }
+
+  return (power > INPUT_THRESHOLD);
+}
+
+//-----------------------------------------------------------------------------
+// Modulation (Reader)
+//
+// I've tried to modulate the Legic specific pause-puls using ssc and the default
+// ssc clock of 105.4 kHz (bit periode of 9.4us) - previous commit. However,
+// the timing was not precise enough. By increasing the ssc clock this could
+// be circumvented, but the adventage over bitbang would be little.
+//-----------------------------------------------------------------------------
+
+static inline void tx_bit_as_reader(bool bit) {
+  // insert pause
+  LOW(GPIO_SSC_DOUT);
+  last_frame_end += RWD_TIME_PAUSE;
+  while(GET_TICKS < last_frame_end) { };
+  HIGH(GPIO_SSC_DOUT);
+
+  // return to high, wait for bit periode to end
+  last_frame_end += (bit ? RWD_TIME_1 : RWD_TIME_0) - RWD_TIME_PAUSE;
+  while(GET_TICKS < last_frame_end) { };
+}
+
+//-----------------------------------------------------------------------------
+// Frame Handling (Reader)
+//
+// The LEGIC RF protocol from card to reader does not include explicit frame
+// start/stop information or length information. The reader must know beforehand
+// how many bits it wants to receive.
+// Notably: a card sending a stream of 0-bits is indistinguishable from no card
+// present.
+//-----------------------------------------------------------------------------
+
+static void tx_frame_as_reader(uint32_t frame, uint8_t len) {
+  FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_READER_TX);
+
+  // wait for next tx timeslot
+  last_frame_end += RWD_FRAME_WAIT;
+  while(GET_TICKS < last_frame_end) { };
+
+  // transmit frame, MSB first
+  for(uint8_t i = 0; i < len; ++i) {
+    bool bit = (frame >> i) & 0x01;
+    tx_bit_as_reader(bit ^ legic_prng_get_bit());
+    legic_prng_forward(1);
+  };
+
+  // add pause to mark end of the frame
+  LOW(GPIO_SSC_DOUT);
+  last_frame_end += RWD_TIME_PAUSE;
+  while(GET_TICKS < last_frame_end) { };
+  HIGH(GPIO_SSC_DOUT);
+}
+
+static uint32_t rx_frame_as_reader(uint8_t len) {
+  FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_READER_RX_XCORR
+                  | FPGA_HF_READER_RX_XCORR_848_KHZ
+                  | FPGA_HF_READER_RX_XCORR_QUARTER_FREQ);
+
+  // hold sampling until card is expected to respond
+  last_frame_end += TAG_FRAME_WAIT;
+  while(GET_TICKS < last_frame_end) { };
+
+  uint32_t frame = 0;
+  for(uint8_t i = 0; i < len; i++) {
+    frame |= (rx_bit_as_reader() ^ legic_prng_get_bit()) << i;
+    legic_prng_forward(1);
+
+    // rx_bit_as_reader runs only 95us, resync to TAG_BIT_PERIOD
+    last_frame_end += TAG_BIT_PERIOD;
+  }
+
+  return frame;
+}
+
+static bool rx_ack_as_reader() {
+  // change fpga into rx mode
+  FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_READER_RX_XCORR
+                  | FPGA_HF_READER_RX_XCORR_848_KHZ
+                  | FPGA_HF_READER_RX_XCORR_QUARTER_FREQ);
+
+  // hold sampling until card is expected to respond
+  last_frame_end += TAG_FRAME_WAIT;
+  while(GET_TICKS < last_frame_end) { };
+
+  uint32_t ack = 0;
+  for(uint8_t i = 0; i < TAG_WRITE_TIMEOUT; ++i) {
+    // sample bit
+    ack = rx_bit_as_reader();
+    legic_prng_forward(1);
+
+    // rx_bit_as_reader runs only 95us, resync to TAG_BIT_PERIOD
+    last_frame_end += TAG_BIT_PERIOD;
+
+    // check if it was an ACK
+    if(ack) {
+      break;
+    }
+  }
+
+  return ack;
+}
+
+//-----------------------------------------------------------------------------
+// Legic Reader
+//-----------------------------------------------------------------------------
+
+int init_card(uint8_t cardtype, legic_card_select_t *p_card) {
+  p_card->tagtype = cardtype;
+
+  switch(p_card->tagtype) {
+    case 0x0d:
+      p_card->cmdsize = 6;
+      p_card->addrsize = 5;
+      p_card->cardsize = 22;
+      break;
+    case 0x1d:
+      p_card->cmdsize = 9;
+      p_card->addrsize = 8;
+      p_card->cardsize = 256;
+      break;
+    case 0x3d:
+      p_card->cmdsize = 11;
+      p_card->addrsize = 10;
+      p_card->cardsize = 1024;
+      break;
+    default:
+      p_card->cmdsize = 0;
+      p_card->addrsize = 0;
+      p_card->cardsize = 0;
+      return 2;
+  }
+  return 0;
+}
+
+static void init_reader(bool clear_mem) {
+  // configure FPGA
+  FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
+  FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_READER_RX_XCORR
+                  | FPGA_HF_READER_RX_XCORR_848_KHZ
+                  | FPGA_HF_READER_RX_XCORR_QUARTER_FREQ);
+  SetAdcMuxFor(GPIO_MUXSEL_HIPKD);
+  LED_D_ON();
+
+  // configure SSC with defaults
+  FpgaSetupSsc();
+
+  // re-claim GPIO_SSC_DOUT as GPIO and enable output
+  AT91C_BASE_PIOA->PIO_OER = GPIO_SSC_DOUT;
+  AT91C_BASE_PIOA->PIO_PER = GPIO_SSC_DOUT;
+  HIGH(GPIO_SSC_DOUT);
+
+  // init crc calculator
+  crc_init(&legic_crc, 4, 0x19 >> 1, 0x05, 0);
+
+  // start us timer
+  StartTicks();
+}
+
+// Setup reader to card connection
+//
+// The setup consists of a three way handshake:
+//  - Transmit initialisation vector 7 bits
+//  - Receive card type 6 bits
+//  - Acknowledge frame 6 bits
+static uint32_t setup_phase_reader(uint8_t iv) {
+  // init coordination timestamp
+  last_frame_end = GET_TICKS;
+
+  // Switch on carrier and let the card charge for 5ms.
+  last_frame_end += 7500;
+  while(GET_TICKS < last_frame_end) { };
+
+  legic_prng_init(0);
+  tx_frame_as_reader(iv, 7);
+
+  // configure iv
+  legic_prng_init(iv);
+  legic_prng_forward(2);
+
+  // receive card type
+  int32_t card_type = rx_frame_as_reader(6);
+  legic_prng_forward(3);
+
+  // send obsfuscated acknowledgment frame
+  switch (card_type) {
+    case 0x0D:
+      tx_frame_as_reader(0x19, 6); // MIM22 | READCMD = 0x18 | 0x01
+      break;
+    case 0x1D:
+    case 0x3D:
+      tx_frame_as_reader(0x39, 6); // MIM256 | READCMD = 0x38 | 0x01
+      break;
+  }
+
+  return card_type;
+}
+
+static uint8_t calc_crc4(uint16_t cmd, uint8_t cmd_sz, uint8_t value) {
+  crc_clear(&legic_crc);
+  crc_update(&legic_crc, (value << cmd_sz) | cmd, 8 + cmd_sz);
+  return crc_finish(&legic_crc);
+}
+
+static int16_t read_byte(uint16_t index, uint8_t cmd_sz) {
+  uint16_t cmd = (index << 1) | LEGIC_READ;
+
+  // read one byte
+  LED_B_ON();
+  legic_prng_forward(2);
+  tx_frame_as_reader(cmd, cmd_sz);
+  legic_prng_forward(2);
+  uint32_t frame = rx_frame_as_reader(12);
+  LED_B_OFF();
+
+  // split frame into data and crc
+  uint8_t byte = BYTEx(frame, 0);
+  uint8_t crc = BYTEx(frame, 1);
+
+  // check received against calculated crc
+  uint8_t calc_crc = calc_crc4(cmd, cmd_sz, byte);
+  if(calc_crc != crc) {
+    Dbprintf("!!! crc mismatch: %x != %x !!!",  calc_crc, crc);
+    return -1;
+  }
+
+  legic_prng_forward(1);
+
+  return byte;
+}
+
+// Transmit write command, wait until (3.6ms) the tag sends back an unencrypted
+// ACK ('1' bit) and forward the prng time based.
+bool write_byte(uint16_t index, uint8_t byte, uint8_t addr_sz) {
+  uint32_t cmd = index << 1 | LEGIC_WRITE;          // prepare command
+  uint8_t  crc = calc_crc4(cmd, addr_sz + 1, byte); // calculate crc
+  cmd |= byte << (addr_sz + 1);                     // append value
+  cmd |= (crc & 0xF) << (addr_sz + 1 + 8);          // and crc
+
+  // send write command
+  LED_C_ON();
+  legic_prng_forward(2);
+  tx_frame_as_reader(cmd, addr_sz + 1 + 8 + 4); // sz = addr_sz + cmd + data + crc
+  legic_prng_forward(3);
+  LED_C_OFF();
+
+  // wait for ack
+  return rx_ack_as_reader();
+}
+
+//-----------------------------------------------------------------------------
+// Command Line Interface
+//
+// Only this functions are public / called from appmain.c
+//-----------------------------------------------------------------------------
+void LegicRfReader(int offset, int bytes) {
+  uint8_t *BigBuf = BigBuf_get_addr();
+  memset(BigBuf, 0, 1024);
+
+  // configure ARM and FPGA
+  init_reader(false);
+
+  // establish shared secret and detect card type
+  DbpString("Reading card ...");
+  uint8_t card_type = setup_phase_reader(SESSION_IV);
+  if(init_card(card_type, &card) != 0) {
+    Dbprintf("No or unknown card found, aborting");
+    goto OUT;
+  }
+
+  // if no argument is specified create full dump
+  if(bytes == -1) {
+    bytes = card.cardsize;
+  }
+
+  // do not read beyond card memory
+  if(bytes + offset > card.cardsize) {
+    bytes = card.cardsize - offset;
+  }
+
+  for(uint16_t i = 0; i < bytes; ++i) {
+    int16_t byte = read_byte(offset + i, card.cmdsize);
+    if(byte == -1) {
+      Dbprintf("operation failed @ 0x%03.3x", bytes);
+      goto OUT;
+    }
+    BigBuf[i] = byte;
+  }
+
+  // OK
+  Dbprintf("Card (MIM %i) read, use 'hf legic decode' or", card.cardsize);
+  Dbprintf("'data hexsamples %d' to view results", (bytes+7) & ~7);
+
+OUT:
+  FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
+  LED_B_OFF();
+  LED_C_OFF();
+  LED_D_OFF();
+  StopTicks();
+}
+
+void LegicRfWriter(int bytes, int offset) {
+  uint8_t *BigBuf = BigBuf_get_addr();
+
+  // configure ARM and FPGA
+  init_reader(false);
+
+  // uid is not writeable
+  if(offset <= WRITE_LOWERLIMIT) {
+    goto OUT;
+  }
+
+  // establish shared secret and detect card type
+  Dbprintf("Writing 0x%02.2x - 0x%02.2x ...", offset, offset+bytes);
+  uint8_t card_type = setup_phase_reader(SESSION_IV);
+  if(init_card(card_type, &card) != 0) {
+    Dbprintf("No or unknown card found, aborting");
+    goto OUT;
+  }
+
+  // do not write beyond card memory
+  if(bytes + offset > card.cardsize) {
+    bytes = card.cardsize - offset;
+  }
+
+  // write in reverse order, only then is DCF (decremental field) writable
+  while(bytes-- > 0 && !BUTTON_PRESS()) {
+    if(!write_byte(bytes + offset, BigBuf[bytes], card.addrsize)) {
+      Dbprintf("operation failed @ 0x%03.3x", bytes);
+      goto OUT;
+    }
+  }
+
+  // OK
+  DbpString("Write successful");
+
+OUT:
+  FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
+  LED_B_OFF();
+  LED_C_OFF();
+  LED_D_OFF();
+  StopTicks();
+}
+
+//-----------------------------------------------------------------------------
+// Legic Simulator
+//-----------------------------------------------------------------------------
+
 static void setup_timer(void)
 {
 	/* Set up Timer 1 to use for measuring time between pulses. Since we're bit-banging
@@ -61,22 +515,6 @@ static void setup_timer(void)
 	prng_timer->TC_CMR = AT91C_TC_CLKS_TIMER_DIV2_CLOCK;
     prng_timer->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
 }
-
-/* At TIMER_CLOCK3 (MCK/32) */
-#define	RWD_TIME_1 150     /* RWD_TIME_PAUSE off, 80us on = 100us */
-#define RWD_TIME_0 90      /* RWD_TIME_PAUSE off, 40us on = 60us */
-#define RWD_TIME_PAUSE 30  /* 20us */
-#define RWD_TIME_FUZZ 20   /* rather generous 13us, since the peak detector + hysteresis fuzz quite a bit */
-#define TAG_TIME_BIT 150   /* 100us for every bit */
-#define TAG_TIME_WAIT 490  /* time from RWD frame end to tag frame start, experimentally determined */
-
-#define SIM_DIVISOR  586   /* prng_time/SIM_DIVISOR count prng needs to be forwared */
-#define SIM_SHIFT    900   /* prng_time+SIM_SHIFT shift of delayed start */
-
-#define SESSION_IV 0x55
-#define OFFSET_LOG 1024
-
-#define FUZZ_EQUAL(value, target, fuzz) ((value) > ((target)-(fuzz)) && (value) < ((target)+(fuzz)))
 
 /* Generate Keystream */
 static uint32_t get_key_stream(int skip, int count)
@@ -138,11 +576,11 @@ static void frame_send_tag(uint16_t response, int bits, int crypt)
    }
 
    /* Wait for the frame start */
-   while(timer->TC_CV < (TAG_TIME_WAIT - 30)) ;
+   while(timer->TC_CV < (TAG_FRAME_WAIT - 30)) ;
        
    int i;
    for(i=0; i<bits; i++) {
-      int nextbit = timer->TC_CV + TAG_TIME_BIT;
+      int nextbit = timer->TC_CV + TAG_BIT_PERIOD;
       int bit = response & 1;
       response = response >> 1;
       if(bit) {
@@ -153,126 +591,6 @@ static void frame_send_tag(uint16_t response, int bits, int crypt)
       while(timer->TC_CV < nextbit) ;
    }
    AT91C_BASE_PIOA->PIO_CODR = GPIO_SSC_DOUT;
-}
-
-/* Send a frame in reader mode, the FPGA must have been set up by
- * LegicRfReader
- */
-static void frame_send_rwd(uint32_t data, int bits)
-{
-	/* Start clock */
-	timer->TC_CCR = AT91C_TC_CLKEN | AT91C_TC_SWTRG;
-	while(timer->TC_CV > 1) ; /* Wait till the clock has reset */
-
-	int i;
-	for(i=0; i<bits; i++) {
-		int starttime = timer->TC_CV;
-		int pause_end = starttime + RWD_TIME_PAUSE, bit_end;
-		int bit = data & 1;
-		data = data >> 1;
-
-		if(bit ^ legic_prng_get_bit()) {
-			bit_end = starttime + RWD_TIME_1;
-		} else {
-			bit_end = starttime + RWD_TIME_0;
-		}
-
-		/* RWD_TIME_PAUSE time off, then some time on, so that the complete bit time is
-		 * RWD_TIME_x, where x is the bit to be transmitted */
-		AT91C_BASE_PIOA->PIO_CODR = GPIO_SSC_DOUT;
-		while(timer->TC_CV < pause_end) ;
-		AT91C_BASE_PIOA->PIO_SODR = GPIO_SSC_DOUT;
-		legic_prng_forward(1); /* bit duration is longest. use this time to forward the lfsr */
-
-		while(timer->TC_CV < bit_end) ;
-	}
-
-	{
-		/* One final pause to mark the end of the frame */
-		int pause_end = timer->TC_CV + RWD_TIME_PAUSE;
-		AT91C_BASE_PIOA->PIO_CODR = GPIO_SSC_DOUT;
-		while(timer->TC_CV < pause_end) ;
-		AT91C_BASE_PIOA->PIO_SODR = GPIO_SSC_DOUT;
-	}
-
-	/* Reset the timer, to measure time until the start of the tag frame */
-	timer->TC_CCR = AT91C_TC_SWTRG;
-	while(timer->TC_CV > 1) ; /* Wait till the clock has reset */
-}
-
-/* Receive a frame from the card in reader emulation mode, the FPGA and
- * timer must have been set up by LegicRfReader and frame_send_rwd.
- *
- * The LEGIC RF protocol from card to reader does not include explicit
- * frame start/stop information or length information. The reader must
- * know beforehand how many bits it wants to receive. (Notably: a card
- * sending a stream of 0-bits is indistinguishable from no card present.)
- *
- * Receive methodology: There is a fancy correlator in hi_read_rx_xcorr, but
- * I'm not smart enough to use it. Instead I have patched hi_read_tx to output
- * the ADC signal with hysteresis on SSP_DIN. Bit-bang that signal and look
- * for edges. Count the edges in each bit interval. If they are approximately
- * 0 this was a 0-bit, if they are approximately equal to the number of edges
- * expected for a 212kHz subcarrier, this was a 1-bit. For timing we use the
- * timer that's still running from frame_send_rwd in order to get a synchronization
- * with the frame that we just sent.
- *
- * FIXME: Because we're relying on the hysteresis to just do the right thing
- * the range is severely reduced (and you'll probably also need a good antenna).
- * So this should be fixed some time in the future for a proper receiver.
- */
-static void frame_receive_rwd(struct legic_frame * const f, int bits, int crypt)
-{
-	uint32_t the_bit = 1;  /* Use a bitmask to save on shifts */
-	uint32_t data=0;
-	int i, old_level=0, edges=0;
-	int next_bit_at = TAG_TIME_WAIT;
-	
-	if(bits > 32) {
-		bits = 32;
-    }
-
-	AT91C_BASE_PIOA->PIO_ODR = GPIO_SSC_DIN;
-	AT91C_BASE_PIOA->PIO_PER = GPIO_SSC_DIN;
-
-	/* we have some time now, precompute the cipher
-     * since we cannot compute it on the fly while reading */
-	legic_prng_forward(2);
-
-	if(crypt)
-	{
-		for(i=0; i<bits; i++) {
-			data |= legic_prng_get_bit() << i;
-			legic_prng_forward(1);
-		}
-	}
-
-	while(timer->TC_CV < next_bit_at) ;
-
-	next_bit_at += TAG_TIME_BIT;
-
-	for(i=0; i<bits; i++) {
-		edges = 0;
-		while(timer->TC_CV < next_bit_at) {
-			int level = (AT91C_BASE_PIOA->PIO_PDSR & GPIO_SSC_DIN);
-			if(level != old_level)
-				edges++;
-			old_level = level;
-		}
-		next_bit_at += TAG_TIME_BIT;
-		
-		if(edges > 20 && edges < 60) { /* expected are 42 edges */
-			data ^= the_bit;
-		}
-		the_bit <<= 1;
-	}
-
-	f->data = data;
-	f->bits = bits;
-
-	/* Reset the timer, to synchronize the next frame */
-	timer->TC_CCR = AT91C_TC_SWTRG;
-	while(timer->TC_CV > 1) ; /* Wait till the clock has reset */
 }
 
 static void frame_append_bit(struct legic_frame * const f, int bit)
@@ -289,250 +607,6 @@ static void frame_clean(struct legic_frame * const f)
 	f->data = 0;
 	f->bits = 0;
 }
-
-static uint32_t perform_setup_phase_rwd(int iv)
-{
-
-	/* Switch on carrier and let the tag charge for 1ms */
-	AT91C_BASE_PIOA->PIO_SODR = GPIO_SSC_DOUT;
-	SpinDelay(1);
-
-	legic_prng_init(0); /* no keystream yet */
-	frame_send_rwd(iv, 7);
-	legic_prng_init(iv);
-
-	frame_clean(&current_frame);
-	frame_receive_rwd(&current_frame, 6, 1);
-	legic_prng_forward(1); /* we wait anyways */
-	while(timer->TC_CV < 387) ; /* ~ 258us */
-	frame_send_rwd(0x19, 6);
-
-	return current_frame.data;
-}
-
-static void LegicCommonInit(void) {
-	FpgaDownloadAndGo(FPGA_BITSTREAM_HF);
-	SetAdcMuxFor(GPIO_MUXSEL_HIPKD);
-	FpgaSetupSsc();
-	FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_READER_TX);
-
-	/* Bitbang the transmitter */
-	AT91C_BASE_PIOA->PIO_CODR = GPIO_SSC_DOUT;
-	AT91C_BASE_PIOA->PIO_OER = GPIO_SSC_DOUT;
-	AT91C_BASE_PIOA->PIO_PER = GPIO_SSC_DOUT;
-
-	setup_timer();
-
-	crc_init(&legic_crc, 4, 0x19 >> 1, 0x5, 0);
-}
-
-static void switch_off_tag_rwd(void)
-{
-	/* Switch off carrier, make sure tag is reset */
-	AT91C_BASE_PIOA->PIO_CODR = GPIO_SSC_DOUT;
-	SpinDelay(10);
-
-	WDT_HIT();
-}
-/* calculate crc for a legic command */
-static int LegicCRC(int byte_index, int value, int cmd_sz) {
-	crc_clear(&legic_crc);
-	crc_update(&legic_crc, 1, 1); /* CMD_READ */
-	crc_update(&legic_crc, byte_index, cmd_sz-1);
-	crc_update(&legic_crc, value, 8);
-	return crc_finish(&legic_crc);
-}
-
-int legic_read_byte(int byte_index, int cmd_sz) {
-	int byte;
-
-	legic_prng_forward(4); /* we wait anyways */
-	while(timer->TC_CV < 387) ; /* ~ 258us + 100us*delay */
-
-	frame_send_rwd(1 | (byte_index << 1), cmd_sz);
-	frame_clean(&current_frame);
-
-	frame_receive_rwd(&current_frame, 12, 1);
-
-	byte = current_frame.data & 0xff;
-	if( LegicCRC(byte_index, byte, cmd_sz) != (current_frame.data >> 8) ) {
-		Dbprintf("!!! crc mismatch: expected %x but got %x !!!", 
-           LegicCRC(byte_index, current_frame.data & 0xff, cmd_sz), current_frame.data >> 8);
-		return -1;
-	}
-
-	return byte;
-}
-
-/* legic_write_byte() is not included, however it's trivial to implement
- * and here are some hints on what remains to be done:
- *
- *  * assemble a write_cmd_frame with crc and send it
- *  * wait until the tag sends back an ACK ('1' bit unencrypted)
- *  * forward the prng based on the timing
- */
-int legic_write_byte(int byte, int addr, int addr_sz) {
-    //do not write UID, CRC, DCF
-    if(addr <= 0x06) { 
-		return 0;
-	}
-
-	//== send write command ==============================
-	crc_clear(&legic_crc);
-	crc_update(&legic_crc, 0, 1); /* CMD_WRITE */
-	crc_update(&legic_crc, addr, addr_sz);
-	crc_update(&legic_crc, byte, 8);
-
-	uint32_t crc = crc_finish(&legic_crc);
-	uint32_t cmd = ((crc     <<(addr_sz+1+8)) //CRC
-                   |(byte    <<(addr_sz+1))   //Data
-                   |(addr    <<1)             //Address
-                   |(0x00    <<0));           //CMD = W
-    uint32_t cmd_sz = addr_sz+1+8+4;          //crc+data+cmd
-
-    legic_prng_forward(2); /* we wait anyways */
-    while(timer->TC_CV < 387) {}; /* ~ 258us */
-	frame_send_rwd(cmd, cmd_sz);
-
-	//== wait for ack ====================================
-    int t, old_level=0, edges=0;
-    int next_bit_at =0;
-	while(timer->TC_CV < 387) ; /* ~ 258us */
-    for(t=0; t<80; t++) {
-        edges = 0;
-		next_bit_at += TAG_TIME_BIT;
-        while(timer->TC_CV < next_bit_at) {
-            int level = (AT91C_BASE_PIOA->PIO_PDSR & GPIO_SSC_DIN);
-            if(level != old_level) {
-                edges++;
-			}
-            old_level = level;
-        }
-        if(edges > 20 && edges < 60) { /* expected are 42 edges */
-			int t = timer->TC_CV;
-			int c = t/TAG_TIME_BIT;
-			timer->TC_CCR = AT91C_TC_SWTRG;
-			while(timer->TC_CV > 1) ; /* Wait till the clock has reset */
-			legic_prng_forward(c);
-        	return 0;
-        }
-    }
-    timer->TC_CCR = AT91C_TC_SWTRG;
-    while(timer->TC_CV > 1) {}; /* Wait till the clock has reset */
-	return -1;
-}
-
-int LegicRfReader(int offset, int bytes) {
-	int byte_index=0, cmd_sz=0, card_sz=0;
-
-	LegicCommonInit();
-
-	uint8_t *BigBuf = BigBuf_get_addr();
-	memset(BigBuf, 0, 1024);
-
-	DbpString("setting up legic card");
-	uint32_t tag_type = perform_setup_phase_rwd(SESSION_IV);
-	switch_off_tag_rwd(); //we lose to mutch time with dprintf
-	switch(tag_type) {
-		case 0x1d:
-			DbpString("MIM 256 card found, reading card ...");
-            cmd_sz = 9;
-			card_sz = 256;
-			break;
-		case 0x3d:
-			DbpString("MIM 1024 card found, reading card ...");
-            cmd_sz = 11;
-			card_sz = 1024;
-			break;
-		default:
-			Dbprintf("Unknown card format: %x",tag_type);
-			return -1;
-	}
-	if(bytes == -1) {
-		bytes = card_sz;
-	}
-	if(bytes+offset >= card_sz) {
-		bytes = card_sz-offset;
-	}
-
-	perform_setup_phase_rwd(SESSION_IV);
-
-	LED_B_ON();
-	while(byte_index < bytes) {
-		int r = legic_read_byte(byte_index+offset, cmd_sz);
-		if(r == -1 ||BUTTON_PRESS()) {
-           	DbpString("operation aborted");
- 			switch_off_tag_rwd();
-	        LED_B_OFF();
-       		LED_C_OFF();
-	        return -1;
-		}
-		BigBuf[byte_index] = r;
-        WDT_HIT();
-		byte_index++;
-		if(byte_index & 0x10) LED_C_ON(); else LED_C_OFF();
-	}
-	LED_B_OFF();
-    LED_C_OFF();
-	switch_off_tag_rwd();
-	Dbprintf("Card read, use 'hf legic decode' or");
-    Dbprintf("'data hexsamples %d' to view results", (bytes+7) & ~7);
-    return 0;
-}
-
-void LegicRfWriter(int bytes, int offset) {
-	int byte_index=0, addr_sz=0;
-	uint8_t *BigBuf = BigBuf_get_addr();
-
-	LegicCommonInit();
-	
-	DbpString("setting up legic card");
-	uint32_t tag_type = perform_setup_phase_rwd(SESSION_IV);
-	switch_off_tag_rwd();
-	switch(tag_type) {
-		case 0x1d:
-			if(offset+bytes > 0x100) {
-				Dbprintf("Error: can not write to 0x%03.3x on MIM 256", offset+bytes);
-				return;
-			}
-			addr_sz = 8;
-			Dbprintf("MIM 256 card found, writing 0x%02.2x - 0x%02.2x ...", offset, offset+bytes);
-			break;
-		case 0x3d:
-			if(offset+bytes > 0x400) {
-          		Dbprintf("Error: can not write to 0x%03.3x on MIM 1024", offset+bytes);
-           		return;
-          	}
-			addr_sz = 10;
-			Dbprintf("MIM 1024 card found, writing 0x%03.3x - 0x%03.3x ...", offset, offset+bytes);
-			break;
-		default:
-			Dbprintf("No or unknown card found, aborting");
-            return;
-	}
-
-    LED_B_ON();
-	perform_setup_phase_rwd(SESSION_IV);
-    legic_prng_forward(2);
-	while(byte_index < bytes) {
-		int r = legic_write_byte(BigBuf[byte_index+offset], byte_index+offset, addr_sz);
-		if((r != 0) || BUTTON_PRESS()) {
-			Dbprintf("operation aborted @ 0x%03.3x", byte_index);
-			switch_off_tag_rwd();
-			LED_B_OFF();
-			LED_C_OFF();
-			return;
-		}
-        WDT_HIT();
-		byte_index++;
-        if(byte_index & 0x10) LED_C_ON(); else LED_C_OFF();
-	}
-    LED_B_OFF();
-    LED_C_OFF();
-    DbpString("write successful");
-}
-
-int timestamp;
 
 /* Handle (whether to respond) a frame in tag mode */
 static void frame_handle_tag(struct legic_frame const * const f)
@@ -588,7 +662,7 @@ static void frame_handle_tag(struct legic_frame const * const f)
          int key   = get_key_stream(-1, 11); //legic_phase_drift, 11);
          int addr  = f->data ^ key; addr = addr >> 1;
          int data = BigBuf[addr];
-         int hash = LegicCRC(addr, data, 11) << 8;
+         int hash = calc_crc4(addr, data, 11) << 8;
          BigBuf[OFFSET_LOG+legic_read_count] = (uint8_t)addr;
          legic_read_count++;
 

--- a/armsrc/legicrf.h
+++ b/armsrc/legicrf.h
@@ -12,7 +12,7 @@
 #define __LEGICRF_H
 
 extern void LegicRfSimulate(int phase, int frame, int reqresp);
-extern int  LegicRfReader(int bytes, int offset);
+extern void LegicRfReader(int bytes, int offset);
 extern void LegicRfWriter(int bytes, int offset);
 
 #endif /* __LEGICRF_H */

--- a/fpga/hi_read_tx.v
+++ b/fpga/hi_read_tx.v
@@ -71,21 +71,8 @@ always @(negedge ssp_clk)
 
 assign ssp_frame = (hi_byte_div == 3'b000);
 
-// Implement a hysteresis to give out the received signal on
-// ssp_din. Sample at fc.
-assign adc_clk = ck_1356meg;
+assign ssp_din = 1'b0;
 
-// ADC data appears on the rising edge, so sample it on the falling edge
-reg after_hysteresis;
-always @(negedge adc_clk)
-begin
-    if(& adc_d[7:0]) after_hysteresis <= 1'b1;
-    else if(~(| adc_d[7:0])) after_hysteresis <= 1'b0;
-end
-
-
-assign ssp_din = after_hysteresis;
-
-assign dbg = ssp_din;
+assign dbg = ssp_frame;
 
 endmodule

--- a/include/legic.h
+++ b/include/legic.h
@@ -1,0 +1,27 @@
+//-----------------------------------------------------------------------------
+// (c) 2016 Iceman
+//
+// This code is licensed to you under the terms of the GNU GPL, version 2 or,
+// at your option, any later version. See the LICENSE.txt file for the text of
+// the license.
+//-----------------------------------------------------------------------------
+// LEGIC type prototyping
+//-----------------------------------------------------------------------------
+
+#ifndef _LEGIC_H_
+#define _LEGIC_H_
+
+#include "common.h"
+
+//-----------------------------------------------------------------------------
+// LEGIC
+//-----------------------------------------------------------------------------
+typedef struct {
+	uint8_t uid[4];
+	uint32_t tagtype;
+	uint8_t cmdsize;
+	uint8_t addrsize;
+	uint16_t cardsize;	
+} legic_card_select_t;
+
+#endif // _LEGIC_H_


### PR DESCRIPTION
As already discussed in #652 I've rewritten most of the Legic Prime reader code to use xcorrelation and precise timing in preparation of a new simulator (not included yet).

With the new code I'm getting reading distances of up to 15cm. Photographer @iceman1001:
![dkzusbhx0aidquy](https://user-images.githubusercontent.com/8958160/44124472-a583502e-a02d-11e8-97d7-77b2b292eae4.jpg)

Beyond that distance, the modulation is simply not distinguishable from background noise.

This pull request is based on a similar implementation I've made for Proxmark3 Rdv4, a couple of days ago iceman1001/proxmark3#227. The code still builds upon the initial concept of Henryk Plötz and contains refinements from Iceman.

Even tough this PR conflicts with #652 I've decided to start the review process now. The code is completely stable and well tested. Moreover adjusting for the upcoming bumped sample rate should be a breeze.