### PR TITLE
emv/sc fixes and modifications:

### DIFF
--- a/client/cmdhffido.c
+++ b/client/cmdhffido.c
@@ -40,6 +40,7 @@
 #include "emv/emvcore.h"
 #include "emv/emvjson.h"
 #include "emv/dump.h"
+#include "emv/apduinfo.h"
 #include "cliparser/cliparser.h"
 #include "crypto/asn1utils.h"
 #include "crypto/libpcrypto.h"

--- a/client/emv/emvcore.c
+++ b/client/emv/emvcore.c
@@ -330,8 +330,8 @@ int EMVExchangeEx(EMVCommandChannel channel, bool ActivateField, bool LeaveField
 	if (Result[*ResultLen-2] == 0x61) {
 		uint8_t La = Result[*ResultLen-1];
 		uint8_t get_response[5] = {apdu[0], ISO7816_GET_RESPONSE, 0x00, 0x00, La};
-		size_t oldlen = *ResultLen-2;
-		res = EMVExchangeEx(channel, false, LeaveFieldON, get_response, sizeof(get_response), &Result[oldlen], MaxResultLen-oldlen, ResultLen, sw, tlv);
+		size_t oldlen = *ResultLen;
+		res = EMVExchangeEx(channel, false, LeaveFieldON, get_response, sizeof(get_response), &Result[oldlen-2], MaxResultLen-oldlen+2, ResultLen, sw, tlv);
 		*ResultLen += oldlen;
 	}
 

--- a/client/emv/emvcore.h
+++ b/client/emv/emvcore.h
@@ -11,23 +11,10 @@
 #ifndef EMVCORE_H__
 #define EMVCORE_H__
 
-#include <stdio.h>
 #include <stdint.h>
-#include <stdlib.h>
-#include <inttypes.h>
-#include <string.h>
-#include <jansson.h>
-#include "util.h"
-#include "common.h"
-#include "ui.h"
-#include "cmdhf14a.h"
-#include "apduinfo.h"
+#include <stdbool.h>
 #include "tlv.h"
-#include "dol.h"
-#include "dump.h"
-#include "emv_tags.h"
-#include "emv_pk.h"
-#include "emv_pki.h"
+#include "jansson.h"
 
 // maximum APDU lengths. Long APDUs not yet supported/needed
 #define APDU_DATA_LEN      255
@@ -60,6 +47,8 @@ enum CardPSVendor {
 };
 extern enum CardPSVendor GetCardPSVendor(uint8_t * AID, size_t AIDlen);
 
+extern void DropFieldEx(EMVCommandChannel channel);
+
 extern bool TLVPrintFromBuffer(uint8_t *data, int datalen);
 extern void TLVPrintFromTLV(struct tlvdb *tlv);
 extern void TLVPrintFromTLVLev(struct tlvdb *tlv, int level);
@@ -71,7 +60,7 @@ extern struct tlvdb *GetdCVVRawFromTrack2(const struct tlv *track2);
 extern void SetAPDULogging(bool logging);
 
 // exchange
-extern int EMVExchange(EMVCommandChannel channel, bool LeaveFieldON, uint8_t *APDU, int APDU_len, uint8_t *Result, size_t MaxResultLen, size_t *ResultLen, uint16_t *sw, struct tlvdb *tlv);
+extern int EMVExchangeEx(EMVCommandChannel channel, bool ActivateField, bool LeaveFieldON, uint8_t *apdu, int apdu_len, uint8_t *Result, size_t MaxResultLen, size_t *ResultLen, uint16_t *sw, struct tlvdb *tlv);
 
 // search application
 extern int EMVSearchPSE(EMVCommandChannel channel, bool ActivateField, bool LeaveFieldON, uint8_t PSENum, bool decodeTLV, struct tlvdb *tlv);

--- a/client/fido/cbortools.c
+++ b/client/fido/cbortools.c
@@ -11,7 +11,10 @@
 //
 
 #include "cbortools.h"
+
 #include <stdlib.h>
+#include <inttypes.h>
+
 #include "emv/emvjson.h"
 #include "util.h"
 #include "fidocore.h"

--- a/client/fido/fidocore.c
+++ b/client/fido/fidocore.c
@@ -22,7 +22,10 @@
 #include "crypto/libpcrypto.h"
 #include "fido/additional_ca.h"
 #include "fido/cose.h"
+#include "emv/dump.h"
 #include "protocols.h"
+#include "ui.h"
+#include "util.h"
 
 
 typedef struct {
@@ -176,22 +179,22 @@ int FIDOSelect(bool ActivateField, bool LeaveFieldON, uint8_t *Result, size_t Ma
 }
 
 int FIDOExchange(uint8_t* apdu, int apdulen, uint8_t *Result, size_t MaxResultLen, size_t *ResultLen, uint16_t *sw) {
-	int res = EMVExchange(ECC_CONTACTLESS, true, apdu, apdulen, Result, MaxResultLen, ResultLen, sw, NULL);
-	if (res == 5) // apdu result (sw) not a 0x9000
-		res = 0;
-	// software chaining
-	while (!res && (*sw >> 8) == 0x61) {
-		uint8_t La = *sw & 0xff;
-		uint8_t get_response_APDU[5] = {apdu[0], ISO7816_GET_RESPONSE, 0x00, 0x00, La};
-		size_t oldlen = *ResultLen;
-		res = EMVExchange(ECC_CONTACTLESS, true, get_response_APDU, sizeof(get_response_APDU), &Result[oldlen], MaxResultLen - oldlen, ResultLen, sw, NULL);
-		if (res == 5) // apdu result (sw) not a 0x9000
-			res = 0;
+	int res = EMVExchangeEx(ECC_CONTACTLESS, false, true, apdu, apdulen, Result, MaxResultLen, ResultLen, sw, NULL);
+	// if (res == 5) // apdu result (sw) not a 0x9000
+		// res = 0;
+	// // software chaining
+	// while (!res && (*sw >> 8) == 0x61) {
+		// uint8_t La = *sw & 0xff;
+		// uint8_t get_response_APDU[5] = {apdu[0], ISO7816_GET_RESPONSE, 0x00, 0x00, La};
+		// size_t oldlen = *ResultLen;
+		// res = EMVExchange(ECC_CONTACTLESS, true, get_response_APDU, sizeof(get_response_APDU), &Result[oldlen], MaxResultLen - oldlen, ResultLen, sw, NULL);
+		// if (res == 5) // apdu result (sw) not a 0x9000
+			// res = 0;
 		
-		*ResultLen += oldlen;
-		if (*ResultLen > MaxResultLen) 
-			return 100;
-	}
+		// *ResultLen += oldlen;
+		// if (*ResultLen > MaxResultLen) 
+			// return 100;
+	// }
 	return res;
 }
 


### PR DESCRIPTION
* print selected Smartcard Reader in PrintChannel()
* implement 'sc sel \<readername\>'. Readername can include wildcards * and ?
* fixing EMV APDU exchange (again). fix #775 had broken emv commands using contact interface
* use EMVExchangeEx() instead of EMVExchange() in fidocore.c