### PR TITLE
Mfp read plain

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -107,6 +107,7 @@ CMDSRCS = 	$(SRC_SMARTCARD) \
 			crapto1/crypto1.c\
 			polarssl/des.c \
 			polarssl/aes.c\
+			polarssl/aes_cmac128.c\
 			polarssl/bignum.c\
 			polarssl/rsa.c\
 			polarssl/sha1.c\

--- a/client/cliparser/cliparser.h
+++ b/client/cliparser/cliparser.h
@@ -19,6 +19,7 @@
 #define arg_get_lit(n)(((struct arg_lit*)argtable[n])->count)
 #define arg_get_int_count(n)(((struct arg_int*)argtable[n])->count)
 #define arg_get_int(n)(((struct arg_int*)argtable[n])->ival[0])
+#define arg_get_int_def(n,def)(arg_get_int_count(n)?(arg_get_int(n)):(def))
 #define arg_get_str(n)((struct arg_str*)argtable[n])
 #define arg_get_str_len(n)(strlen(((struct arg_str*)argtable[n])->sval[0]))
 

--- a/client/cmdhfmfp.c
+++ b/client/cmdhfmfp.c
@@ -444,6 +444,8 @@ int CmdHFMFPRdbl(const char *cmd) {
 	CLIGetHexWithReturn(6, key, &keylen);
 	CLIParserFree();
 	
+	SetVerboseMode(verbose);
+
 	if (!keylen) {
 		memmove(key, DefaultKey, 16);
 		keylen = 16;
@@ -548,6 +550,8 @@ int CmdHFMFPRdsc(const char *cmd) {
 	CLIGetHexWithReturn(5, key, &keylen);
 	CLIParserFree();
 	
+	SetVerboseMode(verbose);
+
 	if (!keylen) {
 		memmove(key, DefaultKey, 16);
 		keylen = 16;
@@ -644,6 +648,8 @@ int CmdHFMFPWrbl(const char *cmd) {
 	CLIGetHexWithReturn(5, key, &keylen);
 	CLIParserFree();
 	
+	SetVerboseMode(verbose);
+
 	if (!keylen) {
 		memmove(key, DefaultKey, 16);
 		keylen = 16;

--- a/client/cmdhfmfp.c
+++ b/client/cmdhfmfp.c
@@ -88,14 +88,14 @@ int MFPCommitPerso(bool activateField, bool leaveSignalON, uint8_t *dataout, int
 int MFPReadBlock(mf4Session *session, bool plain, uint8_t blockNum, uint8_t blockCount, bool activateField, bool leaveSignalON, uint8_t *dataout, int maxdataoutlen, int *dataoutlen, uint8_t *mac) {
 	uint8_t rcmd[4 + 8] = {(plain?(0x37):(0x33)), blockNum, 0x00, blockCount}; 
 	if (!plain && session)
-		CalulateMAC(session, rcmd, 4, &rcmd[4], VerboseMode);
+		CalculateMAC(session, rcmd, 4, &rcmd[4], VerboseMode);
 	
 	int res = intExchangeRAW14aPlus(rcmd, plain?4:sizeof(rcmd), activateField, leaveSignalON, dataout, maxdataoutlen, dataoutlen);
 	if(res)
 		return res;
 
 	if(session && mac)
-		CalulateMAC(session, dataout, *dataoutlen, mac, VerboseMode);
+		CalculateMAC(session, dataout, *dataoutlen, mac, VerboseMode);
 	
 	return 0;
 }
@@ -104,14 +104,14 @@ int MFPWriteBlock(mf4Session *session, uint8_t blockNum, uint8_t *data, bool act
 	uint8_t rcmd[1 + 2 + 16 + 8] = {0xA3, blockNum, 0x00};
 	memmove(&rcmd[3], data, 16);
 	if (session)
-		CalulateMAC(session, rcmd, 19, &rcmd[19], VerboseMode);
+		CalculateMAC(session, rcmd, 19, &rcmd[19], VerboseMode);
 	
 	int res = intExchangeRAW14aPlus(rcmd, sizeof(rcmd), activateField, leaveSignalON, dataout, maxdataoutlen, dataoutlen);
 	if(res)
 		return res;
 
 	if(session && mac)
-		CalulateMAC(session, dataout, *dataoutlen, mac, VerboseMode);
+		CalculateMAC(session, dataout, *dataoutlen, mac, VerboseMode);
 	
 	return 0;
 }

--- a/client/cmdhfmfp.c
+++ b/client/cmdhfmfp.c
@@ -88,30 +88,30 @@ int MFPCommitPerso(bool activateField, bool leaveSignalON, uint8_t *dataout, int
 int MFPReadBlock(mf4Session *session, bool plain, uint8_t blockNum, uint8_t blockCount, bool activateField, bool leaveSignalON, uint8_t *dataout, int maxdataoutlen, int *dataoutlen, uint8_t *mac) {
 	uint8_t rcmd[4 + 8] = {(plain?(0x37):(0x33)), blockNum, 0x00, blockCount}; 
 	if (!plain && session)
-		CalulateMAC(session, rcmd, 4, &rcmd[4]);
+		CalulateMAC(session, rcmd, 4, &rcmd[4], VerboseMode);
 	
 	int res = intExchangeRAW14aPlus(rcmd, plain?4:sizeof(rcmd), activateField, leaveSignalON, dataout, maxdataoutlen, dataoutlen);
 	if(res)
 		return res;
 
 	if(session && mac)
-		CalulateMAC(session, dataout, *dataoutlen, mac);
+		CalulateMAC(session, dataout, *dataoutlen, mac, VerboseMode);
 	
 	return 0;
 }
 
-int MFPWriteBlock(mf4Session *session, uint8_t blockNum, uint8_t *data, bool activateField, bool leaveSignalON, uint8_t *dataout, int maxdataoutlen, int *dataoutlen) {
+int MFPWriteBlock(mf4Session *session, uint8_t blockNum, uint8_t *data, bool activateField, bool leaveSignalON, uint8_t *dataout, int maxdataoutlen, int *dataoutlen, uint8_t *mac) {
 	uint8_t rcmd[1 + 2 + 16 + 8] = {0xA3, blockNum, 0x00};
 	memmove(&rcmd[3], data, 16);
 	if (session)
-		CalulateMAC(session, rcmd, 19, &rcmd[19]);
+		CalulateMAC(session, rcmd, 19, &rcmd[19], VerboseMode);
 	
 	int res = intExchangeRAW14aPlus(rcmd, sizeof(rcmd), activateField, leaveSignalON, dataout, maxdataoutlen, dataoutlen);
 	if(res)
 		return res;
 
 	if(session && mac)
-		CalulateMAC(session, dataout, *dataoutlen, mac);
+		CalulateMAC(session, dataout, *dataoutlen, mac, VerboseMode);
 	
 	return 0;
 }
@@ -680,7 +680,8 @@ int CmdHFMFPWrbl(const char *cmd) {
 
 	uint8_t data[250] = {0};
 	int datalen = 0;
-	res = MFPWriteBlock(&session, blockNum & 0xff, datain, false, false, data, sizeof(data), &datalen);
+	uint8_t mac[8] = {0};
+	res = MFPWriteBlock(&session, blockNum & 0xff, datain, false, false, data, sizeof(data), &datalen, mac);
 	if (res) {
 		PrintAndLog("Write error: %d", res);
 		return res;
@@ -697,7 +698,7 @@ int CmdHFMFPWrbl(const char *cmd) {
 	}
 	
 	if (!memcmp(&data[1], mac, 8)) {
-		PrintAndLog("WARNING: mac on block %d not equal...", n);
+		PrintAndLog("WARNING: mac not equal...");
 		PrintAndLog("MAC   card: %s", sprint_hex(&data[1], 8));
 		PrintAndLog("MAC reader: %s", sprint_hex(mac, 8));
 	} else {	

--- a/client/cmdhfmfp.c
+++ b/client/cmdhfmfp.c
@@ -690,16 +690,19 @@ int CmdHFMFPWrbl(const char *cmd) {
 	res = MFPWriteBlock(&session, blockNum & 0xff, datain, false, false, data, sizeof(data), &datalen, mac);
 	if (res) {
 		PrintAndLog("Write error: %d", res);
+		DropField();
 		return res;
 	}
 	
 	if (datalen != 3 && (datalen != 3 + 8)) {
 		PrintAndLog("Error return length:%d", datalen);
+		DropField();
 		return 5;
 	}
 	
 	if (datalen && data[0] != 0x90) {
 		PrintAndLog("Card write error: %02x %s", data[0], GetErrorDescription(data[0]));
+		DropField();
 		return 6;
 	}
 	
@@ -712,6 +715,7 @@ int CmdHFMFPWrbl(const char *cmd) {
 			PrintAndLog("MAC: %s", sprint_hex(&data[1], 8));
 	}
 	
+	DropField();
 	return 0;
 }
 

--- a/client/emv/test/cryptotest.c
+++ b/client/emv/test/cryptotest.c
@@ -14,6 +14,7 @@
 
 #include "bignum.h"
 #include "aes.h"
+#include "aes_cmac128.h"
 #include "des.h"
 #include "rsa.h"
 #include "sha1.h"
@@ -32,7 +33,10 @@ int ExecuteCryptoTests(bool verbose) {
 	
 	res = aes_self_test(verbose);
 	if (res) TestFail = true;
-	
+
+	res = aes_cmac_self_test(verbose);
+	if (res) TestFail = true;
+
 	res = des_self_test(verbose);
 	if (res) TestFail = true;
 	

--- a/client/mifare4.c
+++ b/client/mifare4.c
@@ -16,7 +16,7 @@
 #include "ui.h"
 #include "polarssl/libpcrypto.h"
 
-int CalulateMAC(mf4Session *session, uint8_t *data, int datalen, uint8_t *mac, bool verbose) {
+int CalculateMAC(mf4Session *session, uint8_t *data, int datalen, uint8_t *mac, bool verbose) {
 	if (!session || !session->Authenticated || !mac || !data || !datalen)
 		return 1;
 	

--- a/client/mifare4.c
+++ b/client/mifare4.c
@@ -17,9 +17,10 @@
 #include "polarssl/libpcrypto.h"
 
 int CalulateMAC(mf4Session *session, uint8_t *data, int datalen, uint8_t *mac, bool verbose) {
-	memset(mac, 0x00, 8);
 	if (!session || !session->Authenticated || !mac || !data || !datalen)
 		return 1;
+	
+	memset(mac, 0x00, 8);
 	
 	if (verbose)
 		PrintAndLog("MAC data[%d]: %s", datalen, sprint_hex(data, datalen));

--- a/client/mifare4.h
+++ b/client/mifare4.h
@@ -17,14 +17,21 @@
 
 typedef struct {
 	bool Authenticated;
+	uint8_t Key[16];
 	uint16_t KeyNum;
 	uint8_t Rnd1[16];
 	uint8_t Rnd2[16];
 	
 }mf4Session;
 
+extern int CalulateMAC(mf4Session *session, uint8_t *data, int datalen, uint8_t *mac, bool verbose);
 extern int MifareAuth4(mf4Session *session, uint8_t *keyn, uint8_t *key, bool activateField, bool leaveSignalON, bool verbose);
 
+extern uint8_t mfNumBlocksPerSector(uint8_t sectorNo);
+extern uint8_t mfFirstBlockOfSector(uint8_t sectorNo);
+extern uint8_t mfSectorTrailer(uint8_t blockNo);
+extern bool mfIsSectorTrailer(uint8_t blockNo);
+extern uint8_t mfSectorNum(uint8_t blockNo);
 
 
 #endif // mifare4.h

--- a/client/mifare4.h
+++ b/client/mifare4.h
@@ -24,7 +24,7 @@ typedef struct {
 	
 }mf4Session;
 
-extern int CalulateMAC(mf4Session *session, uint8_t *data, int datalen, uint8_t *mac, bool verbose);
+extern int CalculateMAC(mf4Session *session, uint8_t *data, int datalen, uint8_t *mac, bool verbose);
 extern int MifareAuth4(mf4Session *session, uint8_t *keyn, uint8_t *key, bool activateField, bool leaveSignalON, bool verbose);
 
 extern uint8_t mfNumBlocksPerSector(uint8_t sectorNo);

--- a/common/polarssl/aes_cmac128.c
+++ b/common/polarssl/aes_cmac128.c
@@ -1,4 +1,34 @@
-/* Reference : https://polarssl.org/discussions/generic/authentication-token */
+/*
+ *  AES-CMAC from NIST Special Publication 800-38B — Recommendation for block cipher modes of operation: The CMAC mode for authentication.
+ *
+ *  Copyright (C) 2006-2014, Brainspark B.V.
+ *  Copyright (C) 2014, Anargyros Plemenos
+ *  Tests added Merkok, 2018
+ *
+ *  This file is part of PolarSSL (http://www.polarssl.org)
+ *  Lead Maintainer: Paul Bakker <polarssl_maintainer at polarssl.org>
+ *
+ *  All rights reserved.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Reference : https://polarssl.org/discussions/generic/authentication-token
+ *  NIST Special Publication 800-38B — Recommendation for block cipher modes of operation: The CMAC mode for authentication.
+ *  Tests here:
+ *  https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/AES_CMAC.pdf
+*/
 
 #include "polarssl/aes_cmac128.h"
 #include <stdio.h>

--- a/common/polarssl/aes_cmac128.c
+++ b/common/polarssl/aes_cmac128.c
@@ -1,0 +1,292 @@
+/* Reference : https://polarssl.org/discussions/generic/authentication-token */
+
+#include "polarssl/aes_cmac128.h"
+#include <stdio.h>
+
+#define MIN(a,b)           ((a)<(b)?(a):(b))
+#define _MSB(x)            (((x)[0] & 0x80)?1:0)
+
+#if !defined(POLARSSL_CONFIG_FILE)
+#include "polarssl_config.h"
+#else
+#include POLARSSL_CONFIG_FILE
+#endif
+
+#if defined(POLARSSL_AES_C)
+#include "aes.h"
+#endif
+
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf printf
+#endif
+
+
+/** 
+ * zero a structure 
+ */
+#define ZERO_STRUCT(x)      memset((char *)&(x), 0, sizeof(x))
+
+/** 
+ * zero a structure given a pointer to the structure 
+ */
+#define ZERO_STRUCTP(x)     do{ if((x) != NULL) memset((char *)(x), 0, sizeof(*(x)));} while(0)
+
+
+/* For CMAC Calculation */
+static unsigned char const_Rb[16] = {
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x87
+};
+static unsigned char const_Zero[16] = {
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+static inline void aes_cmac_128_left_shift_1(const uint8_t in[16], uint8_t out[16])
+{
+	uint8_t overflow = 0;
+	int8_t i;
+
+	for (i = 15; i >= 0; i--) {
+		out[i] = in[i] << 1;
+		out[i] |= overflow;
+		overflow = _MSB(&in[i]);
+	 } 
+}
+
+static inline void aes_cmac_128_xor(const uint8_t in1[16], const uint8_t in2[16], 
+										uint8_t out[16])
+{
+	uint8_t i;
+
+	for (i = 0; i < 16; i++) {
+		out[i] = in1[i] ^ in2[i];
+	}
+}
+
+/*
+ * AES-CMAC-128 context setup
+ */
+void aes_cmac128_starts(aes_cmac128_context *ctx, const uint8_t K[16])
+{
+	uint8_t L[16];
+
+	/* Zero struct of aes_context */
+	ZERO_STRUCTP(ctx);
+	/* Initialize aes_context */
+	aes_setkey_enc(&ctx->aes_key, K, 128);
+
+	/* step 1 - generate subkeys k1 and k2 */
+	aes_crypt_ecb(&ctx->aes_key, AES_ENCRYPT, const_Zero, L);
+
+	if (_MSB(L) == 0) {
+		aes_cmac_128_left_shift_1(L, ctx->K1);
+	} else {
+		uint8_t tmp_block[16];
+
+		aes_cmac_128_left_shift_1(L, tmp_block);
+		aes_cmac_128_xor(tmp_block, const_Rb, ctx->K1);
+		ZERO_STRUCT(tmp_block);
+	}
+
+	if (_MSB(ctx->K1) == 0) {
+		aes_cmac_128_left_shift_1(ctx->K1, ctx->K2);
+	} else {
+		uint8_t tmp_block[16];
+
+		aes_cmac_128_left_shift_1(ctx->K1, tmp_block);
+		aes_cmac_128_xor(tmp_block, const_Rb, ctx->K2);
+		ZERO_STRUCT(tmp_block);
+   }
+
+	ZERO_STRUCT(L);
+}
+
+/*
+ * AES-CMAC-128 process message
+ */
+void aes_cmac128_update(aes_cmac128_context *ctx, const uint8_t *_msg, size_t _msg_len)
+{
+	uint8_t tmp_block[16];
+	uint8_t Y[16];
+	const uint8_t *msg = _msg;
+	size_t msg_len = _msg_len;
+
+	/*
+	 * copy the remembered last block
+	 */
+	ZERO_STRUCT(tmp_block);
+	if (ctx->last_len) {
+		memcpy(tmp_block, ctx->last, ctx->last_len);
+	}
+
+	/*
+	 * check if we expand the block
+	 */
+	if (ctx->last_len < 16) {
+		size_t len = MIN(16 - ctx->last_len, msg_len);
+
+		memcpy(&tmp_block[ctx->last_len], msg, len);
+		memcpy(ctx->last, tmp_block, 16);
+		msg += len;
+		msg_len -= len;
+		ctx->last_len += len;
+	}
+
+	if (msg_len == 0) {
+		/* if it is still the last block, we are done */
+		ZERO_STRUCT(tmp_block);
+		return;
+	}
+
+	/*
+	 * It is not the last block anymore
+	 */
+	ZERO_STRUCT(ctx->last);
+	ctx->last_len = 0;
+
+	/*
+	 * now checksum everything but the last block
+	 */
+	aes_cmac_128_xor(ctx->X, tmp_block, Y);
+	aes_crypt_ecb(&ctx->aes_key, AES_ENCRYPT, Y, ctx->X);
+
+	while (msg_len > 16) {
+		memcpy(tmp_block, msg, 16);
+		msg += 16;
+		msg_len -= 16;
+
+		aes_cmac_128_xor(ctx->X, tmp_block, Y);
+		aes_crypt_ecb(&ctx->aes_key, AES_ENCRYPT, Y, ctx->X);
+	}
+
+	/*
+	 * copy the last block, it will be processed in
+	 * aes_cmac128_final().
+	 */
+	 memcpy(ctx->last, msg, msg_len);
+	 ctx->last_len = msg_len;
+
+	ZERO_STRUCT(tmp_block);
+	ZERO_STRUCT(Y);
+}
+
+/*
+ * AES-CMAC-128 compute T
+ */
+void aes_cmac128_final(aes_cmac128_context *ctx, uint8_t T[16])
+{
+	uint8_t tmp_block[16];
+	uint8_t Y[16];
+
+	if (ctx->last_len < 16) {
+		ctx->last[ctx->last_len] = 0x80;
+		aes_cmac_128_xor(ctx->last, ctx->K2, tmp_block);
+	} else {
+		aes_cmac_128_xor(ctx->last, ctx->K1, tmp_block);
+	}
+
+	aes_cmac_128_xor(tmp_block, ctx->X, Y);
+	aes_crypt_ecb(&ctx->aes_key, AES_ENCRYPT, Y, T);
+
+	ZERO_STRUCT(tmp_block);
+	ZERO_STRUCT(Y);
+	ZERO_STRUCTP(ctx);
+}
+
+/*
+ * Checkup routine
+ * 
+ * https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
+ * https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/AES_CMAC.pdf
+ */
+int aes_cmac_self_test( int verbose )
+{
+	unsigned char key[16] = {0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6, 0xAB, 0xF7, 0x15, 0x88, 0x09, 0xCF, 0x4F, 0x3C};
+	unsigned char mac[16] = {0};
+	aes_cmac128_context ctx;
+	int ret;
+
+	// check Example1:
+	if( verbose != 0 )
+		polarssl_printf( "  AES-CMAC-128 zero length data: " );
+	unsigned char ex1data[16] = {0};
+	aes_cmac128_starts(&ctx, key);
+	aes_cmac128_update(&ctx, ex1data, 0);
+	aes_cmac128_final(&ctx, mac);
+	unsigned char ex1res[16] = {0xBB, 0x1D, 0x69, 0x29, 0xE9, 0x59, 0x37, 0x28, 0x7F, 0xA3, 0x7D, 0x12, 0x9B, 0x75, 0x67, 0x46};
+	if(!memcmp(mac, ex1res, 16)) {
+		if( verbose != 0 )
+			polarssl_printf( "passed\n" );
+	} else {
+		polarssl_printf( "failed\n" );
+		ret = 1;
+		goto exit;
+	}
+
+	// check Example2:
+	if( verbose != 0 )    
+		polarssl_printf( "  AES-CMAC-128 one block data  : " );
+	unsigned char ex2data[16] = {0x6B, 0xC1, 0xBE, 0xE2, 0x2E, 0x40, 0x9F, 0x96, 0xE9, 0x3D, 0x7E, 0x11, 0x73, 0x93, 0x17, 0x2A};
+	aes_cmac128_starts(&ctx, key);
+	aes_cmac128_update(&ctx, ex2data, sizeof(ex2data));
+	aes_cmac128_final(&ctx, mac);
+	unsigned char ex2res[16] = {0x07, 0x0A, 0x16, 0xB4, 0x6B, 0x4D, 0x41, 0x44, 0xF7, 0x9B, 0xDD, 0x9D, 0xD0, 0x4A, 0x28, 0x7C};
+	if(!memcmp(mac, ex2res, 16)) {
+		if( verbose != 0 )
+			polarssl_printf( "passed\n" );
+	} else {
+		polarssl_printf( "failed\n" );
+		ret = 1;
+		goto exit;
+	}
+	
+	// check Example3:
+	if( verbose != 0 )
+		polarssl_printf( "  AES-CMAC-128 20 bytes of data: " );
+	unsigned char ex3data[20] = {0x6B, 0xC1, 0xBE, 0xE2, 0x2E, 0x40, 0x9F, 0x96, 0xE9, 0x3D, 0x7E, 0x11, 0x73, 0x93, 0x17, 0x2A, 
+								 0xAE, 0x2D, 0x8A, 0x57};
+	aes_cmac128_starts(&ctx, key);
+	aes_cmac128_update(&ctx, ex3data, sizeof(ex3data));
+	aes_cmac128_final(&ctx, mac);
+	unsigned char ex3res[16] = {0x7D, 0x85, 0x44, 0x9E, 0xA6, 0xEA, 0x19, 0xC8, 0x23, 0xA7, 0xBF, 0x78, 0x83, 0x7D, 0xFA, 0xDE};
+	if(!memcmp(mac, ex3res, 16)) {
+		if( verbose != 0 )
+			polarssl_printf( "passed\n" );
+	} else {
+		polarssl_printf( "failed\n" );
+		ret = 1;
+		goto exit;
+	}
+
+	// check Example4:
+	if( verbose != 0 )
+		polarssl_printf( "  AES-CMAC-128 4 blocks of data: " );
+	unsigned char ex4data[64] = {0x6B, 0xC1, 0xBE, 0xE2, 0x2E, 0x40, 0x9F, 0x96, 0xE9, 0x3D, 0x7E, 0x11, 0x73, 0x93, 0x17, 0x2A,
+								 0xAE, 0x2D, 0x8A, 0x57, 0x1E, 0x03, 0xAC, 0x9C, 0x9E, 0xB7, 0x6F, 0xAC, 0x45, 0xAF, 0x8E, 0x51,
+								 0x30, 0xC8, 0x1C, 0x46, 0xA3, 0x5C, 0xE4, 0x11, 0xE5, 0xFB, 0xC1, 0x19, 0x1A, 0x0A, 0x52, 0xEF,
+								 0xF6, 0x9F, 0x24, 0x45, 0xDF, 0x4F, 0x9B, 0x17, 0xAD, 0x2B, 0x41, 0x7B, 0xE6, 0x6C, 0x37, 0x10};
+	aes_cmac128_starts(&ctx, key);
+	aes_cmac128_update(&ctx, ex4data, sizeof(ex4data));
+	aes_cmac128_final(&ctx, mac);
+	unsigned char ex4res[16] = {0x51, 0xF0, 0xBE, 0xBF, 0x7E, 0x3B, 0x9D, 0x92, 0xFC, 0x49, 0x74, 0x17, 0x79, 0x36, 0x3C, 0xFE};
+	if(!memcmp(mac, ex4res, 16)) {
+		if( verbose != 0 )
+			polarssl_printf( "passed\n" );
+	} else {
+		polarssl_printf( "failed\n" );
+		ret = 1;
+		goto exit;
+	}
+
+	if( verbose != 0 )
+		polarssl_printf( "\n" );
+
+	ret = 0;
+
+exit:
+	return( ret );
+}
+

--- a/common/polarssl/aes_cmac128.h
+++ b/common/polarssl/aes_cmac128.h
@@ -1,3 +1,35 @@
+/*
+ *  AES-CMAC from NIST Special Publication 800-38B — Recommendation for block cipher modes of operation: The CMAC mode for authentication.
+ *
+ *  Copyright (C) 2006-2014, Brainspark B.V.
+ *  Copyright (C) 2014, Anargyros Plemenos
+ *  Tests added Merkok, 2018
+ *
+ *  This file is part of PolarSSL (http://www.polarssl.org)
+ *  Lead Maintainer: Paul Bakker <polarssl_maintainer at polarssl.org>
+ *
+ *  All rights reserved.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Reference : https://polarssl.org/discussions/generic/authentication-token
+ *  NIST Special Publication 800-38B — Recommendation for block cipher modes of operation: The CMAC mode for authentication.
+ *  Tests here:
+ *  https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/AES_CMAC.pdf
+*/
+
 #include <stdint.h>
 #include <stddef.h>
 #include "aes.h"

--- a/common/polarssl/aes_cmac128.h
+++ b/common/polarssl/aes_cmac128.h
@@ -1,0 +1,49 @@
+#include <stdint.h>
+#include <stddef.h>
+#include "aes.h"
+
+typedef struct aes_cmac_128_context {
+    aes_context aes_key;
+
+    uint8_t K1[16];
+    uint8_t K2[16];
+
+    uint8_t X[16];
+
+    uint8_t last[16];
+    size_t last_len;
+}
+aes_cmac128_context;
+
+/*
+ * \brief AES-CMAC-128 context setup
+ *
+ * \param ctx      context to be initialized
+ * \param key      secret key for AES-128
+ */
+void aes_cmac128_starts(aes_cmac128_context *ctx, const uint8_t K[16]);
+
+/*
+ * \brief AES-CMAC-128 process message
+ *
+ * \param ctx      context to be initialized
+ * \param _msg     the given message
+ * \param _msg_len the length of message
+ */
+void aes_cmac128_update(aes_cmac128_context *ctx, const uint8_t *_msg, size_t _msg_len);
+
+/*
+ * \brief AES-CMAC-128 compute T
+ *
+ * \param ctx      context to be initialized
+ * \param T        the generated MAC which is used to validate the message
+ */
+void aes_cmac128_final(aes_cmac128_context *ctx, uint8_t T[16]);
+
+/**
+ * \brief          Checkup routine
+ *
+ * \return         0 if successful, or 1 if the test failed
+ */
+int aes_cmac_self_test( int verbose );
+

--- a/common/polarssl/libpcrypto.c
+++ b/common/polarssl/libpcrypto.c
@@ -44,16 +44,16 @@ int aes_decode(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *output, int l
 }
 
 int aes_cmac(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *mac, int length) {
-	setmem(mac, 0x00, 16);
+	memset(mac, 0x00, 16);
 	uint8_t iiv[16] = {0};
 	if (iv)
 		memcpy(iiv, iv, 16);
 	
 	// padding nist...
-	uint8_t data[length + 16] = {0};
+	uint8_t data[2049] = {0}; // length + 16
 	memcpy(data, input, length);
 	data[length] = 0x80;
-	int datalen = length & 0xfffffff0 + 0x10;
+	int datalen = (length & 0xfffffff0) + 0x10;
 	
 	// cmac
 	aes_context aes;
@@ -66,7 +66,7 @@ int aes_cmac(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *mac, int length
 
 int aes_cmac8(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *mac, int length) {
 	uint8_t cmac[16] = {0};
-	setmem(mac, 0x00, 8);
+	memset(mac, 0x00, 8);
 	
 	int res = aes_cmac(iv, key, input, cmac, length);
 	if (res)

--- a/common/polarssl/libpcrypto.c
+++ b/common/polarssl/libpcrypto.c
@@ -42,3 +42,38 @@ int aes_decode(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *output, int l
 
 	return 0;
 }
+
+int aes_cmac(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *mac, int length) {
+	setmem(mac, 0x00, 16);
+	uint8_t iiv[16] = {0};
+	if (iv)
+		memcpy(iiv, iv, 16);
+	
+	// padding nist...
+	uint8_t data[length + 16] = {0};
+	memcpy(data, input, length);
+	data[length] = 0x80;
+	int datalen = length & 0xfffffff0 + 0x10;
+	
+	// cmac
+	aes_context aes;
+	aes_init(&aes);
+
+	aes_free(&aes);
+
+	return 0;
+}
+
+int aes_cmac8(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *mac, int length) {
+	uint8_t cmac[16] = {0};
+	setmem(mac, 0x00, 8);
+	
+	int res = aes_cmac(iv, key, input, cmac, length);
+	if (res)
+		return res;
+	
+	for(int i = 0; i < 8; i++) 
+		mac[i] = cmac[i * 2 + 1];
+
+	return 0;
+}

--- a/common/polarssl/libpcrypto.h
+++ b/common/polarssl/libpcrypto.h
@@ -16,5 +16,7 @@
 
 extern int aes_encode(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *output, int length);
 extern int aes_decode(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *output, int length);
+extern int aes_cmac(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *mac, int length);
+extern int aes_cmac8(uint8_t *iv, uint8_t *key, uint8_t *input, uint8_t *mac, int length);
 
 #endif /* libpcrypto.h */


### PR DESCRIPTION
`hf mfp` can `rdbl` and `rdsc` in plain mode
plus:
- aescmac128
- tests for aescmac

TODO:
- move from **polarssl** to **mbedtls**

_I dont know the MAC calc procedure. so i leave `wrbl` command to time when it will be possible._ 