### PR TITLE
Fixed bugs for FDX-B demod

### DIFF
--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -367,18 +367,20 @@ int Cmdmandecoderaw(const char *Cmd)
 	return 1;
 }
 
-//by marshmellow
-//biphase decode
-//take 01 or 10 = 0 and 11 or 00 = 1
-//takes 2 arguments "offset" default = 0 if 1 it will shift the decode by one bit
-// and "invert" default = 0 if 1 it will invert output
-//  the argument offset allows us to manually shift if the output is incorrect - [EDIT: now auto detects]
+/** 
+ * @author marshmellow
+ * biphase decode
+ * decdoes  01 or 10 to 0 and 11 or 00 to 1
+ * param offset adjust start position
+ * param invert invert output
+ * param maxErr maximum tolerated errors 
+ */
 int CmdBiphaseDecodeRaw(const char *Cmd)
 {
 	size_t size=0;
 	int offset=0, invert=0, maxErr=20, errCnt=0;
 	char cmdp = param_getchar(Cmd, 0);
-	if (strlen(Cmd) > 3 || cmdp == 'h' || cmdp == 'H') {
+	if (strlen(Cmd) > 5 || cmdp == 'h' || cmdp == 'H') {
 		PrintAndLog("Usage:  data biphaserawdecode [offset] [invert] [maxErr]");
 		PrintAndLog("     Converts 10 or 01 to 1 and 11 or 00 to 0");
 		PrintAndLog("     --must have binary sequence in demodbuffer (run data askrawdemod first)");

--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -429,7 +429,7 @@ int CmdBiphaseDecodeRaw(const char *Cmd)
 int ASKbiphaseDemod(const char *Cmd, bool verbose)
 {
 	//ask raw demod GraphBuffer first
-	int offset=0, clk=0, invert=0, maxErr=0;
+	int offset=0, clk=0, invert=0, maxErr=100;
 	sscanf(Cmd, "%i %i %i %i", &offset, &clk, &invert, &maxErr);
 
 	uint8_t BitStream[MAX_GRAPH_TRACE_LEN];	  

--- a/client/cmddata.c
+++ b/client/cmddata.c
@@ -380,7 +380,7 @@ int CmdBiphaseDecodeRaw(const char *Cmd)
 	size_t size=0;
 	int offset=0, invert=0, maxErr=20, errCnt=0;
 	char cmdp = param_getchar(Cmd, 0);
-	if (strlen(Cmd) > 5 || cmdp == 'h' || cmdp == 'H') {
+	if (strlen(Cmd) > 7 || cmdp == 'h' || cmdp == 'H') {
 		PrintAndLog("Usage:  data biphaserawdecode [offset] [invert] [maxErr]");
 		PrintAndLog("     Converts 10 or 01 to 1 and 11 or 00 to 0");
 		PrintAndLog("     --must have binary sequence in demodbuffer (run data askrawdemod first)");

--- a/client/cmdlffdx.c
+++ b/client/cmdlffdx.c
@@ -206,7 +206,7 @@ int CmdFdxDemod(const char *Cmd){
 }
 
 int CmdFdxRead(const char *Cmd) {
-	lf_read(true, 10000);
+	lf_read(true, 39999);
 	return CmdFdxDemod(Cmd);
 }
 

--- a/client/cmdlffdx.c
+++ b/client/cmdlffdx.c
@@ -137,7 +137,7 @@ int CmdFdxDemod(const char *Cmd){
 
 	//Differential Biphase / di-phase (inverted biphase)
 	//get binary from ask wave
-	if (!ASKbiphaseDemod("0 32 1 0", false)) {
+	if (!ASKbiphaseDemod("0 32 1 100", false)) {
 		if (g_debugMode) PrintAndLog("DEBUG: Error - FDX-B ASKbiphaseDemod failed");
 		return 0;
 	}


### PR DESCRIPTION
# CmdBiphaseDecodeRaw()
In CmdBiphaseDecodeRaw it was not possible to set an maxErr-value, because cmd was restricted to strlen 3. Now its 5, so its possible to enter an maxErr-value between 0-9. Maybe it should be 7 to allow values from 0-999?
_(changed the comment a bit, too)_

# ASKbiphaseDemod()
In ASKbiphaseDemod the help text says 
> [set maximum allowed errors], default = 100

but in fact default was 0 errors. Changed to 100, so it works like expected.

# CmdFdxDemod()
The function CmdFdxDemod uses ASKbiphaseDemod and sets maximum allowed errors to 0. If you have any demod-error here, FDX-demod fails. Set to 100, because its standard as mentioned above. 
Now i'm able to demod FDX. :)