### PR TITLE
Update default_pwd.dic

### DIFF
--- a/client/default_pwd.dic
+++ b/client/default_pwd.dic
@@ -73,3 +73,4 @@ BBCCDDEE,
 CCDDEEFF,
 0CB7E7FC,  //rfidler?
 FABADA11,  //china?
+65857569,  //chinese "handheld RFID writer" blue cloner from circa 2013 (also sold by xfpga.com)


### PR DESCRIPTION
T55xx password for the most used chinese blue cloner "handheld RFID cloner" back in 2013-2015. 
Initially sold on hw688.com back in 2013 and then rebranded by xfpga.com with the PCB board stamped with:

> 64129H2
> 25168F-19

See: https://imgur.com/a/V6Mexyh
