### PR TITLE
Legic: fix write

### DIFF
--- a/armsrc/legicrf.c
+++ b/armsrc/legicrf.c
@@ -476,7 +476,7 @@ void LegicRfWriter(int bytes, int offset) {
 
   // write in reverse order, only then is DCF (decremental field) writable
   while(bytes-- > 0 && !BUTTON_PRESS()) {
-    if(!write_byte(bytes + offset, BigBuf[bytes], card.addrsize)) {
+    if(!write_byte(bytes + offset, BigBuf[bytes + offset], card.addrsize)) {
       Dbprintf("operation failed @ 0x%03.3x", bytes);
       goto OUT;
     }


### PR DESCRIPTION
Due to an oversight the bytes to be written were fetched from the wrong location. This is fixed now.
I falsely assumed only data to be written would be loaded into BigBuf. However BigBuf always holds a full copy of the tags data.

Sorry for not noticing this earyler.