### PR TITLE
Fix bad version tag

### DIFF
--- a/tools/mkversion.pl
+++ b/tools/mkversion.pl
@@ -11,7 +11,7 @@
 $ENV{'LC_ALL'} = "C";
 $ENV{'LANG'} = "C";
 
-my $gitversion = `git describe --dirty`;
+my $gitversion = `git describe --dirty --tags`;
 my $gitbranch = `git rev-parse --abbrev-ref HEAD`;
 my $clean = 2;
 my @compiletime = gmtime();


### PR DESCRIPTION
The 3.1.0 release has not been tagged with an annotated tag, therefore
`git describe` ignores it and marks the firmware as 3.0.1.