### PR TITLE
Fix format-truncation warning, missing string.h inclusion and strnlen warning

### DIFF
--- a/client/crypto/asn1dump.c
+++ b/client/crypto/asn1dump.c
@@ -8,11 +8,14 @@
 // asn.1 dumping
 //-----------------------------------------------------------------------------
 
+#define _POSIX_C_SOURCE 200809L                 // need for strnlen()
+
 #include "asn1dump.h"
 #include <ctype.h>
 #include <stdlib.h>
 #include <unistd.h> 
 #include <stdio.h>
+#include <string.h>
 #include <jansson.h>
 #include <mbedtls/asn1.h>
 #include <mbedtls/oid.h>

--- a/client/ui.c
+++ b/client/ui.c
@@ -99,7 +99,7 @@ void PrintAndLogEx(logLevel_t level, char *fmt, ...) {
 		}
 		PrintAndLog(buffer2);
 	} else {
-		snprintf(buffer2, sizeof(buffer2), "%s%s", prefix, buffer);
+		snprintf(buffer2, sizeof(buffer2), "%s%.2028s", prefix, buffer);
 		PrintAndLog(buffer2);
 	}
 }

--- a/client/ui.c
+++ b/client/ui.c
@@ -99,7 +99,7 @@ void PrintAndLogEx(logLevel_t level, char *fmt, ...) {
 		}
 		PrintAndLog(buffer2);
 	} else {
-		snprintf(buffer2, sizeof(buffer2), "%s%.2028s", prefix, buffer);
+		snprintf(buffer2, sizeof(buffer2), "%s%.*s", prefix, MAX_PRINT_BUFFER - 20, buffer);
 		PrintAndLog(buffer2);
 	}
 }


### PR DESCRIPTION
Fix these warnings:

