### PR TITLE
Adding support for standard USB Smartcard Readers (cont.)

### DIFF
--- a/client/cmdhffido.c
+++ b/client/cmdhffido.c
@@ -61,7 +61,7 @@ int CmdHFFidoInfo(const char *cmd) {
 	PrintAndLog("--------------------------------------------"); 
 	SetAPDULogging(false);
 	
-	uint8_t buf[APDU_RES_LEN] = {0};
+	uint8_t buf[APDU_RESPONSE_LEN] = {0};
 	size_t len = 0;
 	uint16_t sw = 0;
 	int res = FIDOSelect(true, true, buf, sizeof(buf), &len, &sw);

--- a/client/cmdsmartcard.h
+++ b/client/cmdsmartcard.h
@@ -15,12 +15,6 @@
 #include <stdbool.h>
 
 extern int CmdSmartcard(const char *Cmd);
-
-extern int CmdSmartRaw(const char* cmd);
-extern int CmdSmartUpgrade(const char* cmd);
-extern int CmdSmartInfo(const char* cmd);
-extern int CmdSmartReader(const char *Cmd);
-
 extern int ExchangeAPDUSC(uint8_t *datain, int datainlen, bool activateCard, bool leaveSignalON, uint8_t *dataout, int maxdataoutlen, int *dataoutlen);
 
 #endif

--- a/client/emv/cmdemv.c
+++ b/client/emv/cmdemv.c
@@ -45,7 +45,7 @@ void ParamLoadDefaults(struct tlvdb *tlvRoot) {
 }
 
 int CmdEMVSelect(const char *cmd) {
-	uint8_t data[APDU_AID_LEN] = {0};
+	uint8_t data[APDU_DATA_LEN] = {0};
 	int datalen = 0;
 
 	CLIParserInit("emv select", 
@@ -83,7 +83,7 @@ int CmdEMVSelect(const char *cmd) {
 	SetAPDULogging(APDULogging);
 	
 	// exec
-	uint8_t buf[APDU_RES_LEN] = {0};
+	uint8_t buf[APDU_RESPONSE_LEN] = {0};
 	size_t len = 0;
 	uint16_t sw = 0;
 	int res = EMVSelect(channel, activateField, leaveSignalON, data, datalen, buf, sizeof(buf), &len, &sw, NULL);
@@ -193,7 +193,7 @@ int CmdEMVPPSE(const char *cmd) {
 	SetAPDULogging(APDULogging);
 	
 	// exec
-	uint8_t buf[APDU_RES_LEN] = {0};
+	uint8_t buf[APDU_RESPONSE_LEN] = {0};
 	size_t len = 0;
 	uint16_t sw = 0;
 	int res = EMVSelectPSE(channel, activateField, leaveSignalON, PSENum, buf, sizeof(buf), &len, &sw);
@@ -212,7 +212,7 @@ int CmdEMVPPSE(const char *cmd) {
 }
 
 int CmdEMVGPO(const char *cmd) {
-	uint8_t data[APDU_RES_LEN] = {0};
+	uint8_t data[APDU_RESPONSE_LEN] = {0};
 	int datalen = 0;
 
 	CLIParserInit("emv gpo", 
@@ -295,7 +295,7 @@ int CmdEMVGPO(const char *cmd) {
 	PrintAndLogEx(INFO, "PDOL data[%d]: %s", pdol_data_tlv_data_len, sprint_hex(pdol_data_tlv_data, pdol_data_tlv_data_len));
 	
 	// exec
-	uint8_t buf[APDU_RES_LEN] = {0};
+	uint8_t buf[APDU_RESPONSE_LEN] = {0};
 	size_t len = 0;
 	uint16_t sw = 0;
 	int res = EMVGPO(channel, leaveSignalON, pdol_data_tlv_data, pdol_data_tlv_data_len, buf, sizeof(buf), &len, &sw, tlvRoot);
@@ -317,7 +317,7 @@ int CmdEMVGPO(const char *cmd) {
 }
 
 int CmdEMVReadRecord(const char *cmd) {
-	uint8_t data[APDU_RES_LEN] = {0};
+	uint8_t data[APDU_RESPONSE_LEN] = {0};
 	int datalen = 0;
 
 	CLIParserInit("emv readrec", 
@@ -356,7 +356,7 @@ int CmdEMVReadRecord(const char *cmd) {
 	SetAPDULogging(APDULogging);
 		
 	// exec
-	uint8_t buf[APDU_RES_LEN] = {0};
+	uint8_t buf[APDU_RESPONSE_LEN] = {0};
 	size_t len = 0;
 	uint16_t sw = 0;
 	int res = EMVReadRecord(channel, leaveSignalON, data[0], data[1], buf, sizeof(buf), &len, &sw, NULL);
@@ -375,7 +375,7 @@ int CmdEMVReadRecord(const char *cmd) {
 }
 
 int CmdEMVAC(const char *cmd) {
-	uint8_t data[APDU_RES_LEN] = {0};
+	uint8_t data[APDU_RESPONSE_LEN] = {0};
 	int datalen = 0;
 
 	CLIParserInit("emv genac", 
@@ -474,7 +474,7 @@ int CmdEMVAC(const char *cmd) {
 	PrintAndLogEx(INFO, "CDOL data[%d]: %s", cdol_data_tlv->len, sprint_hex(cdol_data_tlv->value, cdol_data_tlv->len));
 
 	// exec
-	uint8_t buf[APDU_RES_LEN] = {0};
+	uint8_t buf[APDU_RESPONSE_LEN] = {0};
 	size_t len = 0;
 	uint16_t sw = 0;
 	int res = EMVAC(channel, leaveSignalON, termDecision, (uint8_t *)cdol_data_tlv->value, cdol_data_tlv->len, buf, sizeof(buf), &len, &sw, tlvRoot);
@@ -524,7 +524,7 @@ int CmdEMVGenerateChallenge(const char *cmd) {
 	SetAPDULogging(APDULogging);
 	
 	// exec
-	uint8_t buf[APDU_RES_LEN] = {0};
+	uint8_t buf[APDU_RESPONSE_LEN] = {0};
 	size_t len = 0;
 	uint16_t sw = 0;
 	int res = EMVGenerateChallenge(channel, leaveSignalON, buf, sizeof(buf), &len, &sw, NULL);
@@ -544,7 +544,7 @@ int CmdEMVGenerateChallenge(const char *cmd) {
 }
 
 int CmdEMVInternalAuthenticate(const char *cmd) {
-	uint8_t data[APDU_RES_LEN] = {0};
+	uint8_t data[APDU_RESPONSE_LEN] = {0};
 	int datalen = 0;
 
 	CLIParserInit("emv intauth", 
@@ -624,7 +624,7 @@ int CmdEMVInternalAuthenticate(const char *cmd) {
 	PrintAndLogEx(INFO, "DDOL data[%d]: %s", ddol_data_tlv->len, sprint_hex(ddol_data_tlv->value, ddol_data_tlv->len));
 	
 	// exec
-	uint8_t buf[APDU_RES_LEN] = {0};
+	uint8_t buf[APDU_RESPONSE_LEN] = {0};
 	size_t len = 0;
 	uint16_t sw = 0;
 	int res = EMVInternalAuthenticate(channel, leaveSignalON, data, datalen, buf, sizeof(buf), &len, &sw, NULL);
@@ -711,10 +711,10 @@ void ProcessGPOResponseFormat1(struct tlvdb *tlvRoot, uint8_t *buf, size_t len, 
 }
 
 int CmdEMVExec(const char *cmd) {
-	uint8_t buf[APDU_RES_LEN] = {0};
+	uint8_t buf[APDU_RESPONSE_LEN] = {0};
 	size_t len = 0;
 	uint16_t sw = 0;
-	uint8_t AID[APDU_AID_LEN] = {0};
+	uint8_t AID[APDU_DATA_LEN] = {0};
 	size_t AIDlen = 0;
 	uint8_t ODAiList[4096];
 	size_t ODAiListLen = 0;
@@ -769,6 +769,8 @@ int CmdEMVExec(const char *cmd) {
 		channel = ECC_CONTACT;
 #endif
 	uint8_t psenum = (channel == ECC_CONTACT) ? 1 : 2;
+	char *PSE_or_PPSE = psenum == 1 ? "PSE" : "PPSE";
+	
 	CLIParserFree();
 	
 	SetAPDULogging(showAPDU);
@@ -780,12 +782,12 @@ int CmdEMVExec(const char *cmd) {
 	// Application Selection
 	// https://www.openscdp.org/scripts/tutorial/emv/applicationselection.html
 	if (!forceSearch) {
-		// PPSE
-		PrintAndLogEx(NORMAL, "\n* PPSE.");
+		// PPSE / PSE
+		PrintAndLogEx(NORMAL, "\n* %s.", PSE_or_PPSE);
 		SetAPDULogging(showAPDU);
 		res = EMVSearchPSE(channel, activateField, true, psenum, decodeTLV, tlvSelect);
 
-		// check PPSE and select application id
+		// check PPSE / PSE and select application id
 		if (!res) { 
 			TLVPrintAIDlistFromSelectTLV(tlvSelect);
 			EMVSelectApplication(tlvSelect, AID, &AIDlen);
@@ -1152,7 +1154,9 @@ int CmdEMVExec(const char *cmd) {
 		}
 	}
 
-	DropField();
+	if (channel == ECC_CONTACTLESS) {
+		DropField();
+	}
 	
 	// Destroy TLV's
 	free(pdol_data_tlv);
@@ -1164,9 +1168,9 @@ int CmdEMVExec(const char *cmd) {
 }
 
 int CmdEMVScan(const char *cmd) {
-	uint8_t AID[APDU_AID_LEN] = {0};
+	uint8_t AID[APDU_DATA_LEN] = {0};
 	size_t AIDlen = 0;
-	uint8_t buf[APDU_RES_LEN] = {0};
+	uint8_t buf[APDU_RESPONSE_LEN] = {0};
 	size_t len = 0;
 	uint16_t sw = 0;
 	int res;
@@ -1260,8 +1264,10 @@ int CmdEMVScan(const char *cmd) {
 	}
 
 	// drop field at start
-	DropField();
-
+	if (channel == ECC_CONTACTLESS) {
+		DropField();
+	}
+	
 	// iso 14443 select
 	PrintAndLogEx(NORMAL, "--> GET UID, ATS.");
 	
@@ -1329,7 +1335,9 @@ int CmdEMVScan(const char *cmd) {
 
 	if (!AIDlen) {
 		PrintAndLogEx(INFO, "Can't select AID. EMV AID not found. Exit...");
-		DropField();
+		if (channel == ECC_CONTACTLESS) {
+			DropField();
+		}
 		return 4;
 	}
 
@@ -1376,7 +1384,9 @@ int CmdEMVScan(const char *cmd) {
 	if (!pdol_data_tlv){
 		PrintAndLogEx(ERR, "Can't create PDOL TLV.");
 		tlvdb_free(tlvRoot);
-		DropField();
+		if (channel == ECC_CONTACTLESS) {
+			DropField();
+		}
 		return 6;
 	}
 	
@@ -1399,7 +1409,9 @@ int CmdEMVScan(const char *cmd) {
 	if (res) {  
 		PrintAndLogEx(ERR, "GPO error(%d): %4x. Exit...", res, sw);
 		tlvdb_free(tlvRoot);
-		DropField();
+		if (channel == ECC_CONTACTLESS) {
+			DropField();
+		}
 		return 7;
 	}
 	ProcessGPOResponseFormat1(tlvRoot, buf, len, decodeTLV);
@@ -1491,8 +1503,9 @@ int CmdEMVScan(const char *cmd) {
 	// free tlv object
 	tlvdb_free(tlvRoot);
 
-	// DropField
-	DropField();
+	if (channel == ECC_CONTACTLESS) {
+		DropField();
+	}
 	
 	res = json_dump_file(root, fname, JSON_INDENT(2));
 	if (res) {
@@ -1512,9 +1525,9 @@ int CmdEMVTest(const char *cmd) {
 }
 
 int CmdEMVRoca(const char *cmd) {
-	uint8_t AID[APDU_AID_LEN] = {0};
+	uint8_t AID[APDU_DATA_LEN] = {0};
 	size_t AIDlen = 0;
-	uint8_t buf[APDU_RES_LEN] = {0};
+	uint8_t buf[APDU_RESPONSE_LEN] = {0};
 	size_t len = 0;
 	uint16_t sw = 0;
 	int res;
@@ -1573,7 +1586,9 @@ int CmdEMVRoca(const char *cmd) {
 
 	if (!AIDlen) {
 		PrintAndLogEx(INFO, "Can't select AID. EMV AID not found. Exit...");
-		DropField();
+		if (channel == ECC_CONTACTLESS) {
+			DropField();
+		}
 		return 4;
 	}
 
@@ -1588,7 +1603,9 @@ int CmdEMVRoca(const char *cmd) {
 	if (res) {	
 		PrintAndLogEx(ERR, "Can't select AID (%d). Exit...", res);
 		tlvdb_free(tlvRoot);
-		DropField();
+		if (channel == ECC_CONTACTLESS) {
+			DropField();
+		}
 		return 5;
 	}
 
@@ -1600,7 +1617,9 @@ int CmdEMVRoca(const char *cmd) {
 	if (!pdol_data_tlv){
 		PrintAndLogEx(ERR, "Can't create PDOL TLV.");
 		tlvdb_free(tlvRoot);
-		DropField();
+		if (channel == ECC_CONTACTLESS) {
+			DropField();
+		}
 		return 6;
 	}
 	
@@ -1623,7 +1642,9 @@ int CmdEMVRoca(const char *cmd) {
 	if (res) {	
 		PrintAndLogEx(ERR, "GPO error(%d): %4x. Exit...", res, sw);
 		tlvdb_free(tlvRoot);
-		DropField();
+		if (channel == ECC_CONTACTLESS) {
+			DropField();
+		}
 		return 7;
 	}
 	ProcessGPOResponseFormat1(tlvRoot, buf, len, false);
@@ -1721,9 +1742,9 @@ out:
 	// free tlv object
 	tlvdb_free(tlvRoot);
 
-	if ( channel == ECC_CONTACTLESS)
+	if (channel == ECC_CONTACTLESS) {
 		DropField();
-
+	}
 
 	return 0;
 }
@@ -1732,18 +1753,18 @@ int CmdHelp(const char *Cmd);
 
 static command_t CommandTable[] =  {
 	{"help",        CmdHelp,                    1,  "This help"},
-	{"exec",        CmdEMVExec,                 0,  "Executes EMV contactless transaction."},
-	{"pse",         CmdEMVPPSE,                 0,  "Execute PPSE. It selects 2PAY.SYS.DDF01 or 1PAY.SYS.DDF01 directory."},
-	{"search",      CmdEMVSearch,               0,  "Try to select all applets from applets list and print installed applets."},
-	{"select",      CmdEMVSelect,               0,  "Select applet."},
-	{"gpo",         CmdEMVGPO,                  0,  "Execute GetProcessingOptions."},
-	{"readrec",     CmdEMVReadRecord,           0,  "Read files from card."},
-	{"genac",       CmdEMVAC,                   0,  "Generate ApplicationCryptogram."},
-	{"challenge",   CmdEMVGenerateChallenge,    0,  "Generate challenge."},
-	{"intauth",     CmdEMVInternalAuthenticate, 0,  "Internal authentication."},
-	{"scan",        CmdEMVScan,                 0,  "Scan EMV card and save it contents to json file for emulator."},
-	{"test",        CmdEMVTest,                 0,  "Crypto logic test."},
-	{"roca",        CmdEMVRoca,                 0,  "Extract public keys and run ROCA test"}, 
+	{"exec",        CmdEMVExec,                 1,  "Executes EMV contactless transaction."},
+	{"pse",         CmdEMVPPSE,                 1,  "Execute PPSE. It selects 2PAY.SYS.DDF01 or 1PAY.SYS.DDF01 directory."},
+	{"search",      CmdEMVSearch,               1,  "Try to select all applets from applets list and print installed applets."},
+	{"select",      CmdEMVSelect,               1,  "Select applet."},
+	{"gpo",         CmdEMVGPO,                  1,  "Execute GetProcessingOptions."},
+	{"readrec",     CmdEMVReadRecord,           1,  "Read files from card."},
+	{"genac",       CmdEMVAC,                   1,  "Generate ApplicationCryptogram."},
+	{"challenge",   CmdEMVGenerateChallenge,    1,  "Generate challenge."},
+	{"intauth",     CmdEMVInternalAuthenticate, 1,  "Internal authentication."},
+	{"scan",        CmdEMVScan,                 1,  "Scan EMV card and save it contents to json file for emulator."},
+	{"test",        CmdEMVTest,                 1,  "Crypto logic test."},
+	{"roca",        CmdEMVRoca,                 1,  "Extract public keys and run ROCA test"}, 
 	{NULL,          NULL,                       0,  NULL}
 };
 

--- a/client/emv/emvcore.h
+++ b/client/emv/emvcore.h
@@ -29,8 +29,10 @@
 #include "emv_pk.h"
 #include "emv_pki.h"
 
-#define APDU_RES_LEN 260
-#define APDU_AID_LEN 50
+// maximum APDU lengths. Long APDUs not yet supported/needed
+#define APDU_DATA_LEN      255
+#define APDU_COMMAND_LEN   (4 + 1 + APDU_DATA_LEN + 1)
+#define APDU_RESPONSE_LEN  (256 + 2)
 
 typedef enum {
 	ECC_CONTACTLESS,
@@ -44,15 +46,6 @@ enum TransactionType {
 	TT_CDA,
 };
 extern char *TransactionTypeStr[];
-
-typedef struct {
-	uint8_t CLA;
-	uint8_t INS;
-	uint8_t P1;
-	uint8_t P2;
-	uint8_t Lc;
-	uint8_t *data;
-} sAPDU;
 
 enum CardPSVendor {
 	CV_NA,
@@ -76,7 +69,7 @@ extern struct tlvdb *GetdCVVRawFromTrack2(const struct tlv *track2);
 extern void SetAPDULogging(bool logging);
 
 // exchange
-extern int EMVExchange(EMVCommandChannel channel, bool LeaveFieldON, sAPDU apdu, uint8_t *Result, size_t MaxResultLen, size_t *ResultLen, uint16_t *sw, struct tlvdb *tlv);
+extern int EMVExchange(EMVCommandChannel channel, bool LeaveFieldON, uint8_t *APDU, int APDU_len, uint8_t *Result, size_t MaxResultLen, size_t *ResultLen, uint16_t *sw, struct tlvdb *tlv);
 
 // search application
 extern int EMVSearchPSE(EMVCommandChannel channel, bool ActivateField, bool LeaveFieldON, uint8_t PSENum, bool decodeTLV, struct tlvdb *tlv);

--- a/client/fido/fidocore.h
+++ b/client/fido/fidocore.h
@@ -37,7 +37,7 @@ typedef enum  {
 } fido2PacketType;
 
 extern int FIDOSelect(bool ActivateField, bool LeaveFieldON, uint8_t *Result, size_t MaxResultLen, size_t *ResultLen, uint16_t *sw);
-extern int FIDOExchange(sAPDU apdu, uint8_t *Result, size_t MaxResultLen, size_t *ResultLen, uint16_t *sw);
+extern int FIDOExchange(uint8_t *APDU, int APDU_len, uint8_t *Result, size_t MaxResultLen, size_t *ResultLen, uint16_t *sw);
 extern int FIDORegister(uint8_t *params, uint8_t *Result, size_t MaxResultLen, size_t *ResultLen, uint16_t *sw);
 extern int FIDOAuthentication(uint8_t *params, uint8_t paramslen, uint8_t controlb, uint8_t *Result, size_t MaxResultLen, size_t *ResultLen, uint16_t *sw);
 extern int FIDO2GetInfo(uint8_t *Result, size_t MaxResultLen, size_t *ResultLen, uint16_t *sw);

--- a/client/pcsc.c
+++ b/client/pcsc.c
@@ -175,3 +175,41 @@ bool pcscGetATR(smart_card_atr_t *card)
 	
 	return true;	
 }
+
+
+void pcscTransmit(uint8_t *data, uint32_t data_len, uint32_t flags, uint8_t *response, int *response_len)
+{
+	LPCSCARD_IO_REQUEST protocol;
+	if (flags & SC_RAW_T0) {
+		protocol = SCARD_PCI_T0;
+	} else {
+		protocol = SCARD_PCI_RAW;
+	}
+
+	// TODO: tracing
+	// if ((flags & SC_CONNECT))
+		// clear_trace();
+
+	// set_tracing(true);
+
+	if ((flags & SC_CONNECT || flags & SC_SELECT)) {	
+		LONG res = SCardConnect(SC_Context, AlternativeSmartcardReader, SCARD_SHARE_SHARED,
+		                        SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1, &SC_Card, &SC_Protocol);
+		if (res != SCARD_S_SUCCESS) {
+			*response_len = -1;
+			return;
+		}
+	}
+	
+	if ((flags & SC_RAW) || (flags & SC_RAW_T0)) {
+		// TODO: tracing
+		// LogTrace(data, arg1, 0, 0, NULL, true);
+		DWORD len = *response_len;
+		LONG res = SCardTransmit(SC_Card, protocol, data, data_len, NULL, response, &len);
+		if (res != SCARD_S_SUCCESS) {
+			*response_len = -1;
+		} else {
+			*response_len = len;
+		}
+	}
+}

--- a/client/pcsc.h
+++ b/client/pcsc.h
@@ -18,5 +18,6 @@ char *getAlternativeSmartcardReader(void);
 bool pcscCheckForCardReaders(void);
 bool pcscSelectAlternativeCardReader(const char *readername);
 bool pcscGetATR(smart_card_atr_t *card);
+void pcscTransmit(uint8_t *data, uint32_t data_len, uint32_t flags, uint8_t *response, int *response_len);
 
 #endif

--- a/client/proxmark3.c
+++ b/client/proxmark3.c
@@ -28,7 +28,6 @@
 #include "cmdhw.h"
 #include "whereami.h"
 #include "comms.h"
-#include "pcsc.h"
 
 
 void

--- a/common/protocols.h
+++ b/common/protocols.h
@@ -262,12 +262,13 @@ NXP/Philips CUSTOM COMMANDS
 #define ISO7816_VERIFY                   0x20
 #define ISO7816_INTERNAL_AUTHENTICATION  0x88
 #define ISO7816_EXTERNAL_AUTHENTICATION  0x82
-#define ISO7816_GET_CHALLENGE            0xB4
+#define ISO7816_GET_CHALLENGE            0x84
 #define ISO7816_MANAGE_CHANNEL           0x70
-#define ISO7816_GETSTATUS                0xC0
+#define ISO7816_GET_RESPONSE             0xC0
 // ISO7816-4	For response APDU's
 #define ISO7816_OK                       0x9000
 //	6x xx = ERROR
+#define ISO7816_MAX_FRAME_SIZE           261
 
 
 


### PR DESCRIPTION
* add PCSC reader support to 'sc raw' and all 'emv' commands
* move all APDU -> TPDU mapping to ExchangeAPDUSC()
* print "PSE" instead of "PPSE" when using contact interface
* fix some #defines in protocols.h
* DropField only when using contactless
* some refactoring