### PR TITLE
Jansson gcc8 fix

### DIFF
--- a/client/jansson/error.c
+++ b/client/jansson/error.c
@@ -25,10 +25,10 @@ void jsonp_error_set_source(json_error_t *error, const char *source)
 
     length = strlen(source);
     if(length < JSON_ERROR_SOURCE_LENGTH)
-        strncpy(error->source, source, length + 1);
+        strncpy(error->source, source, JSON_ERROR_SOURCE_LENGTH);
     else {
         size_t extra = length - JSON_ERROR_SOURCE_LENGTH + 4;
-        strncpy(error->source, "...", 3);
+        memcpy(error->source, "...", 3);
         strncpy(error->source + 3, source + extra, length - extra + 1);
     }
 }

--- a/client/jansson/load.c
+++ b/client/jansson/load.c
@@ -114,7 +114,7 @@ static void error_set(json_error_t *error, const lex_t *lex,
         if(saved_text && saved_text[0])
         {
             if(lex->saved_text.length <= 20) {
-                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH + 17,
+                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH + 8,
                          "%s near '%s'", msg_text, saved_text);
                 msg_with_context[JSON_ERROR_TEXT_LENGTH - 1] = '\0';
                 result = msg_with_context;

--- a/client/jansson/load.c
+++ b/client/jansson/load.c
@@ -89,7 +89,7 @@ static void error_set(json_error_t *error, const lex_t *lex,
 {
     va_list ap;
     char msg_text[JSON_ERROR_TEXT_LENGTH];
-    char msg_with_context[JSON_ERROR_TEXT_LENGTH + 17];
+    char msg_with_context[JSON_ERROR_TEXT_LENGTH + 28];
 
     int line = -1, col = -1;
     size_t pos = 0;
@@ -114,7 +114,7 @@ static void error_set(json_error_t *error, const lex_t *lex,
         if(saved_text && saved_text[0])
         {
             if(lex->saved_text.length <= 20) {
-                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH + 8,
+                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH + 28,
                          "%s near '%s'", msg_text, saved_text);
                 msg_with_context[JSON_ERROR_TEXT_LENGTH - 1] = '\0';
                 result = msg_with_context;

--- a/client/jansson/load.c
+++ b/client/jansson/load.c
@@ -89,7 +89,7 @@ static void error_set(json_error_t *error, const lex_t *lex,
 {
     va_list ap;
     char msg_text[JSON_ERROR_TEXT_LENGTH];
-    char msg_with_context[JSON_ERROR_TEXT_LENGTH];
+    char msg_with_context[JSON_ERROR_TEXT_LENGTH * 2 + 9];
 
     int line = -1, col = -1;
     size_t pos = 0;
@@ -114,7 +114,7 @@ static void error_set(json_error_t *error, const lex_t *lex,
         if(saved_text && saved_text[0])
         {
             if(lex->saved_text.length <= 20) {
-                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH,
+                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH * 2 + 9,
                          "%s near '%s'", msg_text, saved_text);
                 msg_with_context[JSON_ERROR_TEXT_LENGTH - 1] = '\0';
                 result = msg_with_context;
@@ -131,7 +131,7 @@ static void error_set(json_error_t *error, const lex_t *lex,
                 result = msg_text;
             }
             else {
-                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH,
+                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH * 2 + 9,
                          "%s near end of file", msg_text);
                 msg_with_context[JSON_ERROR_TEXT_LENGTH - 1] = '\0';
                 result = msg_with_context;

--- a/client/jansson/load.c
+++ b/client/jansson/load.c
@@ -89,7 +89,7 @@ static void error_set(json_error_t *error, const lex_t *lex,
 {
     va_list ap;
     char msg_text[JSON_ERROR_TEXT_LENGTH];
-    char msg_with_context[JSON_ERROR_TEXT_LENGTH * 2 + 9];
+    char msg_with_context[JSON_ERROR_TEXT_LENGTH + 17];
 
     int line = -1, col = -1;
     size_t pos = 0;
@@ -114,7 +114,7 @@ static void error_set(json_error_t *error, const lex_t *lex,
         if(saved_text && saved_text[0])
         {
             if(lex->saved_text.length <= 20) {
-                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH * 2 + 9,
+                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH + 17,
                          "%s near '%s'", msg_text, saved_text);
                 msg_with_context[JSON_ERROR_TEXT_LENGTH - 1] = '\0';
                 result = msg_with_context;
@@ -131,7 +131,7 @@ static void error_set(json_error_t *error, const lex_t *lex,
                 result = msg_text;
             }
             else {
-                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH * 2 + 9,
+                snprintf(msg_with_context, JSON_ERROR_TEXT_LENGTH + 17,
                          "%s near end of file", msg_text);
                 msg_with_context[JSON_ERROR_TEXT_LENGTH - 1] = '\0';
                 result = msg_with_context;


### PR DESCRIPTION
Fix GCC 8 warnings stringop-truncation, stringop-overflow and format-truncation.

