### PR TITLE
Fido - fix public key lenght to 65 bytes

### DIFF
--- a/client/cmdhffido.c
+++ b/client/cmdhffido.c
@@ -531,7 +531,7 @@ int CmdHFFidoAuthenticate(const char *cmd) {
 
 	// public key
 	CLIGetHexWithReturn(8, hdata, &hdatalen);
-	if (hdatalen && hdatalen != 130) {
+	if (hdatalen && hdatalen != 65) {
 		PrintAndLog("ERROR: public key length must be 65 bytes only.");
 		return 1;
 	}


### PR DESCRIPTION
Fix `ERROR: public key length must be 65 bytes only` when submitting a valid public key.