### PR TITLE
crypto1_create: initialize malloc()ed memory to 0

### DIFF
--- a/common/crapto1/crypto1.c
+++ b/common/crapto1/crypto1.c
@@ -47,6 +47,7 @@ struct Crypto1State * crypto1_create(uint64_t key)
 	struct Crypto1State *s = malloc(sizeof(*s));
 	int i;
 
+	memset(s, 0x0, sizeof(*s));
 	for(i = 47;s && i > 0; i -= 2) {
 		s->odd  = s->odd  << 1 | BIT(key, (i - 1) ^ 7);
 		s->even = s->even << 1 | BIT(key, i ^ 7);


### PR DESCRIPTION
On systems that support malloc(), crypto1_create() allocates a new
struct Crypto1State and starts calculations without initializing the
allocated memory area.

At least on Linux, malloc(3) says that the allocated memory is not
initialized. Looking at the version for bare metal ARM, it seems that
the components of struct Crypto1State should be 0 initially. Add a
memset() call to initialize them.