### PR TITLE
Fix CmdSmartUpgrade GCC8 strncpy specified bound depends on the lengt…

### DIFF
--- a/client/cmdsmartcard.c
+++ b/client/cmdsmartcard.c
@@ -581,7 +581,7 @@ int CmdSmartUpgrade(const char *Cmd) {
 		return 1;
 	}
 
-	char sha512filename[FILE_PATH_SIZE];
+	char sha512filename[FILE_PATH_SIZE] = {'\0'};
 	char *bin_extension = filename;
 	char *dot_position = NULL;
 	while ((dot_position = strchr(bin_extension, '.')) != NULL) {
@@ -592,7 +592,7 @@ int CmdSmartUpgrade(const char *Cmd) {
 	    || !strcmp(bin_extension, "bin")
 #endif
 	    ) {
-		strncpy(sha512filename, filename, strlen(filename) - strlen("bin"));
+		memcpy(sha512filename, filename, strlen(filename) - strlen("bin"));
 		strcat(sha512filename, "sha512.txt");
 	} else {
 		PrintAndLogEx(FAILED, "Filename extension of Firmware Upgrade File must be .BIN");


### PR DESCRIPTION
…h of the source argument warning

Fix for the warning:

```
cmdsmartcard.c:595:3: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
   strncpy(sha512filename, filename, strlen(filename) - strlen("bin"));
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cmdsmartcard.c:595:37: note: length computed here
   strncpy(sha512filename, filename, strlen(filename) - strlen("bin"));
                                     ^~~~~~~~~~~~~~~~
```