### PR TITLE
Remove unused functions le32toh, le24toh, hextobinstring, binarraytobinstring, print_hex, print_hex_break, sprint_hex_ascii, sprint_ascii, SwapEndian64ex

### DIFF
--- a/armsrc/util.c
+++ b/armsrc/util.c
@@ -81,11 +81,6 @@ void lsl (uint8_t *data, size_t len) {
     data[len - 1] <<= 1;
 }
 
-int32_t le24toh (uint8_t data[3])
-{
-    return (data[2] << 16) | (data[1] << 8) | data[0];
-}
-
 void LEDsoff()
 {
 	LED_A_OFF();

--- a/armsrc/util.h
+++ b/armsrc/util.h
@@ -34,7 +34,6 @@ void num_to_bytes(uint64_t n, size_t len, uint8_t* dest);
 uint64_t bytes_to_num(uint8_t* src, size_t len);
 void rol(uint8_t *data, const size_t len);
 void lsl (uint8_t *data, size_t len);
-int32_t le24toh (uint8_t data[3]);
 
 void LED(int led, int ms);
 void LEDsoff();

--- a/client/util.c
+++ b/client/util.c
@@ -272,16 +272,6 @@ uint8_t *SwapEndian64(const uint8_t *src, const size_t len, const uint8_t blockS
 	return tmp;
 }
 
-// takes a uint8_t src array, for len items and reverses the byte order in blocksizes (8,16,32,64), 
-// returns: the dest array contains the reordered src array.
-void SwapEndian64ex(const uint8_t *src, const size_t len, const uint8_t blockSize, uint8_t *dest){
-	for (uint8_t block=0; block < (uint8_t)(len/blockSize); block++){
-		for (size_t i = 0; i < blockSize; i++){
-			dest[i+(blockSize*block)] = src[(blockSize-1-i)+(blockSize*block)];
-		}
-	}
-}
-
 //assumes little endian
 char * printBits(size_t const size, void const * const ptr)
 {

--- a/client/util.c
+++ b/client/util.c
@@ -718,10 +718,6 @@ void xor(unsigned char *dst, unsigned char *src, size_t len) {
        *dst ^= *src;
 }
 
-int32_t le24toh (uint8_t data[3]) {
-    return (data[2] << 16) | (data[1] << 8) | data[0];
-}
-
 // RotateLeft - Ultralight, Desfire, works on byte level
 // 00-01-02  >> 01-02-00
 void rol(uint8_t *data, const size_t len){

--- a/client/util.c
+++ b/client/util.c
@@ -721,9 +721,6 @@ void xor(unsigned char *dst, unsigned char *src, size_t len) {
 int32_t le24toh (uint8_t data[3]) {
     return (data[2] << 16) | (data[1] << 8) | data[0];
 }
-uint32_t le32toh (uint8_t *data) {
-	return (uint32_t)( (data[3]<<24) | (data[2]<<16) | (data[1]<<8) | data[0]);
-}
 
 // RotateLeft - Ultralight, Desfire, works on byte level
 // 00-01-02  >> 01-02-00

--- a/client/util.c
+++ b/client/util.c
@@ -138,33 +138,6 @@ void hex_to_buffer(const uint8_t *buf, const uint8_t *hex_data, const size_t hex
 
 // printing and converting functions
 
-void print_hex(const uint8_t * data, const size_t len)
-{
-	size_t i;
-
-	for (i=0; i < len; i++)
-		printf("%02x ", data[i]);
-
-	printf("\n");
-}
-
-void print_hex_break(const uint8_t *data, const size_t len, uint8_t breaks) {
-
-	int rownum = 0;
-	printf("[%02d] | ", rownum);
-	for (int i = 0; i < len; ++i) {
-
-		printf("%02X ", data[i]);
-		
-		// check if a line break is needed
-		if ( breaks > 0 && !((i+1) % breaks) && (i+1 < len) ) {
-			++rownum;
-			printf("\n[%02d] | ", rownum);
-		}
-	}
-	printf("\n");
-}
-
 char *sprint_hex(const uint8_t *data, const size_t len) {
 	static char buf[1025] = {0};
 	

--- a/client/util.c
+++ b/client/util.c
@@ -193,27 +193,6 @@ char *sprint_bin(const uint8_t *data, const size_t len) {
 	return sprint_bin_break(data, len, 0);
 }
 
-char *sprint_hex_ascii(const uint8_t *data, const size_t len) {
-	static char buf[1024];
-	char *tmp = buf;
-	memset(buf, 0x00, 1024);
-	size_t max_len = (len > 255) ? 255 : len;
-	// max 255 bytes * 3 + 2 characters = 767 in buffer
-	sprintf(tmp, "%.765s| ", sprint_hex(data, max_len) );
-	
-	size_t i = 0;
-	size_t pos = (max_len * 3)+2;
-	// add another 255 characters ascii = 1020 characters of buffer used
-	while(i < max_len) {
-		char c = data[i];
-		if ( (c < 32) || (c == 127))
-			c = '.';
-		sprintf(tmp+pos+i, "%c",  c);
-		++i;
-	}
-	return buf;
-}
-
 char *sprint_ascii_ex(const uint8_t *data, const size_t len, const size_t min_str_len) {
 	static char buf[1024];
 	char *tmp = buf;
@@ -231,10 +210,6 @@ char *sprint_ascii_ex(const uint8_t *data, const size_t len, const size_t min_st
 		tmp[i] = ' ';
 	
 	return buf;
-}
-
-char *sprint_ascii(const uint8_t *data, const size_t len) {
-	return sprint_ascii_ex(data, len, 0);
 }
 
 void num_to_bytes(uint64_t n, size_t len, uint8_t* dest)

--- a/client/util.c
+++ b/client/util.c
@@ -648,17 +648,6 @@ int hextobinarray(char *target, char *source)
     return count;
 }
 
-// convert hex to human readable binary string
-int hextobinstring(char *target, char *source)
-{
-    int length;
-
-    if(!(length= hextobinarray(target, source)))
-        return 0;
-    binarraytobinstring(target, target, length);
-    return length;
-}
-
 // convert binary array of 0x00/0x01 values to hex (safe to do in place as target will always be shorter than source)
 // return number of bits converted
 int binarraytohex(char *target,char *source, int length)
@@ -679,16 +668,6 @@ int binarraytohex(char *target,char *source, int length)
         j -= 4;
     }
     return length;
-}
-
-// convert binary array to human readable binary
-void binarraytobinstring(char *target, char *source,  int length)
-{
-    int i;
-
-    for(i= 0 ; i < length ; ++i)
-        *(target++)= *(source++) + '0';
-    *target= '\0';
 }
 
 // return parity bit required to match type

--- a/client/util.h
+++ b/client/util.h
@@ -61,7 +61,6 @@ extern char *printBits(size_t const size, void const * const ptr);
 extern char * printBitsPar(const uint8_t *b, size_t len);
 extern uint32_t SwapBits(uint32_t value, int nrbits);
 extern uint8_t *SwapEndian64(const uint8_t *src, const size_t len, const uint8_t blockSize);
-extern void SwapEndian64ex(const uint8_t *src, const size_t len, const uint8_t blockSize, uint8_t *dest);
 
 extern int param_getlength(const char *line, int paramnum);
 extern char param_getchar(const char *line, int paramnum);

--- a/client/util.h
+++ b/client/util.h
@@ -46,7 +46,6 @@ extern void FillFileNameByUID(char *fileName, uint8_t * uid, char *ext, int byte
 extern void hex_to_buffer(const uint8_t *buf, const uint8_t *hex_data, const size_t hex_len, 
 	const size_t hex_max_len, const size_t min_str_len, const size_t spaces_between, bool uppercase);
 
-extern void print_hex(const uint8_t * data, const size_t len);
 extern char *sprint_hex(const uint8_t * data, const size_t len);
 extern char *sprint_hex_inrow(const uint8_t *data, const size_t len);
 extern char *sprint_hex_inrow_ex(const uint8_t *data, const size_t len, const size_t min_str_len);

--- a/client/util.h
+++ b/client/util.h
@@ -51,8 +51,6 @@ extern char *sprint_hex_inrow(const uint8_t *data, const size_t len);
 extern char *sprint_hex_inrow_ex(const uint8_t *data, const size_t len, const size_t min_str_len);
 extern char *sprint_bin(const uint8_t * data, const size_t len);
 extern char *sprint_bin_break(const uint8_t *data, const size_t len, const uint8_t breaks);
-extern char *sprint_hex_ascii(const uint8_t *data, const size_t len);
-extern char *sprint_ascii(const uint8_t *data, const size_t len);
 extern char *sprint_ascii_ex(const uint8_t *data, const size_t len, const size_t min_str_len);
 
 extern void num_to_bytes(uint64_t n, size_t len, uint8_t* dest);

--- a/client/util.h
+++ b/client/util.h
@@ -90,7 +90,6 @@ extern void wiegand_add_parity(uint8_t *target, uint8_t *source, uint8_t length)
 
 extern void xor(unsigned char *dst, unsigned char *src, size_t len);
 extern int32_t le24toh(uint8_t data[3]);
-extern uint32_t le32toh (uint8_t *data);
 extern void rol(uint8_t *data, const size_t len);
 
 extern void clean_ascii(unsigned char *buf, size_t len);

--- a/client/util.h
+++ b/client/util.h
@@ -89,7 +89,6 @@ extern uint8_t GetParity( uint8_t *string, uint8_t type,  int length);
 extern void wiegand_add_parity(uint8_t *target, uint8_t *source, uint8_t length);
 
 extern void xor(unsigned char *dst, unsigned char *src, size_t len);
-extern int32_t le24toh(uint8_t data[3]);
 extern void rol(uint8_t *data, const size_t len);
 
 extern void clean_ascii(unsigned char *buf, size_t len);

--- a/client/util.h
+++ b/client/util.h
@@ -82,9 +82,7 @@ extern int param_gethex_to_eol(const char *line, int paramnum, uint8_t * data, i
 extern int param_getstr(const char *line, int paramnum, char * str, size_t buffersize);
 
 extern int hextobinarray( char *target,  char *source);
-extern int hextobinstring( char *target,  char *source);
 extern int binarraytohex( char *target,  char *source,  int length);
-extern void binarraytobinstring(char *target,  char *source,  int length);
 extern uint8_t GetParity( uint8_t *string, uint8_t type,  int length);
 extern void wiegand_add_parity(uint8_t *target, uint8_t *source, uint8_t length);
 


### PR DESCRIPTION
The version of `le32toh` in PM3 conflicts with a declaration in `/usr/include/x86_64-linux-gnu/bits/waitstatus.h`.

I only seem to see this when compiling with gcc, when wrapping PM3 on a _non-Android_ JNI implementation (which I'm using for testing).  I _don't_ see this on Android JNI builds, or on regular upstream non-Android builds.

The code that is erroring out is from current, vanilla PM3 master. 

It doesn't look like `le32toh` is even used in PM3, so this PR just removes it.  The version that is in PM3 would fail on big-endian CPUs anyway.

## Sample error cases:

### gcc: 7.3.0, Travis CI:

```
Scanning dependencies of target pm3
[  7%] Building C object CMakeFiles/pm3.dir/home/travis/build/AndProx/AndProx/natives/src/main/cpp/fakemain.c.o
[  8%] Building C object CMakeFiles/pm3.dir/home/travis/build/AndProx/AndProx/natives/src/main/cpp/uart_android.c.o
In file included from /usr/include/x86_64-linux-gnu/bits/waitstatus.h:64:0,
                 from /usr/include/stdlib.h:42,
                 from /home/travis/build/AndProx/AndProx/third_party/proxmark3/uart/uart.h:37,
                 from /home/travis/build/AndProx/AndProx/natives/src/main/cpp/uart_android.h:35,
                 from /home/travis/build/AndProx/AndProx/natives/src/main/cpp/uart_android.c:31:
/home/travis/build/AndProx/AndProx/third_party/proxmark3/client/util.h:93:34: error: expected ‘)’ before ‘*’ token
 extern uint32_t le32toh (uint8_t *data);
                                  ^
make[2]: *** [CMakeFiles/pm3.dir/home/travis/build/AndProx/AndProx/natives/src/main/cpp/uart_android.c.o] Error 1
make[1]: *** [CMakeFiles/pm3.dir/all] Error 2
make: *** [all] Error 2
:natives:runNonAndroidMake FAILED
```

### gcc: 8.1.1, local build:

```
Scanning dependencies of target pm3
[  7%] Building C object CMakeFiles/pm3.dir/home/me/dev/AndProx/natives/src/main/cpp/fakemain.c.o
[  8%] Building C object CMakeFiles/pm3.dir/home/me/dev/AndProx/natives/src/main/cpp/uart_android.c.o
In file included from /usr/include/sys/types.h:194,
                 from /usr/include/stdlib.h:394,
                 from /home/me/dev/AndProx/third_party/proxmark3/uart/uart.h:37,
                 from /home/me/dev/AndProx/natives/src/main/cpp/uart_android.h:35,
                 from /home/me/dev/AndProx/natives/src/main/cpp/uart_android.c:31:
/home/me/dev/AndProx/third_party/proxmark3/client/util.h:93:17: error: conflicting types for ‘__uint32_identity’
 extern uint32_t le32toh (uint8_t *data);
                 ^~~~~~~
In file included from /usr/include/endian.h:61,
                 from /usr/include/sys/types.h:194,
                 from /usr/include/stdlib.h:394,
                 from /home/me/dev/AndProx/third_party/proxmark3/uart/uart.h:37,
                 from /home/me/dev/AndProx/natives/src/main/cpp/uart_android.h:35,
                 from /home/me/dev/AndProx/natives/src/main/cpp/uart_android.c:31:
/usr/include/bits/uintn-identity.h:39:1: note: previous definition of ‘__uint32_identity’ was here
 __uint32_identity (__uint32_t __x)
 ^~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/pm3.dir/build.make:87: CMakeFiles/pm3.dir/home/me/dev/AndProx/natives/src/main/cpp/uart_android.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:371: CMakeFiles/pm3.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

Explicitly including `util.h` from `uart_android.h` resolves that error, but then it comes up in `util.c`:

```
Scanning dependencies of target pm3
[  7%] Building C object CMakeFiles/pm3.dir/home/me/dev/AndProx/natives/src/main/cpp/uart_android.c.o
[  8%] Building C object CMakeFiles/pm3.dir/home/me/dev/AndProx/third_party/proxmark3/client/util.c.o
In file included from /usr/include/ctype.h:39,
                 from /home/me/dev/AndProx/third_party/proxmark3/client/util.c:15:
/home/me/dev/AndProx/third_party/proxmark3/client/util.c:724:10: error: conflicting types for ‘__uint32_identity’
 uint32_t le32toh (uint8_t *data) {
          ^~~~~~~
In file included from /usr/include/endian.h:61,
                 from /usr/include/ctype.h:39,
                 from /home/me/dev/AndProx/third_party/proxmark3/client/util.c:15:
/usr/include/bits/uintn-identity.h:39:1: note: previous definition of ‘__uint32_identity’ was here
 __uint32_identity (__uint32_t __x)
 ^~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/pm3.dir/build.make:159: CMakeFiles/pm3.dir/home/me/dev/AndProx/third_party/proxmark3/client/util.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:371: CMakeFiles/pm3.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

Removing `le32toh` fixes all the errors.