```
ui.c: In function ‘PrintAndLogEx’:
ui.c:102:41: warning: ‘%s’ directive output may be truncated writing up to 2047 bytes into a region of size between 2029 and 2048 [-Wformat-truncation=]
   snprintf(buffer2, sizeof(buffer2), "%s%s", prefix, buffer);
                                         ^~           ~~~~~~
ui.c:102:3: note: ‘snprintf’ output between 1 and 2067 bytes into a destination of size 2048
   snprintf(buffer2, sizeof(buffer2), "%s%s", prefix, buffer);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mv -f obj/ui.Td obj/ui.d
gcc -MT obj/comms.o -MMD -MP -MF obj/comms.Td  -std=c99 -D_ISOC99_SOURCE -I. -I../include -I../common -I../common/polarssl -I../zlib -I../uart -I/opt/local/include -I../liblua -I./jansson -I../common/mbedtls -Wall -g -O3  -DWITH_ISO14443a_StandAlone -DWITH_LF -DWITH_ISO15693 -DWITH_ISO14443a -DWITH_ISO14443b -DWITH_ICLASS -DWITH_LEGICRF -DWITH_HITAG -DWITH_CRC -DWITH_HFSNOOP -DWITH_GUI -DHAVE_GUI -DZ_SOLO -DZ_PREFIX -DNO_GZIP -DZLIB_PM3_TUNED  -c -o obj/comms.o comms.c
mv -f obj/comms.Td obj/comms.d
gcc -MT obj/crapto1/crapto1.o -MMD -MP -MF obj/crapto1/crapto1.Td  -std=c99 -D_ISOC99_SOURCE -I. -I../include -I../common -I../common/polarssl -I../zlib -I../uart -I/opt/local/include -I../liblua -I./jansson -I../common/mbedtls -Wall -g -O3  -DWITH_ISO14443a_StandAlone -DWITH_LF -DWITH_ISO15693 -DWITH_ISO14443a -DWITH_ISO14443b -DWITH_ICLASS -DWITH_LEGICRF -DWITH_HITAG -DWITH_CRC -DWITH_HFSNOOP -DWITH_GUI -DHAVE_GUI -DZ_SOLO -DZ_PREFIX -DNO_GZIP -DZLIB_PM3_TUNED  -c -o obj/crapto1/crapto1.o ../common/crapto1/crapto1.c
mv -f obj/crapto1/crapto1.Td obj/crapto1/crapto1.d
gcc -MT obj/crapto1/crypto1.o -MMD -MP -MF obj/crapto1/crypto1.Td  -std=c99 -D_ISOC99_SOURCE -I. -I../include -I../common -I../common/polarssl -I../zlib -I../uart -I/opt/local/include -I../liblua -I./jansson -I../common/mbedtls -Wall -g -O3  -DWITH_ISO14443a_StandAlone -DWITH_LF -DWITH_ISO15693 -DWITH_ISO14443a -DWITH_ISO14443b -DWITH_ICLASS -DWITH_LEGICRF -DWITH_HITAG -DWITH_CRC -DWITH_HFSNOOP -DWITH_GUI -DHAVE_GUI -DZ_SOLO -DZ_PREFIX -DNO_GZIP -DZLIB_PM3_TUNED  -c -o obj/crapto1/crypto1.o ../common/crapto1/crypto1.c
mv -f obj/crapto1/crypto1.Td obj/crapto1/crypto1.d
gcc -MT obj/crypto/libpcrypto.o -MMD -MP -MF obj/crypto/libpcrypto.Td  -std=c99 -D_ISOC99_SOURCE -I. -I../include -I../common -I../common/polarssl -I../zlib -I../uart -I/opt/local/include -I../liblua -I./jansson -I../common/mbedtls -Wall -g -O3  -DWITH_ISO14443a_StandAlone -DWITH_LF -DWITH_ISO15693 -DWITH_ISO14443a -DWITH_ISO14443b -DWITH_ICLASS -DWITH_LEGICRF -DWITH_HITAG -DWITH_CRC -DWITH_HFSNOOP -DWITH_GUI -DHAVE_GUI -DZ_SOLO -DZ_PREFIX -DNO_GZIP -DZLIB_PM3_TUNED  -c -o obj/crypto/libpcrypto.o crypto/libpcrypto.c
mv -f obj/crypto/libpcrypto.Td obj/crypto/libpcrypto.d
gcc -MT obj/crypto/asn1utils.o -MMD -MP -MF obj/crypto/asn1utils.Td  -std=c99 -D_ISOC99_SOURCE -I. -I../include -I../common -I../common/polarssl -I../zlib -I../uart -I/opt/local/include -I../liblua -I./jansson -I../common/mbedtls -Wall -g -O3  -DWITH_ISO14443a_StandAlone -DWITH_LF -DWITH_ISO15693 -DWITH_ISO14443a -DWITH_ISO14443b -DWITH_ICLASS -DWITH_LEGICRF -DWITH_HITAG -DWITH_CRC -DWITH_HFSNOOP -DWITH_GUI -DHAVE_GUI -DZ_SOLO -DZ_PREFIX -DNO_GZIP -DZLIB_PM3_TUNED  -c -o obj/crypto/asn1utils.o crypto/asn1utils.c
mv -f obj/crypto/asn1utils.Td obj/crypto/asn1utils.d
gcc -MT obj/crypto/asn1dump.o -MMD -MP -MF obj/crypto/asn1dump.Td  -std=c99 -D_ISOC99_SOURCE -I. -I../include -I../common -I../common/polarssl -I../zlib -I../uart -I/opt/local/include -I../liblua -I./jansson -I../common/mbedtls -Wall -g -O3  -DWITH_ISO14443a_StandAlone -DWITH_LF -DWITH_ISO15693 -DWITH_ISO14443a -DWITH_ISO14443b -DWITH_ICLASS -DWITH_LEGICRF -DWITH_HITAG -DWITH_CRC -DWITH_HFSNOOP -DWITH_GUI -DHAVE_GUI -DZ_SOLO -DZ_PREFIX -DNO_GZIP -DZLIB_PM3_TUNED  -c -o obj/crypto/asn1dump.o crypto/asn1dump.c
crypto/asn1dump.c: In function ‘asn1_oid_description’:
crypto/asn1dump.c:234:2: warning: implicit declaration of function ‘memset’ [-Wimplicit-function-declaration]
  memset(res, 0x00, sizeof(res));
  ^~~~~~
crypto/asn1dump.c:234:2: warning: incompatible implicit declaration of built-in function ‘memset’
crypto/asn1dump.c:234:2: note: include ‘<string.h>’ or provide a declaration of ‘memset’
crypto/asn1dump.c:24:1:
+#include <string.h>
 
crypto/asn1dump.c:234:2:
  memset(res, 0x00, sizeof(res));
  ^~~~~~
crypto/asn1dump.c:236:2: warning: implicit declaration of function ‘strcpy’ [-Wimplicit-function-declaration]
  strcpy(fname, get_my_executable_directory());
  ^~~~~~
crypto/asn1dump.c:236:2: warning: incompatible implicit declaration of built-in function ‘strcpy’
crypto/asn1dump.c:236:2: note: include ‘<string.h>’ or provide a declaration of ‘strcpy’
crypto/asn1dump.c:237:2: warning: implicit declaration of function ‘strcat’ [-Wimplicit-function-declaration]
  strcat(fname, "crypto/oids.json");
  ^~~~~~
crypto/asn1dump.c:237:2: warning: incompatible implicit declaration of built-in function ‘strcat’
crypto/asn1dump.c:237:2: note: include ‘<string.h>’ or provide a declaration of ‘strcat’
crypto/asn1dump.c: In function ‘asn1_tag_dump_object_id’:
crypto/asn1dump.c:292:16: warning: implicit declaration of function ‘strnlen’; did you mean ‘strcleanrn’? [-Wimplicit-function-declaration]
   if (ppstr && strnlen(ppstr, 1)) {
                ^~~~~~~
                strcleanrn
```
`strnlen()` is not standard C; part of the man page:
```
Feature Test Macro Requirements for glibc (see feature_test_macros(7)):

       strnlen():
           Since glibc 2.10:
               _POSIX_C_SOURCE >= 200809L
           Before glibc 2.10:
               _GNU_SOURCE
```

