### PR TITLE
Fix util.c missing include

### DIFF
--- a/client/util.c
+++ b/client/util.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
+#include <stdarg.h>
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
Fix missing include in #716:

```
util.c: In function ‘FillBuffer’:
util.c:116:2: error: unknown type name ‘va_list’
  va_list valist;
  ^~~~~~~
util.c:116:2: note: ‘va_list’ is defined in header ‘<stdarg.h>’; did you forget to ‘#include <stdarg.h>’?
util.c:30:1:
+#include <stdarg.h>
 
util.c:116:2:
  va_list valist;
  ^~~~~~~
util.c:117:2: warning: implicit declaration of function ‘va_start’ [-Wimplicit-function-declaration]
  va_start(valist, dataLength);
  ^~~~~~~~
util.c:122:11: warning: implicit declaration of function ‘va_arg’; did you mean ‘alarm’? [-Wimplicit-function-declaration]
   vdata = va_arg(valist, uint8_t *);
           ^~~~~~
           alarm
util.c:122:26: error: expected expression before ‘uint8_t’
   vdata = va_arg(valist, uint8_t *);
                          ^~~~~~~
util.c:126:28: error: expected expression before ‘size_t’
   vlength = va_arg(valist, size_t);
                            ^~~~~~
util.c:128:4: warning: implicit declaration of function ‘va_end’; did you mean ‘rand’? [-Wimplicit-function-declaration]
    va_end(valist);
    ^~~~~~
    rand
make[1]: *** [Makefile:318: obj/util.o] Error 1
```