### PR TITLE
Legic TagSim: increased reader timeout

### DIFF
--- a/armsrc/legicrfsim.c
+++ b/armsrc/legicrfsim.c
@@ -51,7 +51,7 @@ static uint32_t last_frame_end; /* ts of last bit of previews rx or tx frame */
 #define RWD_TIME_PAUSE        4 /* 18.9us */
 #define RWD_TIME_1           21 /* RWD_TIME_PAUSE 18.9us off + 80.2us on = 99.1us */
 #define RWD_TIME_0           13 /* RWD_TIME_PAUSE 18.9us off + 42.4us on = 61.3us */
-#define RWD_CMD_TIMEOUT      40 /* 40 * 99.1us (arbitrary value) */
+#define RWD_CMD_TIMEOUT     120 /* 120 * 99.1us (arbitrary value) */
 #define RWD_MIN_FRAME_LEN     6 /* Shortest frame is 6 bits */
 #define RWD_MAX_FRAME_LEN    23 /* Longest frame is 23 bits */
 


### PR DESCRIPTION
Bug reports from @raphCode and @uhei over at the RfidResearchGroup/proxmark3#83 have shown that the tag to rwd timeout is too short.

I still don't know that the best choice is. If the timeout is too short the tag returns too early to idle. If the timeout is too long the tag might never return to idle since it considers reconnects to be still the old connection. That sed both reported success with the new timeout.