### PR TITLE
Fix CMD_PCF7931_BRUTEFORCE duplicate case value in usb_cmd.h

### DIFF
--- a/include/usb_cmd.h
+++ b/include/usb_cmd.h
@@ -97,7 +97,7 @@ typedef struct{
 #define CMD_T55XX_RESET_READ                                              0x0216
 #define CMD_PCF7931_READ                                                  0x0217
 #define CMD_PCF7931_WRITE                                                 0x0222
-#define CMD_PCF7931_BRUTEFORCE											  0x0226
+#define CMD_PCF7931_BRUTEFORCE                                            0x0227
 #define CMD_EM4X_READ_WORD                                                0x0218
 #define CMD_EM4X_WRITE_WORD                                               0x0219
 #define CMD_IO_DEMOD_FSK                                                  0x021A


### PR DESCRIPTION
Fix issue:
```
appmain.c: In function 'UsbPacketReceived':
appmain.c:1074:3: error: duplicate case value
   case CMD_VIKING_CLONE_TAG:
   ^~~~
appmain.c:1062:3: note: previously used here
   case CMD_PCF7931_BRUTEFORCE:
   ^~~~
make[1]: *** [../common/Makefile.common:81: obj/appmain.o] Error 1
```
