### PR TITLE
Fix for USB uart slowness since PR #720

### DIFF
--- a/uart/uart_posix.c
+++ b/uart/uart_posix.c
@@ -69,9 +69,9 @@ typedef struct {
 } serial_port_unix;
 
 // Set time-out on 30 miliseconds
-const struct timeval timeout = {
+struct timeval timeout = {
   .tv_sec  =     0, // 0 second
-  .tv_usec = 300000  // 300000 micro seconds
+  .tv_usec = 30000  // 30000 micro seconds
 };
 
 serial_port uart_open(const char* pcPortName)
@@ -88,6 +88,10 @@ serial_port uart_open(const char* pcPortName)
     }
     char *colon = strrchr(addrstr, ':');
     char *portstr;
+
+    // Set time-out to 300 miliseconds only for TCP port
+    timeout.tv_usec = 300000;
+
     if (colon) {
       portstr = colon + 1;
       *colon = '\0';


### PR DESCRIPTION
Since PR #720 USB uart communications are slow:

For example, dumping a Mifare 1K card take up to 20 seconds now !

```
Saving magic mifare 1K 

     Start |        End | Src | Data (! denotes parity error)                                   | CRC | Annotation         |          
------------|------------|-----|-----------------------------------------------------------------|-----|--------------------|          
          0 |        992 | Rdr | 40                                                              |     | MAGIC WUPC1          
       2244 |       2820 | Tag | 0a!                                                             |     |           
       7040 |      11808 | Rdr | 30  00  02  a8                                                  |  ok | READBLOCK(0)          
      12996 |      33860 | Tag | **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  |     |           
            |            |     | 3d  cd                                                          |  ok |           
    4125184 |    4129952 | Rdr | 30  01  8b  b9                                                  |  ok | READBLOCK(1)          
    4131140 |    4152004 | Tag | **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  |     |           
            |            |     | c0  83                                                          |  ok |           
    8243456 |    8248160 | Rdr | 30  02  10  8b                                                  |  ok | READBLOCK(2)          
    8249412 |    8270276 | Tag | **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  |     |           
            |            |     | 37  49                                                          |  ok |           
   12362752 |   12367456 | Rdr | 30  03  99  9a                                                  |  ok | READBLOCK(3)
            |            |     | 38  6e                                                          |  ok |           
   16481024 |   16485728 | Rdr | 30  04  26  ee                                                  |  ok | READBLOCK(4)          
   16486980 |   16507844 | Tag | **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  |     |           
            |            |     | cd  3e                                                          |  ok |            
```

In my investigation i discovered that There is a delay of ~300ms for waiting the response (watch time values !).
It was due to the change of the timeout for TCP, in fact there is a big performance impact on USB !

After the correction, performance is back to normal:

```
Saving magic mifare 1K 

      Start |        End | Src | Data (! denotes parity error)                                   | CRC | Annotation         |          
------------|------------|-----|-----------------------------------------------------------------|-----|--------------------|          
          0 |        992 | Rdr | 40                                                              |     | MAGIC WUPC1          
       2244 |       2820 | Tag | 0a!                                                             |     |           
       7040 |      11808 | Rdr | 30  00  02  a8                                                  |  ok | READBLOCK(0)          
      12996 |      33860 | Tag | **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  |     |           
            |            |     | 3d  cd                                                          |  ok |           
     461952 |     466720 | Rdr | 30  01  8b  b9                                                  |  ok | READBLOCK(1)          
     467908 |     488772 | Tag | **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  |     |           
            |            |     | c0  83                                                          |  ok |           
     916864 |     921568 | Rdr | 30  02  10  8b                                                  |  ok | READBLOCK(2)          
     922820 |     943684 | Tag | **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  |     |           
            |            |     | 37  49                                                          |  ok |           
    1370496 |    1375200 | Rdr | 30  03  99  9a                                                  |  ok | READBLOCK(3)          
    1376452 |    1397316 | Tag | **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  |     |           
            |            |     | 38  6e                                                          |  ok |           
    1824768 |    1829472 | Rdr | 30  04  26  ee                                                  |  ok | READBLOCK(4)          
    1830724 |    1851588 | Tag | **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  |     |           
            |            |     | cd  3e                                                          |  ok |           
```

Nobody noticed that ?