### PR TITLE
fix hf mf sim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added `hf plot` (piwi)
 - Added `hf mfp mad` `hf mf mad` parsing MAD1 and MAD2 (Merlok)
 - Added `hf mfp ndef` `hf mf ndef` parsing NDEF records (Merlok)
+- Added Mifare Mini, Mifare 2K and 4K support to `hf mf sim` (piwi)
 
 ## [v3.1.0][2018-10-10]
 

--- a/armsrc/BigBuf.c
+++ b/armsrc/BigBuf.c
@@ -21,8 +21,8 @@
 /* BigBuf memory layout:
 Pointer to highest available memory: BigBuf_hi
 
-    high BIGBUF_SIZE
-    reserved = BigBuf_malloc()  subtracts amount from BigBuf_hi,   
+	high BIGBUF_SIZE
+	reserved = BigBuf_malloc()  subtracts amount from BigBuf_hi,
 	low  0x00
 */
 
@@ -39,6 +39,7 @@ static uint8_t *emulator_memory = NULL;
 static uint32_t traceLen = 0;
 static bool tracing = true;
 
+
 // get the address of BigBuf
 uint8_t *BigBuf_get_addr(void)
 {
@@ -53,7 +54,7 @@ uint8_t *BigBuf_get_EM_addr(void)
 	if (emulator_memory == NULL) {
 		emulator_memory = BigBuf_malloc(CARD_MEMORY_SIZE);
 	}
-	
+
 	return emulator_memory;
 }
 
@@ -63,16 +64,21 @@ void BigBuf_Clear(void)
 {
 	BigBuf_Clear_ext(true);
 }
+
+
 // clear ALL of BigBuf
 void BigBuf_Clear_ext(bool verbose)
 {
 	memset(BigBuf, 0, BIGBUF_SIZE);
-	if (verbose) 
-		Dbprintf("Buffer cleared (%i bytes)",BIGBUF_SIZE);
+	if (verbose)
+		Dbprintf("Buffer cleared (%i bytes)", BIGBUF_SIZE);
 }
+
+
 void BigBuf_Clear_EM(void){
 	memset(BigBuf_get_EM_addr(), 0, CARD_MEMORY_SIZE);
 }
+
 
 void BigBuf_Clear_keep_EM(void)
 {
@@ -83,11 +89,11 @@ void BigBuf_Clear_keep_EM(void)
 // at the beginning of BigBuf is always for traces/samples
 uint8_t *BigBuf_malloc(uint16_t chunksize)
 {
-	if (BigBuf_hi - chunksize < 0) { 
-		return NULL;							// no memory left
+	if (BigBuf_hi - chunksize < 0) {
+		return NULL;                            // no memory left
 	} else {
-		chunksize = (chunksize + 3) & 0xfffc;	// round to next multiple of 4
-		BigBuf_hi -= chunksize; 		  		// aligned to 4 Byte boundary 
+		chunksize = (chunksize + 3) & 0xfffc;   // round to next multiple of 4
+		BigBuf_hi -= chunksize;                 // aligned to 4 Byte boundary
 		return (uint8_t *)BigBuf + BigBuf_hi;
 	}
 }
@@ -128,17 +134,21 @@ uint16_t BigBuf_max_traceLen(void)
 	return BigBuf_hi;
 }
 
+
 void clear_trace() {
 	traceLen = 0;
 }
+
 
 void set_tracing(bool enable) {
 	tracing = enable;
 }
 
+
 bool get_tracing(void) {
 	return tracing;
 }
+
 
 /**
  * Get the number of bytes traced
@@ -148,6 +158,7 @@ uint16_t BigBuf_get_traceLen(void)
 {
 	return traceLen;
 }
+
 
 /**
   This is a function to store traces. All protocols can use this generic tracer-function.
@@ -162,14 +173,14 @@ bool RAMFUNC LogTrace(const uint8_t *btBytes, uint16_t iLen, uint32_t timestamp_
 
 	uint8_t *trace = BigBuf_get_addr();
 
-	uint32_t num_paritybytes = (iLen-1)/8 + 1;	// number of valid paritybytes in *parity
+	uint32_t num_paritybytes = (iLen-1)/8 + 1;  // number of valid paritybytes in *parity
 	uint32_t duration = timestamp_end - timestamp_start;
 
 	// Return when trace is full
 	uint16_t max_traceLen = BigBuf_max_traceLen();
 
 	if (traceLen + sizeof(iLen) + sizeof(timestamp_start) + sizeof(duration) + num_paritybytes + iLen >= max_traceLen) {
-		tracing = false;	// don't trace any more
+		tracing = false;    // don't trace any more
 		return false;
 	}
 	// Traceformat:
@@ -237,7 +248,7 @@ int LogTraceHitag(const uint8_t * btBytes, int iBits, int iSamples, uint32_t dwP
 	// Return when trace is full
 	if (traceLen + sizeof(rsamples) + sizeof(dwParity) + sizeof(iBits) + iLen > BigBuf_max_traceLen()) {
 		return false;
-	}	
+	}
 
 	//Hitag traces appear to use this traceformat:
 	// 32 bits timestamp (little endian,Highest Bit used as readerToTag flag)

--- a/armsrc/BigBuf.h
+++ b/armsrc/BigBuf.h
@@ -20,7 +20,7 @@
 #define MAX_PARITY_SIZE			((MAX_FRAME_SIZE + 7) / 8)
 #define MAX_MIFARE_FRAME_SIZE	18		// biggest Mifare frame is answer to a read (one block = 16 Bytes) + 2 Bytes CRC
 #define MAX_MIFARE_PARITY_SIZE	3		// need 18 parity bits for the 18 Byte above. 3 Bytes are enough to store these
-#define CARD_MEMORY_SIZE		4096	
+#define CARD_MEMORY_SIZE		4096
 #define DMA_BUFFER_SIZE    		128
 
 extern uint8_t *BigBuf_get_addr(void);

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -29,6 +29,7 @@
 #include "lfsampling.h"
 #include "BigBuf.h"
 #include "mifareutil.h"
+#include "mifaresim.h"
 #include "pcf7931.h"
 #include "i2c.h"
 #include "hfsnoop.h"
@@ -1249,7 +1250,7 @@ void UsbPacketReceived(uint8_t *packet, int len)
 			MifareChkKeys(c->arg[0], c->arg[1], c->arg[2], c->d.asBytes);
 			break;
 		case CMD_SIMULATE_MIFARE_CARD:
-			Mifare1ksim(c->arg[0], c->arg[1], c->arg[2], c->d.asBytes);
+			MifareSim(c->arg[0], c->arg[1], c->arg[2], c->d.asBytes);
 			break;
 		
 		// emulator

--- a/armsrc/apps.h
+++ b/armsrc/apps.h
@@ -119,7 +119,6 @@ void MifareUWriteBlock(uint8_t arg0, uint8_t arg1, uint8_t *datain);
 void MifareNested(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *datain);
 void MifareAcquireEncryptedNonces(uint32_t arg0, uint32_t arg1, uint32_t flags, uint8_t *datain);
 void MifareChkKeys(uint16_t arg0, uint16_t arg1, uint8_t arg2, uint8_t *datain);
-void Mifare1ksim(uint8_t arg0, uint8_t arg1, uint8_t arg2, uint8_t *datain);
 void MifareSetDbgLvl(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *datain);
 void MifareEMemClr(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *datain);
 void MifareEMemSet(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint8_t *datain);

--- a/armsrc/fpgaloader.c
+++ b/armsrc/fpgaloader.c
@@ -136,7 +136,7 @@ void FpgaSetupSsc(uint8_t FPGA_mode)
 
 	// 8, 16 or 32 bits per transfer, no loopback, MSB first, 1 transfer per sync
 	// pulse, no output sync
-	if ((FPGA_mode & 0xe0) == FPGA_MAJOR_MODE_HF_READER) {
+	if ((FPGA_mode & 0xe0) == FPGA_MAJOR_MODE_HF_READER && FpgaGetCurrent() == FPGA_BITSTREAM_HF) {
 		AT91C_BASE_SSC->SSC_RFMR = SSC_FRAME_MODE_BITS_IN_WORD(16) | AT91C_SSC_MSBF | SSC_FRAME_MODE_WORDS_PER_TRANSFER(0);
 	} else {
 		AT91C_BASE_SSC->SSC_RFMR = SSC_FRAME_MODE_BITS_IN_WORD(8) | AT91C_SSC_MSBF | SSC_FRAME_MODE_WORDS_PER_TRANSFER(0);

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -1264,6 +1264,7 @@ static void PrepareDelayedTransfer(uint16_t delay)
 //-------------------------------------------------------------------------------------
 static void TransmitFor14443a(const uint8_t *cmd, uint16_t len, uint32_t *timing)
 {
+	LED_B_ON();
 	LED_D_ON();
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_ISO14443A | FPGA_HF_ISO14443A_READER_MOD);
 
@@ -1299,6 +1300,7 @@ static void TransmitFor14443a(const uint8_t *cmd, uint16_t len, uint32_t *timing
 	}
 	
 	NextTransferTime = MAX(NextTransferTime, LastTimeProxToAirStart + REQUEST_GUARD_TIME);
+	LED_B_OFF();
 }
 
 
@@ -1420,8 +1422,6 @@ int EmGetCmd(uint8_t *received, uint16_t *len, uint8_t *parity)
 
 	// Set FPGA mode to "simulated ISO 14443 tag", no modulation (listen
 	// only, since we are receiving, not transmitting).
-	// Signal field is off with the appropriate LED
-	LED_D_OFF();
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_ISO14443A | FPGA_HF_ISO14443A_TAGSIM_LISTEN);
 
 	for(;;) {
@@ -1463,12 +1463,13 @@ int EmGetCmd(uint8_t *received, uint16_t *len, uint8_t *parity)
 
 static int EmSendCmd14443aRaw(uint8_t *resp, uint16_t respLen)
 {
+	LED_C_ON();
+	
 	uint8_t b;
 	uint16_t i = 0;
 	bool correctionNeeded;
 
 	// Modulate Manchester
-	LED_D_OFF();
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_ISO14443A | FPGA_HF_ISO14443A_TAGSIM_MOD);
 
 	// include correction bit if necessary
@@ -1516,6 +1517,7 @@ static int EmSendCmd14443aRaw(uint8_t *resp, uint16_t respLen)
 		}
 	}
 
+	LED_C_OFF();
 	return 0;
 }
 
@@ -1762,7 +1764,7 @@ int iso14443a_select_card(byte_t *uid_ptr, iso14a_card_select_t *p_hi14a_card, u
 	
 	// OK we will select at least at cascade 1, lets see if first byte of UID was 0x88 in
 	// which case we need to make a cascade 2 request and select - this is a long UID
-	// While the UID is not complete, the 3nd bit (from the right) is set in the SAK.
+	// While the UID is not complete, the 3rd bit (from the right) is set in the SAK.
 	for(; sak & 0x04; cascade_level++) {
 		// SELECT_* (L1: 0x93, L2: 0x95, L3: 0x97)
 		sel_uid[0] = sel_all[0] = 0x93 + cascade_level * 2;

--- a/armsrc/iso14443a.c
+++ b/armsrc/iso14443a.c
@@ -68,7 +68,7 @@ typedef struct {
 		// DROP_FIRST_HALF,
 		} state;
 	uint16_t shiftReg;
-	int16_t	 bitCount;
+	int16_t  bitCount;
 	uint16_t len;
 	uint16_t byteCntMax;
 	uint16_t posCnt;
@@ -77,7 +77,7 @@ typedef struct {
 	uint8_t  parityLen;
 	uint32_t fourBits;
 	uint32_t startTime, endTime;
-    uint8_t *output;
+	uint8_t *output;
 	uint8_t *parity;
 } tUart;
 
@@ -94,8 +94,8 @@ static uint8_t iso14_pcb_blocknum = 0;
 //
 // minimum time between the start bits of consecutive transfers from reader to tag: 7000 carrier (13.56Mhz) cycles
 #define REQUEST_GUARD_TIME (7000/16 + 1)
-// minimum time between last modulation of tag and next start bit from reader to tag: 1172 carrier cycles 
-#define FRAME_DELAY_TIME_PICC_TO_PCD (1172/16 + 1) 
+// minimum time between last modulation of tag and next start bit from reader to tag: 1172 carrier cycles
+#define FRAME_DELAY_TIME_PICC_TO_PCD (1172/16 + 1)
 // bool LastCommandWasRequest = false;
 
 //
@@ -107,8 +107,8 @@ static uint8_t iso14_pcb_blocknum = 0;
 // 8 ticks until bit_to_arm is assigned from curbit
 // 8*16 ticks for the transfer from FPGA to ARM
 // 4*16 ticks until we measure the time
-// - 8*16 ticks because we measure the time of the previous transfer 
-#define DELAY_AIR2ARM_AS_READER (3 + 16 + 8 + 8*16 + 4*16 - 8*16) 
+// - 8*16 ticks because we measure the time of the previous transfer
+#define DELAY_AIR2ARM_AS_READER (3 + 16 + 8 + 8*16 + 4*16 - 8*16)
 
 // When the PM acts as a reader and is sending, it takes
 // 4*16 ticks until we can write data to the sending hold register
@@ -125,10 +125,10 @@ static uint8_t iso14_pcb_blocknum = 0;
 // 8 ticks until the SSC samples the first data
 // 7*16 ticks to complete the transfer from FPGA to ARM
 // 8 ticks until the next ssp_clk rising edge
-// 4*16 ticks until we measure the time 
-// - 8*16 ticks because we measure the time of the previous transfer 
+// 4*16 ticks until we measure the time
+// - 8*16 ticks because we measure the time of the previous transfer
 #define DELAY_AIR2ARM_AS_TAG (2 + 3 + 8 + 8 + 7*16 + 8 + 4*16 - 8*16)
- 
+
 // The FPGA will report its internal sending delay in
 uint16_t FpgaSendQueueDelay;
 // the 5 first bits are the number of bits buffered in mod_sig_buf
@@ -150,16 +150,16 @@ uint16_t FpgaSendQueueDelay;
 // 8 ticks (on average) until the result is stored in to_arm
 // + the delays in transferring data - which is the same for
 // sniffing reader and tag data and therefore not relevant
-#define DELAY_TAG_AIR2ARM_AS_SNIFFER (3 + 14 + 8) 
- 
+#define DELAY_TAG_AIR2ARM_AS_SNIFFER (3 + 14 + 8)
+
 // When the PM acts as sniffer and is receiving reader data, it takes
-// 2 ticks delay in analogue RF receiver (for the falling edge of the 
+// 2 ticks delay in analogue RF receiver (for the falling edge of the
 // start bit, which marks the start of the communication)
 // 3 ticks A/D conversion
 // 8 ticks on average until the data is stored in to_arm.
 // + the delays in transferring data - which is the same for
 // sniffing reader and tag data and therefore not relevant
-#define DELAY_READER_AIR2ARM_AS_SNIFFER (2 + 3 + 8) 
+#define DELAY_READER_AIR2ARM_AS_SNIFFER (2 + 3 + 8)
 
 //variables used for timing purposes:
 //these are in ssp_clk cycles:
@@ -177,12 +177,12 @@ static uint32_t LastProxToAirDuration;
 // Sequence X: 00001100 drop after half a period
 // Sequence Y: 00000000 no drop
 // Sequence Z: 11000000 drop at start
-#define	SEC_D 0xf0
-#define	SEC_E 0x0f
-#define	SEC_F 0x00
-#define	SEC_X 0x0c
-#define	SEC_Y 0x00
-#define	SEC_Z 0xc0
+#define SEC_D 0xf0
+#define SEC_E 0x0f
+#define SEC_F 0x00
+#define SEC_X 0x0c
+#define SEC_Y 0x00
+#define SEC_Z 0xc0
 
 void iso14a_set_trigger(bool enable) {
 	trigger = enable;
@@ -214,8 +214,8 @@ void GetParity(const uint8_t *pbtCmd, uint16_t iLen, uint8_t *par)
 		// Generate the parity bits
 		parityBits |= ((oddparity8(pbtCmd[i])) << (7-paritybit_cnt));
 		if (paritybit_cnt == 7) {
-			par[paritybyte_cnt] = parityBits;	// save 8 Bits parity
-			parityBits = 0;						// and advance to next Parity Byte
+			par[paritybyte_cnt] = parityBits;   // save 8 Bits parity
+			parityBits = 0;                     // and advance to next Parity Byte
 			paritybyte_cnt++;
 			paritybit_cnt = 0;
 		} else {
@@ -225,7 +225,7 @@ void GetParity(const uint8_t *pbtCmd, uint16_t iLen, uint8_t *par)
 
 	// save remaining parity bits
 	par[paritybyte_cnt] = parityBits;
-	
+
 }
 
 void AppendCrc14443a(uint8_t* data, int len)
@@ -244,14 +244,14 @@ static void AppendCrc14443b(uint8_t* data, int len)
 //=============================================================================
 // Basics:
 // This decoder is used when the PM3 acts as a tag.
-// The reader will generate "pauses" by temporarily switching of the field. 
-// At the PM3 antenna we will therefore measure a modulated antenna voltage. 
+// The reader will generate "pauses" by temporarily switching of the field.
+// At the PM3 antenna we will therefore measure a modulated antenna voltage.
 // The FPGA does a comparison with a threshold and would deliver e.g.:
 // ........  1 1 1 1 1 1 0 0 1 1 1 1 1 1 1 1 1 1 0 0 1 1 1 1 1 1 1 1 1 1  .......
 // The Miller decoder needs to identify the following sequences:
-// 2 (or 3) ticks pause followed by 6 (or 5) ticks unmodulated: 	pause at beginning - Sequence Z ("start of communication" or a "0")
-// 8 ticks without a modulation: 									no pause - Sequence Y (a "0" or "end of communication" or "no information")
-// 4 ticks unmodulated followed by 2 (or 3) ticks pause:			pause in second half - Sequence X (a "1")
+// 2 (or 3) ticks pause followed by 6 (or 5) ticks unmodulated:     pause at beginning - Sequence Z ("start of communication" or a "0")
+// 8 ticks without a modulation:                                    no pause - Sequence Y (a "0" or "end of communication" or "no information")
+// 4 ticks unmodulated followed by 2 (or 3) ticks pause:            pause in second half - Sequence X (a "1")
 // Note 1: the bitstream may start at any time. We therefore need to sync.
 // Note 2: the interpretation of Sequence Y and Z depends on the preceding sequence.
 //-----------------------------------------------------------------------------
@@ -274,19 +274,19 @@ static void UartReset()
 {
 	Uart.state = STATE_UNSYNCD;
 	Uart.bitCount = 0;
-	Uart.len = 0;						// number of decoded data bytes
-	Uart.parityLen = 0;					// number of decoded parity bytes
-	Uart.shiftReg = 0;					// shiftreg to hold decoded data bits
-	Uart.parityBits = 0;				// holds 8 parity bits
-	Uart.startTime = 0;
-	Uart.endTime = 0;
+	Uart.len = 0;                       // number of decoded data bytes
+	Uart.parityLen = 0;                 // number of decoded parity bytes
+	Uart.shiftReg = 0;                  // shiftreg to hold decoded data bits
+	Uart.parityBits = 0;                // holds 8 parity bits
 }
 
 static void UartInit(uint8_t *data, uint8_t *parity)
 {
 	Uart.output = data;
 	Uart.parity = parity;
-	Uart.fourBits = 0x00000000;			// clear the buffer for 4 Bits
+	Uart.fourBits = 0x00000000;         // clear the buffer for 4 Bits
+	Uart.startTime = 0;
+	Uart.endTime = 0;
 	UartReset();
 }
 
@@ -295,17 +295,17 @@ static RAMFUNC bool MillerDecoding(uint8_t bit, uint32_t non_real_time)
 {
 
 	Uart.fourBits = (Uart.fourBits << 8) | bit;
-	
-	if (Uart.state == STATE_UNSYNCD) {											// not yet synced
-	
-		Uart.syncBit = 9999; 													// not set
+
+	if (Uart.state == STATE_UNSYNCD) {                                          // not yet synced
+
+		Uart.syncBit = 9999;                                                    // not set
 		// The start bit is one ore more Sequence Y followed by a Sequence Z (... 11111111 00x11111). We need to distinguish from
 		// Sequence X followed by Sequence Y followed by Sequence Z (111100x1 11111111 00x11111)
-		// we therefore look for a ...xx11111111111100x11111xxxxxx... pattern 
+		// we therefore look for a ...xx11111111111100x11111xxxxxx... pattern
 		// (12 '1's followed by 2 '0's, eventually followed by another '0', followed by 5 '1's)
-		#define ISO14443A_STARTBIT_MASK		0x07FFEF80							// mask is    00000111 11111111 11101111 10000000
-		#define ISO14443A_STARTBIT_PATTERN	0x07FF8F80							// pattern is 00000111 11111111 10001111 10000000
-		if		((Uart.fourBits & (ISO14443A_STARTBIT_MASK >> 0)) == ISO14443A_STARTBIT_PATTERN >> 0) Uart.syncBit = 7;
+		#define ISO14443A_STARTBIT_MASK     0x07FFEF80                          // mask is    00000111 11111111 11101111 10000000
+		#define ISO14443A_STARTBIT_PATTERN  0x07FF8F80                          // pattern is 00000111 11111111 10001111 10000000
+		if      ((Uart.fourBits & (ISO14443A_STARTBIT_MASK >> 0)) == ISO14443A_STARTBIT_PATTERN >> 0) Uart.syncBit = 7;
 		else if ((Uart.fourBits & (ISO14443A_STARTBIT_MASK >> 1)) == ISO14443A_STARTBIT_PATTERN >> 1) Uart.syncBit = 6;
 		else if ((Uart.fourBits & (ISO14443A_STARTBIT_MASK >> 2)) == ISO14443A_STARTBIT_PATTERN >> 2) Uart.syncBit = 5;
 		else if ((Uart.fourBits & (ISO14443A_STARTBIT_MASK >> 3)) == ISO14443A_STARTBIT_PATTERN >> 3) Uart.syncBit = 4;
@@ -314,7 +314,7 @@ static RAMFUNC bool MillerDecoding(uint8_t bit, uint32_t non_real_time)
 		else if ((Uart.fourBits & (ISO14443A_STARTBIT_MASK >> 6)) == ISO14443A_STARTBIT_PATTERN >> 6) Uart.syncBit = 1;
 		else if ((Uart.fourBits & (ISO14443A_STARTBIT_MASK >> 7)) == ISO14443A_STARTBIT_PATTERN >> 7) Uart.syncBit = 0;
 
-		if (Uart.syncBit != 9999) {												// found a sync bit
+		if (Uart.syncBit != 9999) {                                             // found a sync bit
 			Uart.startTime = non_real_time?non_real_time:(GetCountSspClk() & 0xfffffff8);
 			Uart.startTime -= Uart.syncBit;
 			Uart.endTime = Uart.startTime;
@@ -324,97 +324,97 @@ static RAMFUNC bool MillerDecoding(uint8_t bit, uint32_t non_real_time)
 
 	} else {
 
-		if (IsMillerModulationNibble1(Uart.fourBits >> Uart.syncBit)) {			
-			if (IsMillerModulationNibble2(Uart.fourBits >> Uart.syncBit)) {		// Modulation in both halves - error
+		if (IsMillerModulationNibble1(Uart.fourBits >> Uart.syncBit)) {
+			if (IsMillerModulationNibble2(Uart.fourBits >> Uart.syncBit)) {     // Modulation in both halves - error
 				LED_B_OFF();
 				UartReset();
-			} else {															// Modulation in first half = Sequence Z = logic "0"
-				if (Uart.state == STATE_MILLER_X) {								// error - must not follow after X
+			} else {                                                            // Modulation in first half = Sequence Z = logic "0"
+				if (Uart.state == STATE_MILLER_X) {                             // error - must not follow after X
 					LED_B_OFF();
 					UartReset();
 				} else {
 					Uart.bitCount++;
-					Uart.shiftReg = (Uart.shiftReg >> 1);						// add a 0 to the shiftreg
+					Uart.shiftReg = (Uart.shiftReg >> 1);                       // add a 0 to the shiftreg
 					Uart.state = STATE_MILLER_Z;
 					Uart.endTime = Uart.startTime + 8*(9*Uart.len + Uart.bitCount + 1) - 6;
-					if(Uart.bitCount >= 9) {									// if we decoded a full byte (including parity)
+					if(Uart.bitCount >= 9) {                                    // if we decoded a full byte (including parity)
 						Uart.output[Uart.len++] = (Uart.shiftReg & 0xff);
-						Uart.parityBits <<= 1;									// make room for the parity bit
-						Uart.parityBits |= ((Uart.shiftReg >> 8) & 0x01);		// store parity bit
+						Uart.parityBits <<= 1;                                  // make room for the parity bit
+						Uart.parityBits |= ((Uart.shiftReg >> 8) & 0x01);       // store parity bit
 						Uart.bitCount = 0;
 						Uart.shiftReg = 0;
-						if((Uart.len&0x0007) == 0) {							// every 8 data bytes
-							Uart.parity[Uart.parityLen++] = Uart.parityBits;	// store 8 parity bits
+						if((Uart.len&0x0007) == 0) {                            // every 8 data bytes
+							Uart.parity[Uart.parityLen++] = Uart.parityBits;    // store 8 parity bits
 							Uart.parityBits = 0;
 						}
 					}
 				}
 			}
 		} else {
-			if (IsMillerModulationNibble2(Uart.fourBits >> Uart.syncBit)) {		// Modulation second half = Sequence X = logic "1"
+			if (IsMillerModulationNibble2(Uart.fourBits >> Uart.syncBit)) {     // Modulation second half = Sequence X = logic "1"
 				Uart.bitCount++;
-				Uart.shiftReg = (Uart.shiftReg >> 1) | 0x100;					// add a 1 to the shiftreg
+				Uart.shiftReg = (Uart.shiftReg >> 1) | 0x100;                   // add a 1 to the shiftreg
 				Uart.state = STATE_MILLER_X;
 				Uart.endTime = Uart.startTime + 8*(9*Uart.len + Uart.bitCount + 1) - 2;
-				if(Uart.bitCount >= 9) {										// if we decoded a full byte (including parity)
+				if(Uart.bitCount >= 9) {                                        // if we decoded a full byte (including parity)
 					Uart.output[Uart.len++] = (Uart.shiftReg & 0xff);
-					Uart.parityBits <<= 1;										// make room for the new parity bit
-					Uart.parityBits |= ((Uart.shiftReg >> 8) & 0x01); 			// store parity bit
+					Uart.parityBits <<= 1;                                      // make room for the new parity bit
+					Uart.parityBits |= ((Uart.shiftReg >> 8) & 0x01);           // store parity bit
 					Uart.bitCount = 0;
 					Uart.shiftReg = 0;
-					if ((Uart.len&0x0007) == 0) {								// every 8 data bytes
-						Uart.parity[Uart.parityLen++] = Uart.parityBits;		// store 8 parity bits
+					if ((Uart.len&0x0007) == 0) {                               // every 8 data bytes
+						Uart.parity[Uart.parityLen++] = Uart.parityBits;        // store 8 parity bits
 						Uart.parityBits = 0;
 					}
 				}
-			} else {															// no modulation in both halves - Sequence Y
-				if (Uart.state == STATE_MILLER_Z || Uart.state == STATE_MILLER_Y) {	// Y after logic "0" - End of Communication
+			} else {                                                            // no modulation in both halves - Sequence Y
+				if (Uart.state == STATE_MILLER_Z || Uart.state == STATE_MILLER_Y) { // Y after logic "0" - End of Communication
 					LED_B_OFF();
 					Uart.state = STATE_UNSYNCD;
-					Uart.bitCount--;											// last "0" was part of EOC sequence
-					Uart.shiftReg <<= 1;										// drop it
-					if(Uart.bitCount > 0) {										// if we decoded some bits
-						Uart.shiftReg >>= (9 - Uart.bitCount);					// right align them
-						Uart.output[Uart.len++] = (Uart.shiftReg & 0xff);		// add last byte to the output
-						Uart.parityBits <<= 1;									// add a (void) parity bit
-						Uart.parityBits <<= (8 - (Uart.len&0x0007));			// left align parity bits
-						Uart.parity[Uart.parityLen++] = Uart.parityBits;		// and store it
+					Uart.bitCount--;                                            // last "0" was part of EOC sequence
+					Uart.shiftReg <<= 1;                                        // drop it
+					if(Uart.bitCount > 0) {                                     // if we decoded some bits
+						Uart.shiftReg >>= (9 - Uart.bitCount);                  // right align them
+						Uart.output[Uart.len++] = (Uart.shiftReg & 0xff);       // add last byte to the output
+						Uart.parityBits <<= 1;                                  // add a (void) parity bit
+						Uart.parityBits <<= (8 - (Uart.len&0x0007));            // left align parity bits
+						Uart.parity[Uart.parityLen++] = Uart.parityBits;        // and store it
 						return true;
-					} else if (Uart.len & 0x0007) {								// there are some parity bits to store
-						Uart.parityBits <<= (8 - (Uart.len&0x0007));			// left align remaining parity bits
-						Uart.parity[Uart.parityLen++] = Uart.parityBits;		// and store them
+					} else if (Uart.len & 0x0007) {                             // there are some parity bits to store
+						Uart.parityBits <<= (8 - (Uart.len&0x0007));            // left align remaining parity bits
+						Uart.parity[Uart.parityLen++] = Uart.parityBits;        // and store them
 					}
 					if (Uart.len) {
-						return true;											// we are finished with decoding the raw data sequence
+						return true;                                            // we are finished with decoding the raw data sequence
 					} else {
-						UartReset();											// Nothing received - start over
+						UartReset();                                            // Nothing received - start over
 					}
 				}
-				if (Uart.state == STATE_START_OF_COMMUNICATION) {				// error - must not follow directly after SOC
+				if (Uart.state == STATE_START_OF_COMMUNICATION) {               // error - must not follow directly after SOC
 					LED_B_OFF();
 					UartReset();
-				} else {														// a logic "0"
+				} else {                                                        // a logic "0"
 					Uart.bitCount++;
-					Uart.shiftReg = (Uart.shiftReg >> 1);						// add a 0 to the shiftreg
+					Uart.shiftReg = (Uart.shiftReg >> 1);                       // add a 0 to the shiftreg
 					Uart.state = STATE_MILLER_Y;
-					if(Uart.bitCount >= 9) {									// if we decoded a full byte (including parity)
+					if(Uart.bitCount >= 9) {                                    // if we decoded a full byte (including parity)
 						Uart.output[Uart.len++] = (Uart.shiftReg & 0xff);
-						Uart.parityBits <<= 1;									// make room for the parity bit
-						Uart.parityBits |= ((Uart.shiftReg >> 8) & 0x01); 		// store parity bit
+						Uart.parityBits <<= 1;                                  // make room for the parity bit
+						Uart.parityBits |= ((Uart.shiftReg >> 8) & 0x01);       // store parity bit
 						Uart.bitCount = 0;
 						Uart.shiftReg = 0;
-						if ((Uart.len&0x0007) == 0) {							// every 8 data bytes
-							Uart.parity[Uart.parityLen++] = Uart.parityBits;	// store 8 parity bits
+						if ((Uart.len&0x0007) == 0) {                           // every 8 data bytes
+							Uart.parity[Uart.parityLen++] = Uart.parityBits;    // store 8 parity bits
 							Uart.parityBits = 0;
 						}
 					}
 				}
 			}
 		}
-			
-	} 
 
-    return false;	// not finished yet, need more data
+	}
+
+	return false;   // not finished yet, need more data
 }
 
 
@@ -428,10 +428,10 @@ static RAMFUNC bool MillerDecoding(uint8_t bit, uint32_t non_real_time)
 // at the reader antenna will be modulated as well. The FPGA detects the modulation for us and would deliver e.g. the following:
 // ........ 0 0 1 1 1 1 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .......
 // The Manchester decoder needs to identify the following sequences:
-// 4 ticks modulated followed by 4 ticks unmodulated: 	Sequence D = 1 (also used as "start of communication")
-// 4 ticks unmodulated followed by 4 ticks modulated: 	Sequence E = 0
-// 8 ticks unmodulated:									Sequence F = end of communication
-// 8 ticks modulated:									A collision. Save the collision position and treat as Sequence D
+// 4 ticks modulated followed by 4 ticks unmodulated:   Sequence D = 1 (also used as "start of communication")
+// 4 ticks unmodulated followed by 4 ticks modulated:   Sequence E = 0
+// 8 ticks unmodulated:                                 Sequence F = end of communication
+// 8 ticks modulated:                                   A collision. Save the collision position and treat as Sequence D
 // Note 1: the bitstream may start at any time. We therefore need to sync.
 // Note 2: parameter offset is used to determine the position of the parity bits (required for the anticollision command only)
 static tDemod Demod;
@@ -450,12 +450,12 @@ const bool Mod_Manchester_LUT[] = {
 static void DemodReset()
 {
 	Demod.state = DEMOD_UNSYNCD;
-	Demod.len = 0;						// number of decoded data bytes
+	Demod.len = 0;                      // number of decoded data bytes
 	Demod.parityLen = 0;
-	Demod.shiftReg = 0;					// shiftreg to hold decoded data bits
-	Demod.parityBits = 0;				// 
-	Demod.collisionPos = 0;				// Position of collision bit
-	Demod.twoBits = 0xffff;				// buffer for 2 Bits
+	Demod.shiftReg = 0;                 // shiftreg to hold decoded data bits
+	Demod.parityBits = 0;               //
+	Demod.collisionPos = 0;             // Position of collision bit
+	Demod.twoBits = 0xffff;             // buffer for 2 Bits
 	Demod.highCnt = 0;
 	Demod.startTime = 0;
 	Demod.endTime = 0;
@@ -473,18 +473,18 @@ static RAMFUNC int ManchesterDecoding(uint8_t bit, uint16_t offset, uint32_t non
 {
 
 	Demod.twoBits = (Demod.twoBits << 8) | bit;
-	
+
 	if (Demod.state == DEMOD_UNSYNCD) {
 
-		if (Demod.highCnt < 2) {											// wait for a stable unmodulated signal
+		if (Demod.highCnt < 2) {                                            // wait for a stable unmodulated signal
 			if (Demod.twoBits == 0x0000) {
 				Demod.highCnt++;
 			} else {
 				Demod.highCnt = 0;
 			}
 		} else {
-			Demod.syncBit = 0xFFFF;			// not set
-			if 		((Demod.twoBits & 0x7700) == 0x7000) Demod.syncBit = 7; 
+			Demod.syncBit = 0xFFFF;         // not set
+			if      ((Demod.twoBits & 0x7700) == 0x7000) Demod.syncBit = 7;
 			else if ((Demod.twoBits & 0x3B80) == 0x3800) Demod.syncBit = 6;
 			else if ((Demod.twoBits & 0x1DC0) == 0x1C00) Demod.syncBit = 5;
 			else if ((Demod.twoBits & 0x0EE0) == 0x0E00) Demod.syncBit = 4;
@@ -495,7 +495,7 @@ static RAMFUNC int ManchesterDecoding(uint8_t bit, uint16_t offset, uint32_t non
 			if (Demod.syncBit != 0xFFFF) {
 				Demod.startTime = non_real_time?non_real_time:(GetCountSspClk() & 0xfffffff8);
 				Demod.startTime -= Demod.syncBit;
-				Demod.bitCount = offset;			// number of decoded data bits
+				Demod.bitCount = offset;            // number of decoded data bits
 				Demod.state = DEMOD_MANCHESTER_DATA;
 				LED_C_ON();
 			}
@@ -503,66 +503,66 @@ static RAMFUNC int ManchesterDecoding(uint8_t bit, uint16_t offset, uint32_t non
 
 	} else {
 
-		if (IsManchesterModulationNibble1(Demod.twoBits >> Demod.syncBit)) {		// modulation in first half
-			if (IsManchesterModulationNibble2(Demod.twoBits >> Demod.syncBit)) {	// ... and in second half = collision
+		if (IsManchesterModulationNibble1(Demod.twoBits >> Demod.syncBit)) {        // modulation in first half
+			if (IsManchesterModulationNibble2(Demod.twoBits >> Demod.syncBit)) {    // ... and in second half = collision
 				if (!Demod.collisionPos) {
 					Demod.collisionPos = (Demod.len << 3) + Demod.bitCount;
 				}
-			}															// modulation in first half only - Sequence D = 1
+			}                                                           // modulation in first half only - Sequence D = 1
 			Demod.bitCount++;
-			Demod.shiftReg = (Demod.shiftReg >> 1) | 0x100;				// in both cases, add a 1 to the shiftreg
-			if(Demod.bitCount == 9) {									// if we decoded a full byte (including parity)
+			Demod.shiftReg = (Demod.shiftReg >> 1) | 0x100;             // in both cases, add a 1 to the shiftreg
+			if(Demod.bitCount == 9) {                                   // if we decoded a full byte (including parity)
 				Demod.output[Demod.len++] = (Demod.shiftReg & 0xff);
-				Demod.parityBits <<= 1;									// make room for the parity bit
-				Demod.parityBits |= ((Demod.shiftReg >> 8) & 0x01); 	// store parity bit
+				Demod.parityBits <<= 1;                                 // make room for the parity bit
+				Demod.parityBits |= ((Demod.shiftReg >> 8) & 0x01);     // store parity bit
 				Demod.bitCount = 0;
 				Demod.shiftReg = 0;
-				if((Demod.len&0x0007) == 0) {							// every 8 data bytes
-					Demod.parity[Demod.parityLen++] = Demod.parityBits;	// store 8 parity bits
+				if((Demod.len&0x0007) == 0) {                           // every 8 data bytes
+					Demod.parity[Demod.parityLen++] = Demod.parityBits; // store 8 parity bits
 					Demod.parityBits = 0;
 				}
 			}
 			Demod.endTime = Demod.startTime + 8*(9*Demod.len + Demod.bitCount + 1) - 4;
-		} else {														// no modulation in first half
-			if (IsManchesterModulationNibble2(Demod.twoBits >> Demod.syncBit)) {	// and modulation in second half = Sequence E = 0
+		} else {                                                        // no modulation in first half
+			if (IsManchesterModulationNibble2(Demod.twoBits >> Demod.syncBit)) {    // and modulation in second half = Sequence E = 0
 				Demod.bitCount++;
-				Demod.shiftReg = (Demod.shiftReg >> 1);					// add a 0 to the shiftreg
-				if(Demod.bitCount >= 9) {								// if we decoded a full byte (including parity)
+				Demod.shiftReg = (Demod.shiftReg >> 1);                 // add a 0 to the shiftreg
+				if(Demod.bitCount >= 9) {                               // if we decoded a full byte (including parity)
 					Demod.output[Demod.len++] = (Demod.shiftReg & 0xff);
-					Demod.parityBits <<= 1;								// make room for the new parity bit
+					Demod.parityBits <<= 1;                             // make room for the new parity bit
 					Demod.parityBits |= ((Demod.shiftReg >> 8) & 0x01); // store parity bit
 					Demod.bitCount = 0;
 					Demod.shiftReg = 0;
-					if ((Demod.len&0x0007) == 0) {						// every 8 data bytes
-						Demod.parity[Demod.parityLen++] = Demod.parityBits;	// store 8 parity bits1
+					if ((Demod.len&0x0007) == 0) {                      // every 8 data bytes
+						Demod.parity[Demod.parityLen++] = Demod.parityBits; // store 8 parity bits1
 						Demod.parityBits = 0;
 					}
 				}
 				Demod.endTime = Demod.startTime + 8*(9*Demod.len + Demod.bitCount + 1);
-			} else {													// no modulation in both halves - End of communication
+			} else {                                                    // no modulation in both halves - End of communication
 				LED_C_OFF();
-				if(Demod.bitCount > 0) {								// there are some remaining data bits
-					Demod.shiftReg >>= (9 - Demod.bitCount);			// right align the decoded bits
-					Demod.output[Demod.len++] = Demod.shiftReg & 0xff;	// and add them to the output
-					Demod.parityBits <<= 1;								// add a (void) parity bit
-					Demod.parityBits <<= (8 - (Demod.len&0x0007));		// left align remaining parity bits
-					Demod.parity[Demod.parityLen++] = Demod.parityBits;	// and store them
+				if(Demod.bitCount > 0) {                                // there are some remaining data bits
+					Demod.shiftReg >>= (9 - Demod.bitCount);            // right align the decoded bits
+					Demod.output[Demod.len++] = Demod.shiftReg & 0xff;  // and add them to the output
+					Demod.parityBits <<= 1;                             // add a (void) parity bit
+					Demod.parityBits <<= (8 - (Demod.len&0x0007));      // left align remaining parity bits
+					Demod.parity[Demod.parityLen++] = Demod.parityBits; // and store them
 					return true;
-				} else if (Demod.len & 0x0007) {						// there are some parity bits to store
-					Demod.parityBits <<= (8 - (Demod.len&0x0007));		// left align remaining parity bits
-					Demod.parity[Demod.parityLen++] = Demod.parityBits;	// and store them
+				} else if (Demod.len & 0x0007) {                        // there are some parity bits to store
+					Demod.parityBits <<= (8 - (Demod.len&0x0007));      // left align remaining parity bits
+					Demod.parity[Demod.parityLen++] = Demod.parityBits; // and store them
 				}
 				if (Demod.len) {
-					return true;										// we are finished with decoding the raw data sequence
-				} else { 												// nothing received. Start over
+					return true;                                        // we are finished with decoding the raw data sequence
+				} else {                                                // nothing received. Start over
 					DemodReset();
 				}
 			}
 		}
-			
-	} 
 
-    return false;	// not finished yet, need more data
+	}
+
+	return false;   // not finished yet, need more data
 }
 
 //=============================================================================
@@ -579,7 +579,7 @@ void RAMFUNC SnoopIso14443a(uint8_t param) {
 	// param:
 	// bit 0 - trigger from first card answer
 	// bit 1 - trigger from first reader 7-bit request
-	
+
 	LEDsoff();
 	LED_A_ON();
 
@@ -592,11 +592,11 @@ void RAMFUNC SnoopIso14443a(uint8_t param) {
 	// The command (reader -> tag) that we're receiving.
 	uint8_t *receivedCmd = BigBuf_malloc(MAX_FRAME_SIZE);
 	uint8_t *receivedCmdPar = BigBuf_malloc(MAX_PARITY_SIZE);
-	
+
 	// The response (tag -> reader) that we're receiving.
 	uint8_t *receivedResponse = BigBuf_malloc(MAX_FRAME_SIZE);
 	uint8_t *receivedResponsePar = BigBuf_malloc(MAX_PARITY_SIZE);
-	
+
 	// The DMA buffer, used to stream samples from the FPGA
 	uint8_t *dmaBuf = BigBuf_malloc(DMA_BUFFER_SIZE);
 
@@ -610,26 +610,26 @@ void RAMFUNC SnoopIso14443a(uint8_t param) {
 	int dataLen = 0;
 	bool TagIsActive = false;
 	bool ReaderIsActive = false;
-	
+
 	// Set up the demodulator for tag -> reader responses.
 	DemodInit(receivedResponse, receivedResponsePar);
-	
+
 	// Set up the demodulator for the reader -> tag commands
 	UartInit(receivedCmd, receivedCmdPar);
-	
+
 	// Setup and start DMA.
 	FpgaSetupSscDma((uint8_t *)dmaBuf, DMA_BUFFER_SIZE);
-	
+
 	// We won't start recording the frames that we acquire until we trigger;
 	// a good trigger condition to get started is probably when we see a
 	// response from the tag.
 	// triggered == false -- to wait first for card
-	bool triggered = !(param & 0x03); 
-	
-	// And now we loop, receiving samples.
-	for(uint32_t rsamples = 0; true; ) {
+	bool triggered = !(param & 0x03);
 
-		if(BUTTON_PRESS()) {
+	// And now we loop, receiving samples.
+	for (uint32_t rsamples = 0; true; ) {
+
+		if (BUTTON_PRESS()) {
 			DbpString("cancelled by button");
 			break;
 		}
@@ -665,9 +665,9 @@ void RAMFUNC SnoopIso14443a(uint8_t param) {
 			AT91C_BASE_PDC_SSC->PDC_RNCR = DMA_BUFFER_SIZE;
 		}
 
-		if (rsamples & 0x01) {				// Need two samples to feed Miller and Manchester-Decoder
+		if (rsamples & 0x01) {              // Need two samples to feed Miller and Manchester-Decoder
 
-			if(!TagIsActive) {		// no need to try decoding reader data if the tag is sending
+			if(!TagIsActive) {      // no need to try decoding reader data if the tag is sending
 				uint8_t readerdata = (previous_data & 0xF0) | (*data >> 4);
 				if (MillerDecoding(readerdata, (rsamples-1)*4)) {
 					// check - if there is a short 7bit request from reader
@@ -675,11 +675,11 @@ void RAMFUNC SnoopIso14443a(uint8_t param) {
 						triggered = true;
 					}
 					if(triggered) {
-						if (!LogTrace(receivedCmd, 
-										Uart.len, 
+						if (!LogTrace(receivedCmd,
+										Uart.len,
 										Uart.startTime*16 - DELAY_READER_AIR2ARM_AS_SNIFFER,
 										Uart.endTime*16 - DELAY_READER_AIR2ARM_AS_SNIFFER,
-										Uart.parity, 
+										Uart.parity,
 										true)) break;
 					}
 					/* And ready to receive another command. */
@@ -691,12 +691,12 @@ void RAMFUNC SnoopIso14443a(uint8_t param) {
 				ReaderIsActive = (Uart.state != STATE_UNSYNCD);
 			}
 
-			if (!ReaderIsActive) {		// no need to try decoding tag data if the reader is sending - and we cannot afford the time
+			if (!ReaderIsActive) {      // no need to try decoding tag data if the reader is sending - and we cannot afford the time
 				uint8_t tagdata = (previous_data << 4) | (*data & 0x0F);
 				if (ManchesterDecoding(tagdata, 0, (rsamples-1)*4)) {
-					if (!LogTrace(receivedResponse, 
-									Demod.len, 
-									Demod.startTime*16 - DELAY_TAG_AIR2ARM_AS_SNIFFER, 
+					if (!LogTrace(receivedResponse,
+									Demod.len,
+									Demod.startTime*16 - DELAY_TAG_AIR2ARM_AS_SNIFFER,
 									Demod.endTime*16 - DELAY_TAG_AIR2ARM_AS_SNIFFER,
 									Demod.parity,
 									false)) break;
@@ -705,7 +705,7 @@ void RAMFUNC SnoopIso14443a(uint8_t param) {
 					DemodReset();
 					// And reset the Miller decoder including itS (now outdated) input buffer
 					UartInit(receivedCmd, receivedCmdPar);
-				} 
+				}
 				TagIsActive = (Demod.state != DEMOD_UNSYNCD);
 			}
 		}
@@ -742,16 +742,16 @@ static void CodeIso14443aAsTagPar(const uint8_t *cmd, uint16_t len, uint8_t *par
 	ToSendStuffBit(0);
 	ToSendStuffBit(0);
 	ToSendStuffBit(0);
-	
+
 	// Send startbit
 	ToSend[++ToSendMax] = SEC_D;
 	LastProxToAirDuration = 8 * ToSendMax - 4;
 
-	for(uint16_t i = 0; i < len; i++) {
+	for (uint16_t i = 0; i < len; i++) {
 		uint8_t b = cmd[i];
 
 		// Data bits
-		for(uint16_t j = 0; j < 8; j++) {
+		for (uint16_t j = 0; j < 8; j++) {
 			if(b & 1) {
 				ToSend[++ToSendMax] = SEC_D;
 			} else {
@@ -798,7 +798,7 @@ static void Code4bitAnswerAsTag(uint8_t cmd)
 	ToSend[++ToSendMax] = SEC_D;
 
 	uint8_t b = cmd;
-	for(i = 0; i < 4; i++) {
+	for (i = 0; i < 4; i++) {
 		if(b & 1) {
 			ToSend[++ToSendMax] = SEC_D;
 			LastProxToAirDuration = 8 * ToSendMax - 4;
@@ -839,7 +839,7 @@ static void FixLastReaderTraceTime(uint32_t tag_StartTime) {
 	LastReaderTraceTime[3] = (reader_StartTime >> 24) & 0xff;
 }
 
-	
+
 static void EmLogTraceTag(uint8_t *tag_data, uint16_t tag_len, uint8_t *tag_Parity, uint32_t ProxToAirDuration) {
 	uint32_t tag_StartTime = LastTimeProxToAirStart*16 + DELAY_ARM2AIR_AS_TAG;
 	uint32_t tag_EndTime = (LastTimeProxToAirStart + ProxToAirDuration)*16 + DELAY_ARM2AIR_AS_TAG;
@@ -855,38 +855,38 @@ static void EmLogTraceTag(uint8_t *tag_data, uint16_t tag_len, uint8_t *tag_Pari
 //-----------------------------------------------------------------------------
 static int GetIso14443aCommandFromReader(uint8_t *received, uint8_t *parity, int *len)
 {
-    // Set FPGA mode to "simulated ISO 14443 tag", no modulation (listen
-    // only, since we are receiving, not transmitting).
-    // Signal field is off with the appropriate LED
-    LED_D_OFF();
-    FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_ISO14443A | FPGA_HF_ISO14443A_TAGSIM_LISTEN);
+	// Set FPGA mode to "simulated ISO 14443 tag", no modulation (listen
+	// only, since we are receiving, not transmitting).
+	// Signal field is off with the appropriate LED
+	LED_D_OFF();
+	FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_ISO14443A | FPGA_HF_ISO14443A_TAGSIM_LISTEN);
 
-    // Now run a `software UART' on the stream of incoming samples.
+	// Now run a `software UART' on the stream of incoming samples.
 	UartInit(received, parity);
 
 	// clear RXRDY:
-    uint8_t b = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
+	uint8_t b = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
 
-    for(;;) {
-        WDT_HIT();
+	for (;;) {
+		WDT_HIT();
 
-        if(BUTTON_PRESS()) return false;
-		
-        if(AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_RXRDY)) {
-            b = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
+		if(BUTTON_PRESS()) return false;
+
+		if(AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_RXRDY)) {
+			b = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
 			if(MillerDecoding(b, 0)) {
 				*len = Uart.len;
 				EmLogTraceReader();
 				return true;
 			}
- 		}
-    }
+		}
+	}
 }
 
 
 int EmSend4bit(uint8_t resp);
 static int EmSendCmdExPar(uint8_t *resp, uint16_t respLen, uint8_t *par);
-int EmSendCmdEx(uint8_t *resp, uint16_t respLen);
+int EmSendCmd(uint8_t *resp, uint16_t respLen);
 int EmSendPrecompiledCmd(tag_response_info_t *response_info);
 
 
@@ -901,32 +901,32 @@ static bool prepare_tag_modulation(tag_response_info_t* response_info, size_t ma
 	// ----------- +
 	//    166 bytes, since every bit that needs to be send costs us a byte
 	//
- 
- 
+
+
   // Prepare the tag modulation bits from the message
   GetParity(response_info->response, response_info->response_n, &(response_info->par));
   CodeIso14443aAsTagPar(response_info->response,response_info->response_n, &(response_info->par));
-  
+
   // Make sure we do not exceed the free buffer space
   if (ToSendMax > max_buffer_size) {
-    Dbprintf("Out of memory, when modulating bits for tag answer:");
-    Dbhexdump(response_info->response_n, response_info->response, false);
-    return false;
+	Dbprintf("Out of memory, when modulating bits for tag answer:");
+	Dbhexdump(response_info->response_n, response_info->response, false);
+	return false;
   }
-  
+
   // Copy the byte array, used for this modulation to the buffer position
   memcpy(response_info->modulation, ToSend, ToSendMax);
-  
+
   // Store the number of bytes that were used for encoding/modulation and the time needed to transfer them
   response_info->modulation_n = ToSendMax;
   response_info->ProxToAirDuration = LastProxToAirDuration;
-  
+
   return true;
 }
 
 
 // "precompile" responses. There are 7 predefined responses with a total of 28 bytes data to transmit.
-// Coded responses need one byte per bit to transfer (data, parity, start, stop, correction) 
+// Coded responses need one byte per bit to transfer (data, parity, start, stop, correction)
 // 28 * 8 data bits, 28 * 1 parity bits, 7 start bits, 7 stop bits, 7 correction bits for the modulation
 // -> need 273 bytes buffer
 #define ALLOCATED_TAG_MODULATION_BUFFER_SIZE 273
@@ -935,15 +935,15 @@ bool prepare_allocated_tag_modulation(tag_response_info_t* response_info, uint8_
 
   // Retrieve and store the current buffer index
   response_info->modulation = *buffer;
-  
+
   // Forward the prepare tag modulation function to the inner function
   if (prepare_tag_modulation(response_info, *max_buffer_size)) {
-    // Update the free buffer offset and the remaining buffer size
-    *buffer += ToSendMax;
+	// Update the free buffer offset and the remaining buffer size
+	*buffer += ToSendMax;
 	*max_buffer_size -= ToSendMax;
-    return true;
+	return true;
   } else {
-    return false;
+	return false;
   }
 }
 
@@ -957,7 +957,7 @@ void SimulateIso14443aTag(int tagType, int uid_1st, int uid_2nd, byte_t* data)
 
 	// The first response contains the ATQA (note: bytes are transmitted in reverse order).
 	uint8_t response1[2];
-	
+
 	switch (tagType) {
 		case 1: { // MIFARE Classic
 			// Says: I am Mifare 1k - original line
@@ -988,19 +988,19 @@ void SimulateIso14443aTag(int tagType, int uid_1st, int uid_2nd, byte_t* data)
 			response1[0] = 0x01;
 			response1[1] = 0x0f;
 			sak = 0x01;
-		} break;		
+		} break;
 		default: {
 			Dbprintf("Error: unkown tagtype (%d)",tagType);
 			return;
 		} break;
 	}
-	
+
 	// The second response contains the (mandatory) first 24 bits of the UID
 	uint8_t response2[5] = {0x00};
 
 	// Check if the uid uses the (optional) part
 	uint8_t response2a[5] = {0x00};
-	
+
 	if (uid_2nd) {
 		response2[0] = 0x88;
 		num_to_bytes(uid_1st,3,response2+1);
@@ -1031,8 +1031,8 @@ void SimulateIso14443aTag(int tagType, int uid_1st, int uid_2nd, byte_t* data)
 	ComputeCrc14443(CRC_14443_A, response3a, 1, &response3a[1], &response3a[2]);
 
 	uint8_t response5[] = { 0x00, 0x00, 0x00, 0x00 }; // Very random tag nonce
-	uint8_t response6[] = { 0x04, 0x58, 0x80, 0x02, 0x00, 0x00 }; // dummy ATS (pseudo-ATR), answer to RATS: 
-	// Format byte = 0x58: FSCI=0x08 (FSC=256), TA(1) and TC(1) present, 
+	uint8_t response6[] = { 0x04, 0x58, 0x80, 0x02, 0x00, 0x00 }; // dummy ATS (pseudo-ATR), answer to RATS:
+	// Format byte = 0x58: FSCI=0x08 (FSC=256), TA(1) and TC(1) present,
 	// TA(1) = 0x80: different divisors not supported, DR = 1, DS = 1
 	// TB(1) = not present. Defaults: FWI = 4 (FWT = 256 * 16 * 2^4 * 1/fc = 4833us), SFGI = 0 (SFG = 256 * 16 * 2^0 * 1/fc = 302us)
 	// TC(1) = 0x02: CID supported, NAD not supported
@@ -1061,7 +1061,7 @@ void SimulateIso14443aTag(int tagType, int uid_1st, int uid_2nd, byte_t* data)
 		.modulation = dynamic_modulation_buffer,
 		.modulation_n = 0
 	};
-  
+
 	// We need to listen to the high-frequency, peak-detected path.
 	iso14443a_setup(FPGA_HF_ISO14443A_TAGSIM_LISTEN);
 
@@ -1097,7 +1097,7 @@ void SimulateIso14443aTag(int tagType, int uid_1st, int uid_2nd, byte_t* data)
 	tag_response_info_t* p_response;
 
 	LED_A_ON();
-	for(;;) {
+	for (;;) {
 		// Clean receive command buffer
 		if(!GetIso14443aCommandFromReader(receivedCmd, receivedCmdPar, &len)) {
 			DbpString("Button press");
@@ -1105,32 +1105,32 @@ void SimulateIso14443aTag(int tagType, int uid_1st, int uid_2nd, byte_t* data)
 		}
 
 		p_response = NULL;
-		
+
 		// Okay, look at the command now.
 		lastorder = order;
 		if(receivedCmd[0] == 0x26) { // Received a REQUEST
 			p_response = &responses[0]; order = 1;
 		} else if(receivedCmd[0] == 0x52) { // Received a WAKEUP
 			p_response = &responses[0]; order = 6;
-		} else if(receivedCmd[1] == 0x20 && receivedCmd[0] == 0x93) {	// Received request for UID (cascade 1)
+		} else if(receivedCmd[1] == 0x20 && receivedCmd[0] == 0x93) {   // Received request for UID (cascade 1)
 			p_response = &responses[1]; order = 2;
-		} else if(receivedCmd[1] == 0x20 && receivedCmd[0] == 0x95) { 	// Received request for UID (cascade 2)
+		} else if(receivedCmd[1] == 0x20 && receivedCmd[0] == 0x95) {   // Received request for UID (cascade 2)
 			p_response = &responses[2]; order = 20;
-		} else if(receivedCmd[1] == 0x70 && receivedCmd[0] == 0x93) {	// Received a SELECT (cascade 1)
+		} else if(receivedCmd[1] == 0x70 && receivedCmd[0] == 0x93) {   // Received a SELECT (cascade 1)
 			p_response = &responses[3]; order = 3;
-		} else if(receivedCmd[1] == 0x70 && receivedCmd[0] == 0x95) {	// Received a SELECT (cascade 2)
+		} else if(receivedCmd[1] == 0x70 && receivedCmd[0] == 0x95) {   // Received a SELECT (cascade 2)
 			p_response = &responses[4]; order = 30;
-		} else if(receivedCmd[0] == 0x30) {	// Received a (plain) READ
-			EmSendCmdEx(data+(4*receivedCmd[1]),16);
+		} else if(receivedCmd[0] == 0x30) { // Received a (plain) READ
+			EmSendCmd(data+(4*receivedCmd[1]),16);
 			// Dbprintf("Read request from reader: %x %x",receivedCmd[0],receivedCmd[1]);
 			// We already responded, do not send anything with the EmSendCmd14443aRaw() that is called below
 			p_response = NULL;
-		} else if(receivedCmd[0] == 0x50) {	// Received a HALT
+		} else if(receivedCmd[0] == 0x50) { // Received a HALT
 			p_response = NULL;
-		} else if(receivedCmd[0] == 0x60 || receivedCmd[0] == 0x61) {	// Received an authentication request
+		} else if(receivedCmd[0] == 0x60 || receivedCmd[0] == 0x61) {   // Received an authentication request
 			p_response = &responses[5]; order = 7;
-		} else if(receivedCmd[0] == 0xE0) {	// Received a RATS request
-			if (tagType == 1 || tagType == 2) {	// RATS not supported
+		} else if(receivedCmd[0] == 0xE0) { // Received a RATS request
+			if (tagType == 1 || tagType == 2) { // RATS not supported
 				EmSend4bit(CARD_NACK_NA);
 				p_response = NULL;
 			} else {
@@ -1164,7 +1164,7 @@ void SimulateIso14443aTag(int tagType, int uid_1st, int uid_2nd, byte_t* data)
 				  dynamic_response_info.response[0] = receivedCmd[0] ^ 0x11;
 				  dynamic_response_info.response_n = 2;
 				} break;
-				  
+
 				case 0xBA: { //
 				  memcpy(dynamic_response_info.response,"\xAB\x00",2);
 				  dynamic_response_info.response_n = 2;
@@ -1184,7 +1184,7 @@ void SimulateIso14443aTag(int tagType, int uid_1st, int uid_2nd, byte_t* data)
 					dynamic_response_info.response_n = 0;
 				} break;
 			}
-      
+
 			if (dynamic_response_info.response_n > 0) {
 				// Copy the CID from the reader query
 				dynamic_response_info.response[1] = receivedCmd[1];
@@ -1192,7 +1192,7 @@ void SimulateIso14443aTag(int tagType, int uid_1st, int uid_2nd, byte_t* data)
 				// Add CRC bytes, always used in ISO 14443A-4 compliant cards
 				AppendCrc14443a(dynamic_response_info.response,dynamic_response_info.response_n);
 				dynamic_response_info.response_n += 2;
-        
+
 				if (prepare_tag_modulation(&dynamic_response_info,DYNAMIC_MODULATION_BUFFER_SIZE) == false) {
 					Dbprintf("Error preparing tag response");
 					break;
@@ -1216,7 +1216,7 @@ void SimulateIso14443aTag(int tagType, int uid_1st, int uid_2nd, byte_t* data)
 		if (p_response != NULL) {
 			EmSendPrecompiledCmd(p_response);
 		}
-		
+
 		if (!get_tracing()) {
 			Dbprintf("Trace Full. Simulation stopped.");
 			break;
@@ -1236,7 +1236,7 @@ static void PrepareDelayedTransfer(uint16_t delay)
 	uint8_t bitmask = 0;
 	uint8_t bits_to_shift = 0;
 	uint8_t bits_shifted = 0;
-	
+
 	delay &= 0x07;
 	if (delay) {
 		for (uint16_t i = 0; i < delay; i++) {
@@ -1257,8 +1257,8 @@ static void PrepareDelayedTransfer(uint16_t delay)
 // Transmit the command (to the tag) that was placed in ToSend[].
 // Parameter timing:
 // if NULL: transfer at next possible time, taking into account
-// 			request guard time, startup frame guard time and frame delay time
-// if == 0:	transfer immediately and return time of transfer
+//          request guard time, startup frame guard time and frame delay time
+// if == 0: transfer immediately and return time of transfer
 // if != 0: delay transfer until time specified
 //-------------------------------------------------------------------------------------
 static void TransmitFor14443a(const uint8_t *cmd, uint16_t len, uint32_t *timing)
@@ -1270,25 +1270,25 @@ static void TransmitFor14443a(const uint8_t *cmd, uint16_t len, uint32_t *timing
 	uint32_t ThisTransferTime = 0;
 
 	if (timing) {
-		if(*timing == 0) {										// Measure time
+		if(*timing == 0) {                                      // Measure time
 			*timing = (GetCountSspClk() + 8) & 0xfffffff8;
 		} else {
-			PrepareDelayedTransfer(*timing & 0x00000007);		// Delay transfer (fine tuning - up to 7 MF clock ticks)
+			PrepareDelayedTransfer(*timing & 0x00000007);       // Delay transfer (fine tuning - up to 7 MF clock ticks)
 		}
 		if(MF_DBGLEVEL >= 4 && GetCountSspClk() >= (*timing & 0xfffffff8)) Dbprintf("TransmitFor14443a: Missed timing");
-		while(GetCountSspClk() < (*timing & 0xfffffff8));		// Delay transfer (multiple of 8 MF clock ticks)
+		while (GetCountSspClk() < (*timing & 0xfffffff8));      // Delay transfer (multiple of 8 MF clock ticks)
 		LastTimeProxToAirStart = *timing;
 	} else {
 		ThisTransferTime = ((MAX(NextTransferTime, GetCountSspClk()) & 0xfffffff8) + 8);
-		while(GetCountSspClk() < ThisTransferTime);
+		while (GetCountSspClk() < ThisTransferTime);
 		LastTimeProxToAirStart = ThisTransferTime;
 	}
-	
+
 	// clear TXRDY
 	AT91C_BASE_SSC->SSC_THR = SEC_Y;
 
 	uint16_t c = 0;
-	for(;;) {
+	for (;;) {
 		if(AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_TXRDY)) {
 			AT91C_BASE_SSC->SSC_THR = cmd[c];
 			c++;
@@ -1297,7 +1297,7 @@ static void TransmitFor14443a(const uint8_t *cmd, uint16_t len, uint32_t *timing
 			}
 		}
 	}
-	
+
 	NextTransferTime = MAX(NextTransferTime, LastTimeProxToAirStart + REQUEST_GUARD_TIME);
 	LED_B_OFF();
 }
@@ -1392,76 +1392,93 @@ static void CodeIso14443aBitsAsReaderPar(const uint8_t *cmd, uint16_t bits, cons
 //-----------------------------------------------------------------------------
 int EmGetCmd(uint8_t *received, uint16_t *len, uint8_t *parity)
 {
+	uint32_t field_off_time = -1;
+	uint32_t samples = 0;
+	int ret = 0;
+	uint8_t b = 0;;
+	uint8_t dmaBuf[DMA_BUFFER_SIZE];
+	uint8_t *upTo = dmaBuf;
+
 	*len = 0;
 
-	uint32_t timer = 0, vtime = 0;
-	int analogCnt = 0;
-	int analogAVG = 0;
-
-	// Set ADC to read field strength
-	AT91C_BASE_ADC->ADC_CR = AT91C_ADC_SWRST;
-	AT91C_BASE_ADC->ADC_MR =
-				ADC_MODE_PRESCALE(63) |
-				ADC_MODE_STARTUP_TIME(1) |
-				ADC_MODE_SAMPLE_HOLD_TIME(15);
-	AT91C_BASE_ADC->ADC_CHER = ADC_CHANNEL(ADC_CHAN_HF_LOW);
-	// start ADC
-	AT91C_BASE_ADC->ADC_CR = AT91C_ADC_START;
-	
 	// Run a 'software UART' on the stream of incoming samples.
 	UartInit(received, parity);
 
+	// start ADC
+	AT91C_BASE_ADC->ADC_CR = AT91C_ADC_START;
+
 	// Ensure that the FPGA Delay Queue is empty before we switch to TAGSIM_LISTEN
-	while (GetCountSspClk() < LastTimeProxToAirStart + LastProxToAirDuration + (FpgaSendQueueDelay>>3)) /* wait */ ;
+	while (GetCountSspClk() < LastTimeProxToAirStart + LastProxToAirDuration + (FpgaSendQueueDelay>>3) - 8 - 3) /* wait */ ;
 
 	// Set FPGA mode to "simulated ISO 14443 tag", no modulation (listen
 	// only, since we are receiving, not transmitting).
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_ISO14443A | FPGA_HF_ISO14443A_TAGSIM_LISTEN);
-	
-	// Clear RXRDY
-    uint8_t b = (uint8_t)AT91C_BASE_SSC->SSC_RHR; (void)b;
+
+	// clear receive register, measure time of next transfer
+	uint32_t temp = AT91C_BASE_SSC->SSC_RHR; (void) temp;
+	while (!(AT91C_BASE_SSC->SSC_SR & AT91C_SSC_RXRDY)) ;
+	uint32_t start_time = GetCountSspClk() & 0xfffffff8;
+
+	// Setup and start DMA.
+	FpgaSetupSscDma(dmaBuf, DMA_BUFFER_SIZE);
 
 	for(;;) {
-		WDT_HIT();
+		uint16_t behindBy = ((uint8_t*)AT91C_BASE_PDC_SSC->PDC_RPR - upTo) & (DMA_BUFFER_SIZE-1);
 
-		if (BUTTON_PRESS()) return 1;
+		if (behindBy == 0) continue;
 
-		// test if the field exists
-		if (AT91C_BASE_ADC->ADC_SR & ADC_END_OF_CONVERSION(ADC_CHAN_HF_LOW)) {
-			analogCnt++;
-			analogAVG += AT91C_BASE_ADC->ADC_CDR[ADC_CHAN_HF_LOW];
-			AT91C_BASE_ADC->ADC_CR = AT91C_ADC_START;
-			if (analogCnt >= 32) {
-				if ((MAX_ADC_HF_VOLTAGE_LOW * (analogAVG / analogCnt) >> 10) < MF_MINFIELDV) {
-					vtime = GetTickCount();
-					if (!timer) timer = vtime;
-					// 50ms no field --> card to idle state
-					if (vtime - timer > 50) return 2;
-				} else
-					if (timer) timer = 0;
-				analogCnt = 0;
-				analogAVG = 0;
+		b = *upTo++;
+
+		if(upTo >= dmaBuf + DMA_BUFFER_SIZE) {                   // we have read all of the DMA buffer content.
+			upTo = dmaBuf;                                       // start reading the circular buffer from the beginning
+			if(behindBy > (9*DMA_BUFFER_SIZE/10)) {
+				Dbprintf("About to blow circular buffer - aborted! behindBy=%d", behindBy);
+				ret = 1;
+				break;
 			}
 		}
+		if (AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_ENDRX)) {        // DMA Counter Register had reached 0, already rotated.
+			AT91C_BASE_PDC_SSC->PDC_RNPR = (uint32_t) dmaBuf;    // refresh the DMA Next Buffer and
+			AT91C_BASE_PDC_SSC->PDC_RNCR = DMA_BUFFER_SIZE;      // DMA Next Counter registers
+		}
 
-		// receive and test the miller decoding
-        if(AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_RXRDY)) {
-            uint8_t b = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
-			if(MillerDecoding(b, 0)) {
-				*len = Uart.len;
-				EmLogTraceReader();
-				return 0;
+		if (BUTTON_PRESS()) {
+			ret = 1;
+			break;
+		}
+
+		// check reader's HF field
+		if (AT91C_BASE_ADC->ADC_SR & ADC_END_OF_CONVERSION(ADC_CHAN_HF_LOW)) {
+			if ((MAX_ADC_HF_VOLTAGE_LOW * AT91C_BASE_ADC->ADC_CDR[ADC_CHAN_HF_LOW]) >> 10 < MF_MINFIELDV) {
+				if (GetTickCount() - field_off_time > 50) {
+					ret = 2; // reader has switched off HF field for more than 50ms. Timeout
+					break;
+				}
+			} else {
+				field_off_time = GetTickCount(); // HF field is still there. Reset timer
 			}
-        }
+			AT91C_BASE_ADC->ADC_CR = AT91C_ADC_START; // restart ADC
+		}
 
+		if (MillerDecoding(b, start_time + samples*8)) {
+			*len = Uart.len;
+			EmLogTraceReader();
+			ret = 0;
+			break;
+		}
+
+		samples++;
 	}
+
+	FpgaDisableSscDma();
+	return ret;
 }
 
 
 static int EmSendCmd14443aRaw(uint8_t *resp, uint16_t respLen)
 {
 	LED_C_ON();
-	
+
 	uint8_t b;
 	uint16_t i = 0;
 	bool correctionNeeded;
@@ -1481,34 +1498,33 @@ static int EmSendCmd14443aRaw(uint8_t *resp, uint16_t respLen)
 		correctionNeeded = Uart.parity[(Uart.len-1)/8] & (0x80 >> ((Uart.len-1) & 7));
 	}
 
-	if(correctionNeeded) {
+	if (correctionNeeded) {
 		// 1236, so correction bit needed
 		i = 0;
 	} else {
 		i = 1;
 	}
 
- 	// clear receiving shift register and holding register
-	while(!(AT91C_BASE_SSC->SSC_SR & AT91C_SSC_RXRDY));
+	// clear receiving shift register and holding register
 	b = AT91C_BASE_SSC->SSC_RHR; (void) b;
-	while(!(AT91C_BASE_SSC->SSC_SR & AT91C_SSC_RXRDY));
+	while (!(AT91C_BASE_SSC->SSC_SR & AT91C_SSC_RXRDY));
 	b = AT91C_BASE_SSC->SSC_RHR; (void) b;
-	
+
 	// wait for the FPGA to signal fdt_indicator == 1 (the FPGA is ready to queue new data in its delay line)
-	for (uint16_t j = 0; j < 5; j++) {	// allow timeout - better late than never
-		while(!(AT91C_BASE_SSC->SSC_SR & AT91C_SSC_RXRDY));
+	for (uint16_t j = 0; j < 5; j++) {  // allow timeout - better late than never
+		while (!(AT91C_BASE_SSC->SSC_SR & AT91C_SSC_RXRDY));
 		if (AT91C_BASE_SSC->SSC_RHR) break;
 	}
 
 	LastTimeProxToAirStart = (GetCountSspClk() & 0xfffffff8) + (correctionNeeded?8:0);
 
 	// send cycle
-	for(; i < respLen; ) {
+	for (; i < respLen; ) {
 		if(AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_TXRDY)) {
 			AT91C_BASE_SSC->SSC_THR = resp[i++];
 			FpgaSendQueueDelay = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
 		}
-	
+
 		if(BUTTON_PRESS()) {
 			break;
 		}
@@ -1522,7 +1538,7 @@ static int EmSendCmd14443aRaw(uint8_t *resp, uint16_t respLen)
 int EmSend4bit(uint8_t resp){
 	Code4bitAnswerAsTag(resp);
 	int res = EmSendCmd14443aRaw(ToSend, ToSendMax);
-	// do the tracing for the previous reader request and this tag answer:
+	// Log this tag answer and fix timing of previous reader command:
 	EmLogTraceTag(&resp, 1, NULL, LastProxToAirDuration);
 	return res;
 }
@@ -1531,16 +1547,9 @@ int EmSend4bit(uint8_t resp){
 static int EmSendCmdExPar(uint8_t *resp, uint16_t respLen, uint8_t *par){
 	CodeIso14443aAsTagPar(resp, respLen, par);
 	int res = EmSendCmd14443aRaw(ToSend, ToSendMax);
-	// do the tracing for the previous reader request and this tag answer:
+	// Log this tag answer and fix timing of previous reader command:
 	EmLogTraceTag(resp, respLen, par, LastProxToAirDuration);
 	return res;
-}
-
-
-int EmSendCmdEx(uint8_t *resp, uint16_t respLen){
-	uint8_t par[MAX_PARITY_SIZE];
-	GetParity(resp, respLen, par);
-	return EmSendCmdExPar(resp, respLen, par);
 }
 
 
@@ -1558,7 +1567,7 @@ int EmSendCmdPar(uint8_t *resp, uint16_t respLen, uint8_t *par){
 
 int EmSendPrecompiledCmd(tag_response_info_t *response_info) {
 	int ret = EmSendCmd14443aRaw(response_info->modulation, response_info->modulation_n);
-	// do the tracing for the previous reader request and this tag answer:
+	// Log this tag answer and fix timing of previous reader command:
 	EmLogTraceTag(response_info->response, response_info->response_n, &(response_info->par), response_info->ProxToAirDuration);
 	return ret;
 }
@@ -1572,21 +1581,21 @@ int EmSendPrecompiledCmd(tag_response_info_t *response_info) {
 static int GetIso14443aAnswerFromTag(uint8_t *receivedResponse, uint8_t *receivedResponsePar, uint16_t offset)
 {
 	uint32_t c;
-	
+
 	// Set FPGA mode to "reader listen mode", no modulation (listen
 	// only, since we are receiving, not transmitting).
 	// Signal field is on with the appropriate LED
 	LED_D_ON();
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_ISO14443A | FPGA_HF_ISO14443A_READER_LISTEN);
-	
+
 	// Now get the answer from the card
 	DemodInit(receivedResponse, receivedResponsePar);
 
 	// clear RXRDY:
-    uint8_t b = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
+	uint8_t b = (uint8_t)AT91C_BASE_SSC->SSC_RHR;
 
 	c = 0;
-	for(;;) {
+	for (;;) {
 		WDT_HIT();
 
 		if(AT91C_BASE_SSC->SSC_SR & (AT91C_SSC_RXRDY)) {
@@ -1595,7 +1604,7 @@ static int GetIso14443aAnswerFromTag(uint8_t *receivedResponse, uint8_t *receive
 				NextTransferTime = MAX(NextTransferTime, Demod.endTime - (DELAY_AIR2ARM_AS_READER + DELAY_ARM2AIR_AS_READER)/16 + FRAME_DELAY_TIME_PICC_TO_PCD);
 				return true;
 			} else if (c++ > iso14a_timeout && Demod.state == DEMOD_UNSYNCD) {
-				return false; 
+				return false;
 			}
 		}
 	}
@@ -1605,12 +1614,12 @@ static int GetIso14443aAnswerFromTag(uint8_t *receivedResponse, uint8_t *receive
 void ReaderTransmitBitsPar(uint8_t* frame, uint16_t bits, uint8_t *par, uint32_t *timing)
 {
 	CodeIso14443aBitsAsReaderPar(frame, bits, par);
-  
+
 	// Send command to tag
 	TransmitFor14443a(ToSend, ToSendMax, timing);
 	if(trigger)
 		LED_A_ON();
-  
+
 	// Log reader command in trace buffer
 	LogTrace(frame, nbytes(bits), LastTimeProxToAirStart*16 + DELAY_ARM2AIR_AS_READER, (LastTimeProxToAirStart + LastProxToAirDuration)*16 + DELAY_ARM2AIR_AS_READER, par, true);
 }
@@ -1659,24 +1668,24 @@ int ReaderReceive(uint8_t *receivedAnswer, uint8_t *parity)
 static void iso14a_set_ATS_times(uint8_t *ats) {
 
 	uint8_t tb1;
-	uint8_t fwi, sfgi; 
+	uint8_t fwi, sfgi;
 	uint32_t fwt, sfgt;
-	
-	if (ats[0] > 1) {							// there is a format byte T0
-		if ((ats[1] & 0x20) == 0x20) {			// there is an interface byte TB(1)
-			if ((ats[1] & 0x10) == 0x10) {		// there is an interface byte TA(1) preceding TB(1)
+
+	if (ats[0] > 1) {                           // there is a format byte T0
+		if ((ats[1] & 0x20) == 0x20) {          // there is an interface byte TB(1)
+			if ((ats[1] & 0x10) == 0x10) {      // there is an interface byte TA(1) preceding TB(1)
 				tb1 = ats[3];
 			} else {
 				tb1 = ats[2];
 			}
-			fwi = (tb1 & 0xf0) >> 4;			// frame waiting time integer (FWI)
+			fwi = (tb1 & 0xf0) >> 4;            // frame waiting time integer (FWI)
 			if (fwi != 15) {
-				fwt = 256 * 16 * (1 << fwi);	// frame waiting time (FWT) in 1/fc
+				fwt = 256 * 16 * (1 << fwi);    // frame waiting time (FWT) in 1/fc
 				iso14a_set_timeout(fwt/(8*16));
 			}
-			sfgi = tb1 & 0x0f;					// startup frame guard time integer (SFGI)
+			sfgi = tb1 & 0x0f;                  // startup frame guard time integer (SFGI)
 			if (sfgi != 0 && sfgi != 15) {
-				sfgt = 256 * 16 * (1 << sfgi);	// startup frame guard time (SFGT) in 1/fc
+				sfgt = 256 * 16 * (1 << sfgi);  // startup frame guard time (SFGT) in 1/fc
 				NextTransferTime = MAX(NextTransferTime, Demod.endTime + (sfgt - DELAY_AIR2ARM_AS_READER - DELAY_ARM2AIR_AS_READER)/16);
 			}
 		}
@@ -1686,15 +1695,15 @@ static void iso14a_set_ATS_times(uint8_t *ats) {
 
 static int GetATQA(uint8_t *resp, uint8_t *resp_par) {
 
-#define WUPA_RETRY_TIMEOUT	10	// 10ms
+#define WUPA_RETRY_TIMEOUT  10  // 10ms
 	uint8_t wupa[]       = { 0x52 };  // 0x26 - REQA  0x52 - WAKE-UP
 
 	uint32_t save_iso14a_timeout = iso14a_get_timeout();
-	iso14a_set_timeout(1236/(16*8)+1);		// response to WUPA is expected at exactly 1236/fc. No need to wait longer.
-	
+	iso14a_set_timeout(1236/(16*8)+1);      // response to WUPA is expected at exactly 1236/fc. No need to wait longer.
+
 	uint32_t start_time = GetTickCount();
 	int len;
-	
+
 	// we may need several tries if we did send an unknown command or a wrong authentication before...
 	do {
 		// Broadcast for a card, WUPA (0x52) will force response from all cards in the field
@@ -1702,7 +1711,7 @@ static int GetATQA(uint8_t *resp, uint8_t *resp_par) {
 		// Receive the ATQA
 		len = ReaderReceive(resp, resp_par);
 	} while (len == 0 && GetTickCount() <= start_time + WUPA_RETRY_TIMEOUT);
-			
+
 	iso14a_set_timeout(save_iso14a_timeout);
 	return len;
 }
@@ -1711,7 +1720,7 @@ static int GetATQA(uint8_t *resp, uint8_t *resp_par) {
 // performs iso14443a anticollision (optional) and card select procedure
 // fills the uid and cuid pointer unless NULL
 // fills the card info record unless NULL
-// if anticollision is false, then the UID must be provided in uid_ptr[] 
+// if anticollision is false, then the UID must be provided in uid_ptr[]
 // and num_cascades must be set (1: 4 Byte UID, 2: 7 Byte UID, 3: 10 Byte UID)
 // requests ATS unless no_rats is true
 int iso14443a_select_card(byte_t *uid_ptr, iso14a_card_select_t *p_hi14a_card, uint32_t *cuid_ptr, bool anticollision, uint8_t num_cascades, bool no_rats) {
@@ -1753,11 +1762,11 @@ int iso14443a_select_card(byte_t *uid_ptr, iso14a_card_select_t *p_hi14a_card, u
 	if ((resp[0] & 0x1F) == 0) {
 		return 3;
 	}
-	
+
 	// OK we will select at least at cascade 1, lets see if first byte of UID was 0x88 in
 	// which case we need to make a cascade 2 request and select - this is a long UID
 	// While the UID is not complete, the 3rd bit (from the right) is set in the SAK.
-	for(; sak & 0x04; cascade_level++) {
+	for (; sak & 0x04; cascade_level++) {
 		// SELECT_* (L1: 0x93, L2: 0x95, L3: 0x97)
 		sel_uid[0] = sel_all[0] = 0x93 + cascade_level * 2;
 
@@ -1768,21 +1777,21 @@ int iso14443a_select_card(byte_t *uid_ptr, iso14a_card_select_t *p_hi14a_card, u
 				return 0;
 			}
 
-			if (Demod.collisionPos) {			// we had a collision and need to construct the UID bit by bit
+			if (Demod.collisionPos) {           // we had a collision and need to construct the UID bit by bit
 				memset(uid_resp, 0, 4);
 				uint16_t uid_resp_bits = 0;
 				uint16_t collision_answer_offset = 0;
 				// anti-collision-loop:
 				while (Demod.collisionPos) {
 					Dbprintf("Multiple tags detected. Collision after Bit %d", Demod.collisionPos);
-					for (uint16_t i = collision_answer_offset; i < Demod.collisionPos; i++, uid_resp_bits++) {	// add valid UID bits before collision point
+					for (uint16_t i = collision_answer_offset; i < Demod.collisionPos; i++, uid_resp_bits++) {  // add valid UID bits before collision point
 						uint16_t UIDbit = (resp[i/8] >> (i % 8)) & 0x01;
 						uid_resp[uid_resp_bits / 8] |= UIDbit << (uid_resp_bits % 8);
 					}
-					uid_resp[uid_resp_bits/8] |= 1 << (uid_resp_bits % 8);					// next time select the card(s) with a 1 in the collision position
+					uid_resp[uid_resp_bits/8] |= 1 << (uid_resp_bits % 8);                  // next time select the card(s) with a 1 in the collision position
 					uid_resp_bits++;
 					// construct anticollosion command:
-					sel_uid[1] = ((2 + uid_resp_bits/8) << 4) | (uid_resp_bits & 0x07);  	// length of data in bytes and bits
+					sel_uid[1] = ((2 + uid_resp_bits/8) << 4) | (uid_resp_bits & 0x07);     // length of data in bytes and bits
 					for (uint16_t i = 0; i <= uid_resp_bits/8; i++) {
 						sel_uid[2+i] = uid_resp[i];
 					}
@@ -1798,7 +1807,7 @@ int iso14443a_select_card(byte_t *uid_ptr, iso14a_card_select_t *p_hi14a_card, u
 					uid_resp[uid_resp_bits/8] |= UIDbit << (uid_resp_bits % 8);
 				}
 
-			} else {		// no collision, use the response to SELECT_ALL as current uid
+			} else {        // no collision, use the response to SELECT_ALL as current uid
 				memcpy(uid_resp, resp, 4);
 			}
 		} else {
@@ -1817,10 +1826,10 @@ int iso14443a_select_card(byte_t *uid_ptr, iso14a_card_select_t *p_hi14a_card, u
 		}
 
 		// Construct SELECT UID command
-		sel_uid[1] = 0x70;													// transmitting a full UID (1 Byte cmd, 1 Byte NVB, 4 Byte UID, 1 Byte BCC, 2 Bytes CRC)
-		memcpy(sel_uid+2, uid_resp, 4);										// the UID received during anticollision, or the provided UID
-		sel_uid[6] = sel_uid[2] ^ sel_uid[3] ^ sel_uid[4] ^ sel_uid[5];  	// calculate and add BCC
-		AppendCrc14443a(sel_uid, 7);										// calculate and add CRC
+		sel_uid[1] = 0x70;                                                  // transmitting a full UID (1 Byte cmd, 1 Byte NVB, 4 Byte UID, 1 Byte BCC, 2 Bytes CRC)
+		memcpy(sel_uid+2, uid_resp, 4);                                     // the UID received during anticollision, or the provided UID
+		sel_uid[6] = sel_uid[2] ^ sel_uid[3] ^ sel_uid[4] ^ sel_uid[5];     // calculate and add BCC
+		AppendCrc14443a(sel_uid, 7);                                        // calculate and add CRC
 		ReaderTransmit(sel_uid, sizeof(sel_uid), NULL);
 
 		// Receive the SAK
@@ -1828,14 +1837,14 @@ int iso14443a_select_card(byte_t *uid_ptr, iso14a_card_select_t *p_hi14a_card, u
 			return 0;
 		}
 		sak = resp[0];
-	
+
 		// Test if more parts of the uid are coming
 		if ((sak & 0x04) /* && uid_resp[0] == 0x88 */) {
 			// Remove first byte, 0x88 is not an UID byte, it CT, see page 3 of:
 			// http://www.nxp.com/documents/application_note/AN10927.pdf
 			uid_resp[0] = uid_resp[1];
 			uid_resp[1] = uid_resp[2];
-			uid_resp[2] = uid_resp[3]; 
+			uid_resp[2] = uid_resp[3];
 			uid_resp_len = 3;
 		}
 
@@ -1854,7 +1863,7 @@ int iso14443a_select_card(byte_t *uid_ptr, iso14a_card_select_t *p_hi14a_card, u
 	}
 
 	// PICC compilant with iso14443a-4 ---> (SAK & 0x20 != 0)
-	if( (sak & 0x20) == 0) return 2; 
+	if( (sak & 0x20) == 0) return 2;
 
 	if (!no_rats) {
 		// Request for answer to select
@@ -1875,9 +1884,9 @@ int iso14443a_select_card(byte_t *uid_ptr, iso14a_card_select_t *p_hi14a_card, u
 
 		// set default timeout and delay next transfer based on ATS
 		iso14a_set_ATS_times(resp);
-		
+
 	}
-	return 1;	
+	return 1;
 }
 
 
@@ -1897,11 +1906,22 @@ void iso14443a_setup(uint8_t fpga_minor_mode) {
 	}
 	FpgaWriteConfWord(FPGA_MAJOR_MODE_HF_ISO14443A | fpga_minor_mode);
 
+	// Set ADC to read field strength
+	AT91C_BASE_ADC->ADC_CR = AT91C_ADC_SWRST;
+	AT91C_BASE_ADC->ADC_MR =
+				ADC_MODE_PRESCALE(63) |
+				ADC_MODE_STARTUP_TIME(1) |
+				ADC_MODE_SAMPLE_HOLD_TIME(15);
+	AT91C_BASE_ADC->ADC_CHER = ADC_CHANNEL(ADC_CHAN_HF_LOW);
+
 	// Start the timer
 	StartCountSspClk();
-	
+
 	DemodReset();
 	UartReset();
+	LastTimeProxToAirStart = 0;
+	FpgaSendQueueDelay = 0;
+	LastProxToAirDuration = 20; // arbitrary small value. Avoid lock in EmGetCmd()
 	NextTransferTime = 2*DELAY_ARM2AIR_AS_READER;
 	iso14a_set_timeout(1060); // 10ms default
 }
@@ -1926,17 +1946,17 @@ b8 b7 b6 b5 b4 b3 b2 b1
 b5 = ACK/NACK
 Coding of S-block:
 b8 b7 b6 b5 b4 b3 b2 b1
-1  1  x  x  x  0  1  0 
+1  1  x  x  x  0  1  0
 b5,b6 = 00 - DESELECT
-        11 - WTX 
-*/    
+		11 - WTX
+*/
 int iso14_apdu(uint8_t *cmd, uint16_t cmd_len, bool send_chaining, void *data, uint8_t *res) {
 	uint8_t parity[MAX_PARITY_SIZE];
 	uint8_t real_cmd[cmd_len + 4];
-	
+
 	if (cmd_len) {
 		// ISO 14443 APDU frame: PCB [CID] [NAD] APDU CRC PCB=0x02
-		real_cmd[0] = 0x02; // bnr,nad,cid,chn=0; i-block(0x00)	
+		real_cmd[0] = 0x02; // bnr,nad,cid,chn=0; i-block(0x00)
 		if (send_chaining) {
 			real_cmd[0] |= 0x10;
 		}
@@ -1945,11 +1965,11 @@ int iso14_apdu(uint8_t *cmd, uint16_t cmd_len, bool send_chaining, void *data, u
 		memcpy(real_cmd + 1, cmd, cmd_len);
 	} else {
 		// R-block. ACK
-		real_cmd[0] = 0xA2; // r-block + ACK	
+		real_cmd[0] = 0xA2; // r-block + ACK
 		real_cmd[0] |= iso14_pcb_blocknum;
 	}
 	AppendCrc14443a(real_cmd, cmd_len + 1);
- 
+
 	ReaderTransmit(real_cmd, cmd_len + 3, NULL);
 
 	size_t len = ReaderReceive(data, parity);
@@ -1957,20 +1977,20 @@ int iso14_apdu(uint8_t *cmd, uint16_t cmd_len, bool send_chaining, void *data, u
 
 	if (!len) {
 		return 0; //DATA LINK ERROR
-	} else{
-		// S-Block WTX 
-		while(len && ((data_bytes[0] & 0xF2) == 0xF2)) {
+	} else {
+		// S-Block WTX
+		while (len && ((data_bytes[0] & 0xF2) == 0xF2)) {
 			uint32_t save_iso14a_timeout = iso14a_get_timeout();
 			// temporarily increase timeout
 			iso14a_set_timeout(MAX((data_bytes[1] & 0x3f) * save_iso14a_timeout, MAX_ISO14A_TIMEOUT));
-			// Transmit WTX back 
+			// Transmit WTX back
 			// byte1 - WTXM [1..59]. command FWT=FWT*WTXM
 			data_bytes[1] = data_bytes[1] & 0x3f; // 2 high bits mandatory set to 0b
 			// now need to fix CRC.
 			AppendCrc14443a(data_bytes, len - 2);
 			// transmit S-Block
 			ReaderTransmit(data_bytes, len, NULL);
-			// retrieve the result again (with increased timeout) 
+			// retrieve the result again (with increased timeout)
 			len = ReaderReceive(data, parity);
 			data_bytes = data;
 			// restore timeout
@@ -1980,13 +2000,13 @@ int iso14_apdu(uint8_t *cmd, uint16_t cmd_len, bool send_chaining, void *data, u
 		// if we received an I- or R(ACK)-Block with a block number equal to the
 		// current block number, toggle the current block number
 		if (len >= 3 // PCB+CRC = 3 bytes
-	         && ((data_bytes[0] & 0xC0) == 0 // I-Block
-	             || (data_bytes[0] & 0xD0) == 0x80) // R-Block with ACK bit set to 0
-	         && (data_bytes[0] & 0x01) == iso14_pcb_blocknum) // equal block numbers
+			 && ((data_bytes[0] & 0xC0) == 0 // I-Block
+				 || (data_bytes[0] & 0xD0) == 0x80) // R-Block with ACK bit set to 0
+			 && (data_bytes[0] & 0x01) == iso14_pcb_blocknum) // equal block numbers
 		{
 			iso14_pcb_blocknum ^= 1;
 		}
-		
+
 		// if we received I-block with chaining we need to send ACK and receive another block of data
 		if (res)
 			*res = data_bytes[0];
@@ -1995,9 +2015,9 @@ int iso14_apdu(uint8_t *cmd, uint16_t cmd_len, bool send_chaining, void *data, u
 		if (len >= 3 && !CheckCrc14443(CRC_14443_A, data_bytes, len)) {
 			return -1;
 		}
-		
+
 	}
-	
+
 	if (len) {
 		// cut frame byte
 		len -= 1;
@@ -2005,7 +2025,7 @@ int iso14_apdu(uint8_t *cmd, uint16_t cmd_len, bool send_chaining, void *data, u
 		for (int i = 0; i < len; i++)
 			data_bytes[i] = data_bytes[i + 1];
 	}
-		
+
 	return len;
 }
 
@@ -2025,9 +2045,9 @@ void ReaderIso14443a(UsbCommand *c)
 	byte_t buf[USB_CMD_DATA_SIZE] = {0};
 	uint8_t par[MAX_PARITY_SIZE];
 	bool cantSELECT = false;
-  
+
 	set_tracing(true);
-	
+
 	if(param & ISO14A_CLEAR_TRACE) {
 		clear_trace();
 	}
@@ -2078,29 +2098,29 @@ void ReaderIso14443a(UsbCommand *c)
 			len += 2;
 			if (lenbits) lenbits += 16;
 		}
-		if(lenbits>0) {				// want to send a specific number of bits (e.g. short commands)
+		if(lenbits>0) {             // want to send a specific number of bits (e.g. short commands)
 			if(param & ISO14A_TOPAZMODE) {
 				int bits_to_send = lenbits;
 				uint16_t i = 0;
-				ReaderTransmitBitsPar(&cmd[i++], MIN(bits_to_send, 7), NULL, NULL);		// first byte is always short (7bits) and no parity
+				ReaderTransmitBitsPar(&cmd[i++], MIN(bits_to_send, 7), NULL, NULL);     // first byte is always short (7bits) and no parity
 				bits_to_send -= 7;
 				while (bits_to_send > 0) {
-					ReaderTransmitBitsPar(&cmd[i++], MIN(bits_to_send, 8), NULL, NULL);	// following bytes are 8 bit and no parity
+					ReaderTransmitBitsPar(&cmd[i++], MIN(bits_to_send, 8), NULL, NULL); // following bytes are 8 bit and no parity
 					bits_to_send -= 8;
 				}
 			} else {
 				GetParity(cmd, lenbits/8, par);
-				ReaderTransmitBitsPar(cmd, lenbits, par, NULL);							// bytes are 8 bit with odd parity
+				ReaderTransmitBitsPar(cmd, lenbits, par, NULL);                         // bytes are 8 bit with odd parity
 			}
-		} else {					// want to send complete bytes only
+		} else {                    // want to send complete bytes only
 			if(param & ISO14A_TOPAZMODE) {
 				uint16_t i = 0;
-				ReaderTransmitBitsPar(&cmd[i++], 7, NULL, NULL);						// first byte: 7 bits, no paritiy
+				ReaderTransmitBitsPar(&cmd[i++], 7, NULL, NULL);                        // first byte: 7 bits, no paritiy
 				while (i < len) {
-					ReaderTransmitBitsPar(&cmd[i++], 8, NULL, NULL);					// following bytes: 8 bits, no paritiy
+					ReaderTransmitBitsPar(&cmd[i++], 8, NULL, NULL);                    // following bytes: 8 bits, no paritiy
 				}
 			} else {
-				ReaderTransmit(cmd,len, NULL);											// 8 bits, odd parity
+				ReaderTransmit(cmd,len, NULL);                                          // 8 bits, odd parity
 			}
 		}
 		arg0 = ReaderReceive(buf, par);
@@ -2136,14 +2156,14 @@ static int32_t dist_nt(uint32_t nt1, uint32_t nt2) {
 
 	nttmp1 = nt1;
 	nttmp2 = nt2;
-	
+
 	for (i = 1; i < 32768; i++) {
 		nttmp1 = prng_successor(nttmp1, 1);
 		if (nttmp1 == nt2) return i;
 		nttmp2 = prng_successor(nttmp2, 1);
 		if (nttmp2 == nt1) return -i;
 		}
-	
+
 	return(-99999); // either nt1 or nt2 are invalid nonces
 }
 
@@ -2165,15 +2185,15 @@ void ReaderMifare(bool first_try)
 	uint8_t receivedAnswerPar[MAX_MIFARE_PARITY_SIZE];
 
 	iso14443a_setup(FPGA_HF_ISO14443A_READER_MOD);
-	
+
 	// free eventually allocated BigBuf memory. We want all for tracing.
 	BigBuf_free();
-	
+
 	clear_trace();
 	set_tracing(true);
 
 	uint8_t nt_diff = 0;
-	uint8_t par[1] = {0};	// maximum 8 Bytes to be sent here, 1 byte parity is therefore enough
+	uint8_t par[1] = {0};   // maximum 8 Bytes to be sent here, 1 byte parity is therefore enough
 	static uint8_t par_low = 0;
 	bool led_on = true;
 	uint8_t uid[10]  ={0};
@@ -2194,10 +2214,10 @@ void ReaderMifare(bool first_try)
 	uint16_t consecutive_resyncs = 0;
 	int isOK = 0;
 
-	if (first_try) { 
+	if (first_try) {
 		mf_nr_ar3 = 0;
 		par[0] = par_low = 0;
-		sync_cycles = PRNG_SEQUENCE_LENGTH;							// theory: Mifare Classic's random generator repeats every 2^16 cycles (and so do the tag nonces).
+		sync_cycles = PRNG_SEQUENCE_LENGTH;                         // theory: Mifare Classic's random generator repeats every 2^16 cycles (and so do the tag nonces).
 		nt_attacked = 0;
 	}
 	else {
@@ -2210,13 +2230,13 @@ void ReaderMifare(bool first_try)
 	LED_A_ON();
 	LED_B_OFF();
 	LED_C_OFF();
-	
 
-	#define MAX_UNEXPECTED_RANDOM	4		// maximum number of unexpected (i.e. real) random numbers when trying to sync. Then give up.
-	#define MAX_SYNC_TRIES			32
-	#define SYNC_TIME_BUFFER		16		// if there is only SYNC_TIME_BUFFER left before next planned sync, wait for next PRNG cycle
-	#define NUM_DEBUG_INFOS			8		// per strategy
-	#define MAX_STRATEGY			3
+
+	#define MAX_UNEXPECTED_RANDOM   4       // maximum number of unexpected (i.e. real) random numbers when trying to sync. Then give up.
+	#define MAX_SYNC_TRIES          32
+	#define SYNC_TIME_BUFFER        16      // if there is only SYNC_TIME_BUFFER left before next planned sync, wait for next PRNG cycle
+	#define NUM_DEBUG_INFOS         8       // per strategy
+	#define MAX_STRATEGY            3
 	uint16_t unexpected_random = 0;
 	uint16_t sync_tries = 0;
 	int16_t debug_info_nr = -1;
@@ -2224,9 +2244,9 @@ void ReaderMifare(bool first_try)
 	int32_t debug_info[MAX_STRATEGY][NUM_DEBUG_INFOS];
 	uint32_t select_time;
 	uint32_t halt_time;
-	
-	for(uint16_t i = 0; true; i++) {
-		
+
+	for (uint16_t i = 0; true; i++) {
+
 		LED_C_ON();
 		WDT_HIT();
 
@@ -2235,7 +2255,7 @@ void ReaderMifare(bool first_try)
 			isOK = -1;
 			break;
 		}
-		
+
 		if (strategy == 2) {
 			// test with additional hlt command
 			halt_time = 0;
@@ -2252,9 +2272,9 @@ void ReaderMifare(bool first_try)
 			iso14443a_setup(FPGA_HF_ISO14443A_READER_MOD);
 			SpinDelay(100);
 		}
-		
+
 		if(!iso14443a_select_card(uid, NULL, &cuid, true, 0, true)) {
-			if (MF_DBGLEVEL >= 1)	Dbprintf("Mifare: Can't select card");
+			if (MF_DBGLEVEL >= 1)   Dbprintf("Mifare: Can't select card");
 			continue;
 		}
 		select_time = GetCountSspClk();
@@ -2270,11 +2290,11 @@ void ReaderMifare(bool first_try)
 				sync_time = (sync_time & 0xfffffff8) + sync_cycles;
 			}
 
-			// Transmit MIFARE_CLASSIC_AUTH at synctime. Should result in returning the same tag nonce (== nt_attacked) 
+			// Transmit MIFARE_CLASSIC_AUTH at synctime. Should result in returning the same tag nonce (== nt_attacked)
 			ReaderTransmit(mf_auth, sizeof(mf_auth), &sync_time);
 		} else {
 			// collect some information on tag nonces for debugging:
-			#define DEBUG_FIXED_SYNC_CYCLES	PRNG_SEQUENCE_LENGTH
+			#define DEBUG_FIXED_SYNC_CYCLES PRNG_SEQUENCE_LENGTH
 			if (strategy == 0) {
 				// nonce distances at fixed time after card select:
 				sync_time = select_time + DEBUG_FIXED_SYNC_CYCLES;
@@ -2289,11 +2309,11 @@ void ReaderMifare(bool first_try)
 				sync_time = DEBUG_FIXED_SYNC_CYCLES;
 			}
 			ReaderTransmit(mf_auth, sizeof(mf_auth), &sync_time);
-		}			
+		}
 
 		// Receive the (4 Byte) "random" nonce
 		if (!ReaderReceive(receivedAnswer, receivedAnswerPar)) {
-			if (MF_DBGLEVEL >= 1)	Dbprintf("Mifare: Couldn't receive tag nonce");
+			if (MF_DBGLEVEL >= 1)   Dbprintf("Mifare: Couldn't receive tag nonce");
 			continue;
 		  }
 
@@ -2311,17 +2331,17 @@ void ReaderMifare(bool first_try)
 				if (nt_distance == -99999) { // invalid nonce received
 					unexpected_random++;
 					if (unexpected_random > MAX_UNEXPECTED_RANDOM) {
-						isOK = -3;		// Card has an unpredictable PRNG. Give up	
+						isOK = -3;      // Card has an unpredictable PRNG. Give up
 						break;
 					} else {
-						continue;		// continue trying...
+						continue;       // continue trying...
 					}
 				}
 				if (++sync_tries > MAX_SYNC_TRIES) {
 					if (strategy > MAX_STRATEGY || MF_DBGLEVEL < 3) {
-						isOK = -4; 			// Card's PRNG runs at an unexpected frequency or resets unexpectedly
+						isOK = -4;          // Card's PRNG runs at an unexpected frequency or resets unexpectedly
 						break;
-					} else {				// continue for a while, just to collect some debug info
+					} else {                // continue for a while, just to collect some debug info
 						debug_info[strategy][debug_info_nr] = nt_distance;
 						debug_info_nr++;
 						if (debug_info_nr == NUM_DEBUG_INFOS) {
@@ -2342,9 +2362,9 @@ void ReaderMifare(bool first_try)
 			}
 		}
 
-		if ((nt != nt_attacked) && nt_attacked) { 	// we somehow lost sync. Try to catch up again...
+		if ((nt != nt_attacked) && nt_attacked) {   // we somehow lost sync. Try to catch up again...
 			catch_up_cycles = -dist_nt(nt_attacked, nt);
-			if (catch_up_cycles == 99999) {			// invalid nonce received. Don't resync on that one.
+			if (catch_up_cycles == 99999) {         // invalid nonce received. Don't resync on that one.
 				catch_up_cycles = 0;
 				continue;
 			}
@@ -2354,12 +2374,12 @@ void ReaderMifare(bool first_try)
 			}
 			else {
 				last_catch_up = catch_up_cycles;
-			    consecutive_resyncs = 0;
+				consecutive_resyncs = 0;
 			}
 			if (consecutive_resyncs < 3) {
 				if (MF_DBGLEVEL >= 3) Dbprintf("Lost sync in cycle %d. nt_distance=%d. Consecutive Resyncs = %d. Trying one time catch up...\n", i, -catch_up_cycles, consecutive_resyncs);
 			}
-			else {	
+			else {
 				sync_cycles = sync_cycles + catch_up_cycles;
 				if (MF_DBGLEVEL >= 3) Dbprintf("Lost sync in cycle %d for the fourth time consecutively (nt_distance = %d). Adjusting sync_cycles to %d.\n", i, -catch_up_cycles, sync_cycles);
 				last_catch_up = 0;
@@ -2368,13 +2388,13 @@ void ReaderMifare(bool first_try)
 			}
 			continue;
 		}
- 
+
 		consecutive_resyncs = 0;
-		
+
 		// Receive answer. This will be a 4 Bit NACK when the 8 parity bits are OK after decoding
 		if (ReaderReceive(receivedAnswer, receivedAnswerPar)) {
-			catch_up_cycles = 8; 	// the PRNG is delayed by 8 cycles due to the NAC (4Bits = 0x05 encrypted) transfer
-	
+			catch_up_cycles = 8;    // the PRNG is delayed by 8 cycles due to the NAC (4Bits = 0x05 encrypted) transfer
+
 			if (nt_diff == 0) {
 				par_low = par[0] & 0xE0; // there is no need to check all parities for other nt_diff. Parity Bits for mf_nr_ar[0..2] won't change
 			}
@@ -2398,7 +2418,7 @@ void ReaderMifare(bool first_try)
 			if (nt_diff == 0 && first_try)
 			{
 				par[0]++;
-				if (par[0] == 0x00) {		// tried all 256 possible parities without success. Card doesn't send NACK.
+				if (par[0] == 0x00) {       // tried all 256 possible parities without success. Card doesn't send NACK.
 					isOK = -2;
 					break;
 				}
@@ -2414,13 +2434,13 @@ void ReaderMifare(bool first_try)
 	if (isOK == -4) {
 		if (MF_DBGLEVEL >= 3) {
 			for (uint16_t i = 0; i <= MAX_STRATEGY; i++) {
-				for(uint16_t j = 0; j < NUM_DEBUG_INFOS; j++) {
+				for (uint16_t j = 0; j < NUM_DEBUG_INFOS; j++) {
 					Dbprintf("collected debug info[%d][%d] = %d", i, j, debug_info[i][j]);
 				}
 			}
 		}
 	}
-	
+
 	FpgaDisableTracing();
 
 	uint8_t buf[32];
@@ -2429,7 +2449,7 @@ void ReaderMifare(bool first_try)
 	memcpy(buf + 8,  par_list, 8);
 	memcpy(buf + 16, ks_list, 8);
 	memcpy(buf + 24, mf_nr_ar, 8);
-		
+
 	cmd_send(CMD_ACK, isOK, 0, 0, buf, 32);
 
 	// Thats it...
@@ -2441,8 +2461,8 @@ void ReaderMifare(bool first_try)
 
 
 //-----------------------------------------------------------------------------
-// MIFARE sniffer. 
-// 
+// MIFARE sniffer.
+//
 //-----------------------------------------------------------------------------
 void RAMFUNC SniffMifare(uint8_t param) {
 	// param:
@@ -2452,7 +2472,7 @@ void RAMFUNC SniffMifare(uint8_t param) {
 	// C(red) A(yellow) B(green)
 	LEDsoff();
 	LED_A_ON();
-	
+
 	// init trace buffer
 	clear_trace();
 	set_tracing(true);
@@ -2492,19 +2512,19 @@ void RAMFUNC SniffMifare(uint8_t param) {
 	MfSniffInit();
 
 	// And now we loop, receiving samples.
-	for(uint32_t sniffCounter = 0; true; ) {
-	
+	for (uint32_t sniffCounter = 0; true; ) {
+
 		if(BUTTON_PRESS()) {
 			DbpString("Canceled by button.");
 			break;
 		}
 
 		WDT_HIT();
-		
- 		if ((sniffCounter & 0x0000FFFF) == 0) {	// from time to time
+
+		if ((sniffCounter & 0x0000FFFF) == 0) { // from time to time
 			// check if a transaction is completed (timeout after 2000ms).
 			// if yes, stop the DMA transfer and send what we have so far to the client
-			if (MfSniffSend(2000)) {			
+			if (MfSniffSend(2000)) {
 				// Reset everything - we missed some sniffed data anyway while the DMA was stopped
 				sniffCounter = 0;
 				data = dmaBuf;
@@ -2514,17 +2534,17 @@ void RAMFUNC SniffMifare(uint8_t param) {
 				FpgaSetupSscDma((uint8_t *)dmaBuf, DMA_BUFFER_SIZE); // set transfer address and number of bytes. Start transfer.
 			}
 		}
-		
-		int register readBufDataP = data - dmaBuf;	// number of bytes we have processed so far
+
+		int register readBufDataP = data - dmaBuf;  // number of bytes we have processed so far
 		int register dmaBufDataP = DMA_BUFFER_SIZE - AT91C_BASE_PDC_SSC->PDC_RCR; // number of bytes already transferred
-		if (readBufDataP <= dmaBufDataP){			// we are processing the same block of data which is currently being transferred
-			dataLen = dmaBufDataP - readBufDataP;	// number of bytes still to be processed
-		} else {									
+		if (readBufDataP <= dmaBufDataP){           // we are processing the same block of data which is currently being transferred
+			dataLen = dmaBufDataP - readBufDataP;   // number of bytes still to be processed
+		} else {
 			dataLen = DMA_BUFFER_SIZE - readBufDataP + dmaBufDataP; // number of bytes still to be processed
 		}
 		// test for length of buffer
-		if(dataLen > maxDataLen) {					// we are more behind than ever...
-			maxDataLen = dataLen;					
+		if(dataLen > maxDataLen) {                  // we are more behind than ever...
+			maxDataLen = dataLen;
 			if(dataLen > (9 * DMA_BUFFER_SIZE / 10)) {
 				Dbprintf("blew circular buffer! dataLen=0x%x", dataLen);
 				break;
@@ -2546,7 +2566,7 @@ void RAMFUNC SniffMifare(uint8_t param) {
 
 		if (sniffCounter & 0x01) {
 
-			if(!TagIsActive) {		// no need to try decoding tag data if the reader is sending
+			if(!TagIsActive) {      // no need to try decoding tag data if the reader is sending
 				uint8_t readerdata = (previous_data & 0xF0) | (*data >> 4);
 				if(MillerDecoding(readerdata, (sniffCounter-1)*4)) {
 
@@ -2554,14 +2574,14 @@ void RAMFUNC SniffMifare(uint8_t param) {
 
 					/* And ready to receive another command. */
 					UartInit(receivedCmd, receivedCmdPar);
-					
+
 					/* And also reset the demod code */
 					DemodReset();
 				}
 				ReaderIsActive = (Uart.state != STATE_UNSYNCD);
 			}
-			
-			if(!ReaderIsActive) {		// no need to try decoding tag data if the reader is sending
+
+			if(!ReaderIsActive) {       // no need to try decoding tag data if the reader is sending
 				uint8_t tagdata = (previous_data << 4) | (*data & 0x0F);
 				if(ManchesterDecoding(tagdata, 0, (sniffCounter-1)*4)) {
 
@@ -2592,6 +2612,6 @@ void RAMFUNC SniffMifare(uint8_t param) {
 	DbpString("COMMAND FINISHED.");
 
 	MfSniffEnd();
-	
+
 	Dbprintf("maxDataLen=%x, Uart.state=%x, Uart.len=%x", maxDataLen, Uart.state, Uart.len);
 }

--- a/armsrc/iso14443a.h
+++ b/armsrc/iso14443a.h
@@ -41,7 +41,6 @@ extern void ReaderMifare(bool first_try);
 
 extern int EmGetCmd(uint8_t *received, uint16_t *len, uint8_t *parity);
 extern int EmSendCmd(uint8_t *resp, uint16_t respLen);
-extern int EmSendCmdEx(uint8_t *resp, uint16_t respLen);
 extern int EmSend4bit(uint8_t resp);
 extern int EmSendCmdPar(uint8_t *resp, uint16_t respLen, uint8_t *par);
 extern int EmSendPrecompiledCmd(tag_response_info_t *response_info);

--- a/armsrc/mifaresim.c
+++ b/armsrc/mifaresim.c
@@ -32,19 +32,17 @@
 #define MFEMUL_SELECT3      4
 #define MFEMUL_AUTH1        5
 #define MFEMUL_AUTH2        6
-#define MFEMUL_WORK	        7
+#define MFEMUL_WORK         7
 #define MFEMUL_WRITEBL2     8
 #define MFEMUL_INTREG_INC   9
 #define MFEMUL_INTREG_DEC  10
 #define MFEMUL_INTREG_REST 11
 #define MFEMUL_HALTED      12
 
-#define cardSTATE_TO_IDLE() { cardSTATE = MFEMUL_IDLE; LED_B_OFF(); LED_C_OFF(); }
-
 #define AC_DATA_READ             0
 #define AC_DATA_WRITE            1
-#define AC_DATA_INC				 2
-#define AC_DATA_DEC_TRANS_REST	 3
+#define AC_DATA_INC              2
+#define AC_DATA_DEC_TRANS_REST   3
 #define AC_KEYA_READ             0
 #define AC_KEYA_WRITE            1
 #define AC_KEYB_READ             2
@@ -57,11 +55,30 @@
 #define AUTHKEYNONE              0xff
 
 
+static int ParamCardSizeBlocks(const char c) {
+	int numBlocks = 16 * 4;
+	switch (c) {
+		case '0' : numBlocks = 5 * 4; break;
+		case '2' : numBlocks = 32 * 4; break;
+		case '4' : numBlocks = 32 * 4 + 8 * 16; break;
+		default:   numBlocks = 16 * 4;
+	}
+	return numBlocks;
+}
+
+static uint8_t BlockToSector(int block_num) {
+	if (block_num < 32 * 4) {    // 4 blocks per sector
+		return (block_num / 4);
+	} else {                     // 16 blocks per sector
+		return 32 + (block_num - 32 * 4) / 16;
+	}
+}
+
 static bool IsTrailerAccessAllowed(uint8_t blockNo, uint8_t keytype, uint8_t action) {
 	uint8_t sector_trailer[16];
 	emlGetMem(sector_trailer, blockNo, 1);
 	uint8_t AC = ((sector_trailer[7] >> 5) & 0x04)
-	           | ((sector_trailer[8] >> 2) & 0x02)
+			   | ((sector_trailer[8] >> 2) & 0x02)
 			   | ((sector_trailer[8] >> 7) & 0x01);
 	switch (action) {
 		case AC_KEYA_READ: {
@@ -69,8 +86,8 @@ static bool IsTrailerAccessAllowed(uint8_t blockNo, uint8_t keytype, uint8_t act
 			break;
 		}
 		case AC_KEYA_WRITE: {
-			return ((keytype == AUTHKEYA && (AC == 0x00 || AC == 0x01)) 
-			     || (keytype == AUTHKEYB && (AC == 0x04 || AC == 0x03)));
+			return ((keytype == AUTHKEYA && (AC == 0x00 || AC == 0x01))
+				 || (keytype == AUTHKEYB && (AC == 0x04 || AC == 0x03)));
 			break;
 		}
 		case AC_KEYB_READ: {
@@ -79,17 +96,17 @@ static bool IsTrailerAccessAllowed(uint8_t blockNo, uint8_t keytype, uint8_t act
 		}
 		case AC_KEYB_WRITE: {
 			return ((keytype == AUTHKEYA && (AC == 0x00 || AC == 0x04))
-			     || (keytype == AUTHKEYB && (AC == 0x04 || AC == 0x03)));
+				 || (keytype == AUTHKEYB && (AC == 0x04 || AC == 0x03)));
 			break;
 		}
 		case AC_AC_READ: {
 			return ((keytype == AUTHKEYA)
-			     || (keytype == AUTHKEYB && !(AC == 0x00 || AC == 0x02 || AC == 0x01)));
+				 || (keytype == AUTHKEYB && !(AC == 0x00 || AC == 0x02 || AC == 0x01)));
 			break;
 		}
 		case AC_AC_WRITE: {
 			return ((keytype == AUTHKEYA && (AC == 0x01))
-			     || (keytype == AUTHKEYB && (AC == 0x03 || AC == 0x05)));
+				 || (keytype == AUTHKEYB && (AC == 0x03 || AC == 0x05)));
 			break;
 		}
 		default: return false;
@@ -129,33 +146,33 @@ static bool IsDataAccessAllowed(uint8_t blockNo, uint8_t keytype, uint8_t action
 			   | ((sector_trailer[8] >> 6) & 0x01);
 			break;
 		}
-		default: 
+		default:
 			return false;
 	}
-	
+
 	switch (action) {
 		case AC_DATA_READ: {
 			return ((keytype == AUTHKEYA && !(AC == 0x03 || AC == 0x05 || AC == 0x07))
-			     || (keytype == AUTHKEYB && !(AC == 0x07)));
+				 || (keytype == AUTHKEYB && !(AC == 0x07)));
 			break;
 		}
 		case AC_DATA_WRITE: {
 			return ((keytype == AUTHKEYA && (AC == 0x00))
-			     || (keytype == AUTHKEYB && (AC == 0x00 || AC == 0x04 || AC == 0x06 || AC == 0x03)));
+				 || (keytype == AUTHKEYB && (AC == 0x00 || AC == 0x04 || AC == 0x06 || AC == 0x03)));
 			break;
 		}
 		case AC_DATA_INC: {
 			return ((keytype == AUTHKEYA && (AC == 0x00))
-			     || (keytype == AUTHKEYB && (AC == 0x00 || AC == 0x06)));
+				 || (keytype == AUTHKEYB && (AC == 0x00 || AC == 0x06)));
 			break;
 		}
 		case AC_DATA_DEC_TRANS_REST: {
 			return ((keytype == AUTHKEYA && (AC == 0x00 || AC == 0x06 || AC == 0x01))
-			     || (keytype == AUTHKEYB && (AC == 0x00 || AC == 0x06 || AC == 0x01)));
+				 || (keytype == AUTHKEYB && (AC == 0x00 || AC == 0x06 || AC == 0x01)));
 			break;
 		}
 	}
-	
+
 	return false;
 }
 
@@ -169,18 +186,18 @@ static bool IsAccessAllowed(uint8_t blockNo, uint8_t keytype, uint8_t action) {
 }
 
 
-static void MifareSimInit(uint8_t flags, uint8_t *datain, tag_response_info_t **responses, uint32_t *cuid, uint8_t *uid_len) {
+static void MifareSimInit(uint8_t flags, uint8_t *datain, tag_response_info_t **responses, uint32_t *cuid, uint8_t *uid_len, uint8_t cardsize) {
 
-	#define TAG_RESPONSE_COUNT 5								// number of precompiled responses
-	static uint8_t rATQA[]    = {0x04, 0x00}; 					// indicate Mifare classic 1k 4Byte UID
-	static uint8_t rUIDBCC1[] = {0x00, 0x00, 0x00, 0x00, 0x00};	// UID 1st cascade level
-	static uint8_t rUIDBCC2[] = {0x00, 0x00, 0x00, 0x00, 0x00};	// UID 2nd cascade level
-	static uint8_t rSAKfinal[]= {0x08, 0xb6, 0xdd};				// mifare 1k indicated
-	static uint8_t rSAK1[]    = {0x04, 0xda, 0x17}; 			// indicate UID not finished
+	#define TAG_RESPONSE_COUNT 5                                // number of precompiled responses
+	static uint8_t rATQA[]    = {0x00, 0x00};
+	static uint8_t rUIDBCC1[] = {0x00, 0x00, 0x00, 0x00, 0x00}; // UID 1st cascade level
+	static uint8_t rUIDBCC2[] = {0x00, 0x00, 0x00, 0x00, 0x00}; // UID 2nd cascade level
+	static uint8_t rSAKfinal[]= {0x00, 0x00, 0x00};             // SAK after UID complete
+	static uint8_t rSAK1[]    = {0x00, 0x00, 0x00};             // indicate UID not finished
 
 	*uid_len = 4;
 	// UID can be set from emulator memory or incoming data and can be 4 or 7 bytes long
-	if (flags & FLAG_4B_UID_IN_DATA) { 	// get UID from datain
+	if (flags & FLAG_4B_UID_IN_DATA) {  // get UID from datain
 		memcpy(rUIDBCC1, datain, 4);
 	} else if (flags & FLAG_7B_UID_IN_DATA) {
 		rUIDBCC1[0] = 0x88;
@@ -189,10 +206,10 @@ static void MifareSimInit(uint8_t flags, uint8_t *datain, tag_response_info_t **
 		*uid_len = 7;
 	} else {
 		uint8_t probable_atqa;
-		emlGetMemBt(&probable_atqa, 7, 1);	// get UID from emul memory - weak guess at length
-		if (probable_atqa == 0x00) {      	// ---------- 4BUID
+		emlGetMemBt(&probable_atqa, 7, 1);  // get UID from emul memory - weak guess at length
+		if (probable_atqa == 0x00) {        // ---------- 4BUID
 			emlGetMemBt(rUIDBCC1, 0, 4);
-		} else {                           	// ---------- 7BUID
+		} else {                            // ---------- 7BUID
 			rUIDBCC1[0] = 0x88;
 			emlGetMemBt(rUIDBCC1+1, 0, 3);
 			emlGetMemBt(rUIDBCC2, 3, 4);
@@ -204,37 +221,65 @@ static void MifareSimInit(uint8_t flags, uint8_t *datain, tag_response_info_t **
 		case 4:
 			*cuid = bytes_to_num(rUIDBCC1, 4);
 			rUIDBCC1[4] = rUIDBCC1[0] ^ rUIDBCC1[1] ^ rUIDBCC1[2] ^ rUIDBCC1[3];
-			if (MF_DBGLEVEL >= 2)	{
-				Dbprintf("4B UID: %02x%02x%02x%02x", 
-					rUIDBCC1[0], rUIDBCC1[1], rUIDBCC1[2], rUIDBCC1[3]	);
+			if (MF_DBGLEVEL >= 2)   {
+				Dbprintf("4B UID: %02x%02x%02x%02x",
+					rUIDBCC1[0], rUIDBCC1[1], rUIDBCC1[2], rUIDBCC1[3]  );
 			}
 			break;
 		case 7:
-			rATQA[0] |= 0x40;
 			*cuid = bytes_to_num(rUIDBCC2, 4);
-			rUIDBCC1[4] = rUIDBCC1[0] ^ rUIDBCC1[1] ^ rUIDBCC1[2] ^ rUIDBCC1[3]; 
-			rUIDBCC2[4] = rUIDBCC2[0] ^ rUIDBCC2[1] ^ rUIDBCC2[2] ^ rUIDBCC2[3]; 
-			if (MF_DBGLEVEL >= 2)	{
+			rUIDBCC1[4] = rUIDBCC1[0] ^ rUIDBCC1[1] ^ rUIDBCC1[2] ^ rUIDBCC1[3];
+			rUIDBCC2[4] = rUIDBCC2[0] ^ rUIDBCC2[1] ^ rUIDBCC2[2] ^ rUIDBCC2[3];
+			if (MF_DBGLEVEL >= 2)   {
 				Dbprintf("7B UID: %02x %02x %02x %02x %02x %02x %02x",
 					rUIDBCC1[1], rUIDBCC1[2], rUIDBCC1[3], rUIDBCC2[0], rUIDBCC2[1], rUIDBCC2[2], rUIDBCC2[3]  );
 			}
 			break;
-		default: 
+		default:
 			break;
+	}
+
+	// set SAK based on cardsize
+	switch (cardsize) {
+		case '0': rSAKfinal[0] = 0x09; break; // Mifare Mini
+		case '2': rSAKfinal[0] = 0x10; break; // Mifare 2K
+		case '4': rSAKfinal[0] = 0x18; break; // Mifare 4K
+		default: rSAKfinal[0] = 0x08;         // Mifare 1K
+	}
+	ComputeCrc14443(CRC_14443_A, rSAKfinal, 1, rSAKfinal + 1, rSAKfinal + 2);
+	if (MF_DBGLEVEL >= 2)   {
+		Dbprintf("SAK:    %02x", rSAKfinal[0]);
+	}
+
+	// set SAK for incomplete UID
+	rSAK1[0] = 0x04; 				          // Bit 3 indicates incomplete UID
+	ComputeCrc14443(CRC_14443_A, rSAK1, 1, rSAK1 + 1, rSAK1 + 2);
+
+	// set ATQA based on cardsize and UIDlen
+	if (cardsize == '4') {
+		rATQA[0] = 0x02;
+	} else {
+		rATQA[0] = 0x04;
+	}
+	if (*uid_len == 7) {
+		rATQA[0] |= 0x40;
+	}
+	if (MF_DBGLEVEL >= 2)   {
+		Dbprintf("ATQA:   %02x %02x", rATQA[1], rATQA[0]);
 	}
 	
 	static tag_response_info_t responses_init[TAG_RESPONSE_COUNT] = {
-		{ .response = rATQA,     .response_n = sizeof(rATQA)  },		// Answer to request - respond with card type
-		{ .response = rUIDBCC1,  .response_n = sizeof(rUIDBCC1) },		// Anticollision cascade1 - respond with first part of uid
-		{ .response = rUIDBCC2,  .response_n = sizeof(rUIDBCC2) },		// Anticollision cascade2 - respond with 2nd part of uid 
-		{ .response = rSAKfinal, .response_n = sizeof(rSAKfinal)  },	// Acknowledge select - last cascade
-		{ .response = rSAK1,     .response_n = sizeof(rSAK1) }			// Acknowledge select - previous cascades
+		{ .response = rATQA,     .response_n = sizeof(rATQA)  },        // Answer to request - respond with card type
+		{ .response = rUIDBCC1,  .response_n = sizeof(rUIDBCC1) },      // Anticollision cascade1 - respond with first part of uid
+		{ .response = rUIDBCC2,  .response_n = sizeof(rUIDBCC2) },      // Anticollision cascade2 - respond with 2nd part of uid
+		{ .response = rSAKfinal, .response_n = sizeof(rSAKfinal)  },    // Acknowledge select - last cascade
+		{ .response = rSAK1,     .response_n = sizeof(rSAK1) }          // Acknowledge select - previous cascades
 	};
 
 	// Prepare ("precompile") the responses of the anticollision phase. There will be not enough time to do this at the moment the reader sends its REQA or SELECT
-	// There are 7 predefined responses with a total of 18 bytes data to transmit. Coded responses need one byte per bit to transfer (data, parity, start, stop, correction) 
+	// There are 7 predefined responses with a total of 18 bytes data to transmit. Coded responses need one byte per bit to transfer (data, parity, start, stop, correction)
 	// 18 * 8 data bits, 18 * 1 parity bits, 5 start bits, 5 stop bits, 5 correction bits  ->   need 177 bytes buffer
-	#define ALLOCATED_TAG_MODULATION_BUFFER_SIZE 177	// number of bytes required for precompiled responses
+	#define ALLOCATED_TAG_MODULATION_BUFFER_SIZE 177    // number of bytes required for precompiled responses
 
 	uint8_t *free_buffer_pointer = BigBuf_malloc(ALLOCATED_TAG_MODULATION_BUFFER_SIZE);
 	size_t free_buffer_size = ALLOCATED_TAG_MODULATION_BUFFER_SIZE;
@@ -262,22 +307,24 @@ static bool HasValidCRC(uint8_t *receivedCmd, uint16_t receivedCmd_len) {
 
 
 /**
-  *MIFARE 1K simulate.
+  *MIFARE simulate.
   *
   *@param flags :
-  *	FLAG_INTERACTIVE - In interactive mode, we are expected to finish the operation with an ACK
+  * FLAG_INTERACTIVE - In interactive mode, we are expected to finish the operation with an ACK
   * FLAG_4B_UID_IN_DATA - means that there is a 4-byte UID in the data-section, we're expected to use that
   * FLAG_7B_UID_IN_DATA - means that there is a 7-byte UID in the data-section, we're expected to use that
-  * FLAG_10B_UID_IN_DATA	- use 10-byte UID in the data-section not finished
-  *	FLAG_NR_AR_ATTACK  - means we should collect NR_AR responses for bruteforcing later
+  * FLAG_10B_UID_IN_DATA    - use 10-byte UID in the data-section not finished
+  * FLAG_NR_AR_ATTACK  - means we should collect NR_AR responses for bruteforcing later
   * FLAG_RANDOM_NONCE - means we should generate some pseudo-random nonce data (only allows moebius attack)
   *@param exitAfterNReads, exit simulation after n blocks have been read, 0 is infinite ...
   * (unless reader attack mode enabled then it runs util it gets enough nonces to recover all keys attmpted)
   */
-void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *datain)
+void MifareSim(uint8_t flags, uint8_t exitAfterNReads, uint8_t cardsize, uint8_t *datain)
 {
+	LED_A_ON();
+	
 	tag_response_info_t *responses;
-	uint8_t uid_len = 4; 
+	uint8_t uid_len = 4;
 	uint32_t cuid = 0;
 	uint8_t cardWRBL = 0;
 	uint8_t cardAUTHSC = 0;
@@ -297,25 +344,27 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 	uint16_t receivedCmd_len;
 	uint8_t response[MAX_MIFARE_FRAME_SIZE];
 	uint8_t response_par[MAX_MIFARE_PARITY_SIZE];
-	
+
 	uint8_t rAUTH_NT[] = {0x01, 0x02, 0x03, 0x04};
 	uint8_t rAUTH_AT[] = {0x00, 0x00, 0x00, 0x00};
-		
-	//Here, we collect UID,sector,keytype,NT,AR,NR,NT2,AR2,NR2
+
+	int num_blocks = ParamCardSizeBlocks(cardsize);
+	
+	// Here we collect UID, sector, keytype, NT, AR, NR, NT2, AR2, NR2
 	// This will be used in the reader-only attack.
 
-	//allow collecting up to 7 sets of nonces to allow recovery of up to 7 keys
+	// allow collecting up to 7 sets of nonces to allow recovery of up to 7 keys
 	#define ATTACK_KEY_COUNT 7 // keep same as define in cmdhfmf.c -> readerAttack() (Cannot be more than 7)
-	nonces_t ar_nr_resp[ATTACK_KEY_COUNT*2]; //*2 for 2 separate attack types (nml, moebius) 36 * 7 * 2 bytes = 504 bytes
+	nonces_t ar_nr_resp[ATTACK_KEY_COUNT*2]; // *2 for 2 separate attack types (nml, moebius) 36 * 7 * 2 bytes = 504 bytes
 	memset(ar_nr_resp, 0x00, sizeof(ar_nr_resp));
 
-	uint8_t ar_nr_collected[ATTACK_KEY_COUNT*2]; //*2 for 2nd attack type (moebius)
+	uint8_t ar_nr_collected[ATTACK_KEY_COUNT*2]; // *2 for 2nd attack type (moebius)
 	memset(ar_nr_collected, 0x00, sizeof(ar_nr_collected));
-	uint8_t	nonce1_count = 0;
-	uint8_t	nonce2_count = 0;
-	uint8_t	moebius_n_count = 0;
+	uint8_t nonce1_count = 0;
+	uint8_t nonce2_count = 0;
+	uint8_t moebius_n_count = 0;
 	bool gettingMoebius = false;
-	uint8_t	mM = 0; //moebius_modifier for collection storage
+	uint8_t mM = 0; // moebius_modifier for collection storage
 
 	// Authenticate response - nonce
 	uint32_t nonce;
@@ -328,8 +377,8 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 	// free eventually allocated BigBuf memory but keep Emulator Memory
 	BigBuf_free_keep_EM();
 
-	MifareSimInit(flags, datain, &responses, &cuid, &uid_len);
-	
+	MifareSimInit(flags, datain, &responses, &cuid, &uid_len, cardsize);
+
 	// We need to listen to the high-frequency, peak-detected path.
 	iso14443a_setup(FPGA_HF_ISO14443A_TAGSIM_LISTEN);
 
@@ -337,7 +386,7 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 	clear_trace();
 	set_tracing(true);
 	ResetSspClk();
-	
+
 	bool finished = false;
 	bool button_pushed = BUTTON_PRESS();
 	int cardSTATE = MFEMUL_NOFIELD;
@@ -349,18 +398,19 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 		if (cardSTATE == MFEMUL_NOFIELD) {
 			int vHf = (MAX_ADC_HF_VOLTAGE_LOW * AvgAdc(ADC_CHAN_HF_LOW)) >> 10;
 			if (vHf > MF_MINFIELDV) {
-				LED_A_ON();
-				cardSTATE_TO_IDLE();
+				LED_D_ON();
+				cardSTATE = MFEMUL_IDLE;
 			}
 			button_pushed = BUTTON_PRESS();
 			continue;
 		}
 
+		FpgaEnableTracing();
 		//Now, get data
 		int res = EmGetCmd(receivedCmd, &receivedCmd_len, receivedCmd_par);
-		
+
 		if (res == 2) { //Field is off!
-			LEDsoff();
+			LED_D_OFF();
 			cardSTATE = MFEMUL_NOFIELD;
 			continue;
 		} else if (res == 1) { // button pressed
@@ -371,6 +421,7 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 		// WUPA in HALTED state or REQA or WUPA in any other state
 		if (receivedCmd_len == 1 && ((receivedCmd[0] == ISO14443A_CMD_REQA && cardSTATE != MFEMUL_HALTED) || receivedCmd[0] == ISO14443A_CMD_WUPA)) {
 			EmSendPrecompiledCmd(&responses[ATQA]);
+			FpgaDisableTracing();
 
 			// init crypto block
 			crypto1_destroy(pcs);
@@ -378,12 +429,10 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 			if (flags & FLAG_RANDOM_NONCE) {
 				nonce = prand();
 			}
-			LED_B_OFF();
-			LED_C_OFF();
 			cardSTATE = MFEMUL_SELECT1;
 			continue;
 		}
-		
+
 		switch (cardSTATE) {
 			case MFEMUL_NOFIELD:
 			case MFEMUL_HALTED:
@@ -393,8 +442,9 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 			case MFEMUL_SELECT1:{
 				// select all - 0x93 0x20
 				if (receivedCmd_len == 2 && (receivedCmd[0] == ISO14443A_CMD_ANTICOLL_OR_SELECT && receivedCmd[1] == 0x20)) {
-					if (MF_DBGLEVEL >= 4)	Dbprintf("SELECT ALL CL1 received");
+					if (MF_DBGLEVEL >= 4)   Dbprintf("SELECT ALL CL1 received");
 					EmSendPrecompiledCmd(&responses[UIDBCC1]);
+					FpgaDisableTracing();
 					break;
 				}
 				// select card - 0x93 0x70 ...
@@ -403,41 +453,44 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 					if (MF_DBGLEVEL >= 4) Dbprintf("SELECT CL1 %02x%02x%02x%02x received",receivedCmd[2],receivedCmd[3],receivedCmd[4],receivedCmd[5]);
 					if (uid_len == 4) {
 						EmSendPrecompiledCmd(&responses[SAKfinal]);
-						LED_B_ON();
+						FpgaDisableTracing();
 						cardSTATE = MFEMUL_WORK;
 						break;
 					} else if (uid_len == 7) {
 						EmSendPrecompiledCmd(&responses[SAK1]);
-						cardSTATE	= MFEMUL_SELECT2;
+						FpgaDisableTracing();
+						cardSTATE   = MFEMUL_SELECT2;
 						break;
 					}
 				}
-				cardSTATE_TO_IDLE();
+				cardSTATE = MFEMUL_IDLE;
 				break;
 			}
 			case MFEMUL_SELECT2:{
 				// select all cl2 - 0x95 0x20
 				if (receivedCmd_len == 2 && (receivedCmd[0] == ISO14443A_CMD_ANTICOLL_OR_SELECT_2 && receivedCmd[1] == 0x20)) {
-					if (MF_DBGLEVEL >= 4)	Dbprintf("SELECT ALL CL2 received");
+					if (MF_DBGLEVEL >= 4)   Dbprintf("SELECT ALL CL2 received");
 					EmSendPrecompiledCmd(&responses[UIDBCC2]);
+					FpgaDisableTracing();
 					break;
 				}
 				// select cl2 card - 0x95 0x70 xxxxxxxxxxxx
-				if (receivedCmd_len == 9 && 
+				if (receivedCmd_len == 9 &&
 						(receivedCmd[0] == ISO14443A_CMD_ANTICOLL_OR_SELECT_2 && receivedCmd[1] == 0x70 && memcmp(&receivedCmd[2], responses[UIDBCC2].response, 4) == 0)) {
 					if (uid_len == 7) {
 						if (MF_DBGLEVEL >= 4) Dbprintf("SELECT CL2 %02x%02x%02x%02x received",receivedCmd[2],receivedCmd[3],receivedCmd[4],receivedCmd[5]);
 						EmSendPrecompiledCmd(&responses[SAKfinal]);
-						LED_B_ON();
+						FpgaDisableTracing();
 						cardSTATE = MFEMUL_WORK;
 						break;
 					}
 				}
-				cardSTATE_TO_IDLE();
+				cardSTATE = MFEMUL_IDLE;
 				break;
 			}
 			case MFEMUL_WORK:{
-				if (receivedCmd_len != 4) {	// all commands must have exactly 4 bytes
+				if (receivedCmd_len != 4) { // all commands must have exactly 4 bytes
+					FpgaDisableTracing();
 					break;
 				}
 				bool encrypted_data = (cardAUTHKEY != AUTHKEYNONE) ;
@@ -448,35 +501,43 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 					memcpy(receivedCmd_dec, receivedCmd, receivedCmd_len);
 				}
 				if (!HasValidCRC(receivedCmd_dec, receivedCmd_len)) { // all commands must have a valid CRC
-					EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_NACK_NA));
+					EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_NACK_TR));
+					FpgaDisableTracing();
 					break;
 				}
 				if (receivedCmd_dec[0] == MIFARE_AUTH_KEYA || receivedCmd_dec[0] == MIFARE_AUTH_KEYB) {
 					// if authenticating to a block that shouldn't exist - as long as we are not doing the reader attack
-					if (receivedCmd_dec[1] >= 16 * 4 && !(flags & FLAG_NR_AR_ATTACK)) {
+					if (receivedCmd_dec[1] >= num_blocks && !(flags & FLAG_NR_AR_ATTACK)) {
 						//is this the correct response to an auth on a out of range block? marshmellow
 						EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_NACK_NA));
-						if (MF_DBGLEVEL >= 2) Dbprintf("Reader tried to operate (0x%02x) on out of range block: %d (0x%02x), nacking",receivedCmd_dec[0],receivedCmd_dec[1],receivedCmd_dec[1]);
+						FpgaDisableTracing();
+						if (MF_DBGLEVEL >= 2) Dbprintf("Reader tried to operate (0x%02x) on out of range block: %d (0x%02x), nacking", receivedCmd_dec[0], receivedCmd_dec[1], receivedCmd_dec[1]);
 						break;
 					}
-					cardAUTHSC = receivedCmd_dec[1] / 4;  // received block num
+					cardAUTHSC = BlockToSector(receivedCmd_dec[1]);  // received block num
 					cardAUTHKEY = receivedCmd_dec[0] & 0x01;
 					crypto1_destroy(pcs);//Added by martin
 					crypto1_create(pcs, emlGetKey(cardAUTHSC, cardAUTHKEY));
 					if (!encrypted_data) { // first authentication
-						if (MF_DBGLEVEL >= 4) Dbprintf("Reader authenticating for block %d (0x%02x) with key %d",receivedCmd_dec[1], receivedCmd_dec[1], cardAUTHKEY);
-						crypto1_word(pcs, cuid ^ nonce, 0);//Update crypto state
-						num_to_bytes(nonce, 4, rAUTH_AT); // Send nonce
+						if (MF_DBGLEVEL >= 4) Dbprintf("Reader authenticating for block %d (0x%02x) with key %d", receivedCmd_dec[1], receivedCmd_dec[1], cardAUTHKEY);
+						crypto1_word(pcs, cuid ^ nonce, 0); // Update crypto state
+						num_to_bytes(nonce, 4, rAUTH_AT);   // Send unencrypted nonce
+						EmSendCmd(rAUTH_AT, sizeof(rAUTH_AT));
 					} else { // nested authentication
 						if (MF_DBGLEVEL >= 4) Dbprintf("Reader doing nested authentication for block %d (0x%02x) with key %d", receivedCmd_dec[1], receivedCmd_dec[1], cardAUTHKEY);
-						ans = nonce ^ crypto1_word(pcs, cuid ^ nonce, 0); 
-						num_to_bytes(ans, 4, rAUTH_AT);
+						num_to_bytes(nonce, sizeof(nonce), response);
+						uint8_t pcs_in[4] = {0};
+						num_to_bytes(cuid ^ nonce, sizeof(nonce), pcs_in);
+						mf_crypto1_encryptEx(pcs, response, pcs_in, sizeof(nonce), response_par);
+						EmSendCmdPar(response, sizeof(nonce), response_par); // send encrypted nonce
 					}
-					EmSendCmd(rAUTH_AT, sizeof(rAUTH_AT));
+					FpgaDisableTracing();
 					cardSTATE = MFEMUL_AUTH1;
 					break;
 				}
+					
 				if (!encrypted_data) { // all other commands must be encrypted (authenticated)
+					FpgaDisableTracing();
 					break;
 				}
 				if(receivedCmd_dec[0] == ISO14443A_CMD_READBLOCK
@@ -485,13 +546,15 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 					|| receivedCmd_dec[0] == MIFARE_CMD_DEC
 					|| receivedCmd_dec[0] == MIFARE_CMD_RESTORE
 					|| receivedCmd_dec[0] == MIFARE_CMD_TRANSFER) {
-					if (receivedCmd_dec[1] >= 16 * 4) {
+					if (receivedCmd_dec[1] >= num_blocks) {
 						EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_NACK_NA));
+						FpgaDisableTracing();
 						if (MF_DBGLEVEL >= 2) Dbprintf("Reader tried to operate (0x%02x) on out of range block: %d (0x%02x), nacking",receivedCmd_dec[0],receivedCmd_dec[1],receivedCmd_dec[1]);
 						break;
 					}
-					if (receivedCmd_dec[1] / 4 != cardAUTHSC) {
+					if (BlockToSector(receivedCmd_dec[1]) != cardAUTHSC) {
 						EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_NACK_NA));
+						FpgaDisableTracing();
 						if (MF_DBGLEVEL >= 2) Dbprintf("Reader tried to operate (0x%02x) on block (0x%02x) not authenticated for (0x%02x), nacking",receivedCmd_dec[0],receivedCmd_dec[1],cardAUTHSC);
 						break;
 					}
@@ -503,21 +566,22 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 					}
 					emlGetMem(response, blockNo, 1);
 					if (IsSectorTrailer(blockNo)) {
-						memset(response, 0x00, 6); 	// keyA can never be read
+						memset(response, 0x00, 6);  // keyA can never be read
 						if (!IsAccessAllowed(blockNo, cardAUTHKEY, AC_KEYB_READ)) {
-							memset(response+10, 0x00, 6); 	// keyB cannot be read
+							memset(response+10, 0x00, 6);   // keyB cannot be read
 						}
 						if (!IsAccessAllowed(blockNo, cardAUTHKEY, AC_AC_READ)) {
-							memset(response+6, 0x00, 4); 	// AC bits cannot be read
+							memset(response+6, 0x00, 4);    // AC bits cannot be read
 						}
 					} else {
 						if (!IsAccessAllowed(blockNo, cardAUTHKEY, AC_DATA_READ)) {
-							memset(response, 0x00, 16);		// datablock cannot be read
+							memset(response, 0x00, 16);     // datablock cannot be read
 						}
 					}
 					AppendCrc14443a(response, 16);
 					mf_crypto1_encrypt(pcs, response, 18, response_par);
 					EmSendCmdPar(response, 18, response_par);
+					FpgaDisableTracing();
 					numReads++;
 					if(exitAfterNReads > 0 && numReads == exitAfterNReads) {
 						Dbprintf("%d reads done, exiting", numReads);
@@ -529,6 +593,7 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 					uint8_t blockNo = receivedCmd_dec[1];
 					if (MF_DBGLEVEL >= 4) Dbprintf("RECV 0xA0 write block %d (%02x)", blockNo, blockNo);
 					EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_ACK));
+					FpgaDisableTracing();
 					cardWRBL = blockNo;
 					cardSTATE = MFEMUL_WRITEBL2;
 					break;
@@ -539,9 +604,11 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 					if (emlCheckValBl(blockNo)) {
 						if (MF_DBGLEVEL >= 2) Dbprintf("Reader tried to operate on block, but emlCheckValBl failed, nacking");
 						EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_NACK_NA));
+						FpgaDisableTracing();
 						break;
 					}
 					EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_ACK));
+					FpgaDisableTracing();
 					cardWRBL = blockNo;
 					if (receivedCmd_dec[0] == MIFARE_CMD_INC)
 						cardSTATE = MFEMUL_INTREG_INC;
@@ -558,24 +625,23 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 						EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_NACK_NA));
 					else
 						EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_ACK));
+					FpgaDisableTracing();
 					break;
 				}
 				// halt
 				if (receivedCmd_dec[0] == ISO14443A_CMD_HALT && receivedCmd_dec[1] == 0x00) {
-					if (MF_DBGLEVEL >= 4)	Dbprintf("--> HALTED.");
-					LED_B_OFF();
-					LED_C_OFF();
+					if (MF_DBGLEVEL >= 4)   Dbprintf("--> HALTED.");
 					cardSTATE = MFEMUL_HALTED;
 					break;
 				}
 				// command not allowed
-				if (MF_DBGLEVEL >= 4)	Dbprintf("Received command not allowed, nacking");
+				if (MF_DBGLEVEL >= 4)   Dbprintf("Received command not allowed, nacking");
 				EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_NACK_NA));
 				break;
 			}
 			case MFEMUL_AUTH1:{
 				if (receivedCmd_len != 8) {
-					cardSTATE_TO_IDLE();
+					cardSTATE = MFEMUL_IDLE;
 					break;
 				}
 
@@ -590,7 +656,7 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 							if (ar_nr_collected[i+mM] < 2) {
 								// if we haven't already collected 2 nonces for this sector
 								if (ar_nr_resp[ar_nr_collected[i+mM]].ar != ar) {
-									// Avoid duplicates... probably not necessary, ar should vary. 
+									// Avoid duplicates... probably not necessary, ar should vary.
 									if (ar_nr_collected[i+mM]==0) {
 										// first nonce collect
 										ar_nr_resp[i+mM].cuid = cuid;
@@ -618,7 +684,7 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 											if ( nonce2_count == nonce1_count ) {
 												// done collecting std test switch to moebius
 												// first finish incrementing last sample
-												ar_nr_collected[i+mM]++; 
+												ar_nr_collected[i+mM]++;
 												// switch to moebius collection
 												gettingMoebius = true;
 												mM = ATTACK_KEY_COUNT;
@@ -657,15 +723,16 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 					// Right now, we don't nack or anything, which causes the
 					// reader to do a WUPA after a while. /Martin
 					// -- which is the correct response. /piwi
-					cardAUTHKEY = AUTHKEYNONE;	// not authenticated
-					cardSTATE_TO_IDLE();
+					cardAUTHKEY = AUTHKEYNONE;  // not authenticated
+					cardSTATE = MFEMUL_IDLE;
 					break;
 				}
-				ans = prng_successor(nonce, 96) ^ crypto1_word(pcs, 0, 0);
-				num_to_bytes(ans, 4, rAUTH_AT);
-				EmSendCmd(rAUTH_AT, sizeof(rAUTH_AT));
-				if (MF_DBGLEVEL >= 4)	Dbprintf("AUTH COMPLETED for sector %d with key %c.", cardAUTHSC, cardAUTHKEY == AUTHKEYA ? 'A' : 'B');
-				LED_C_ON();
+				ans = prng_successor(nonce, 96);
+				num_to_bytes(ans, 4, response);
+				mf_crypto1_encrypt(pcs, response, 4, response_par);
+				EmSendCmdPar(response, 4, response_par);
+				FpgaDisableTracing();
+				if (MF_DBGLEVEL >= 4)   Dbprintf("AUTH COMPLETED for sector %d with key %c.", cardAUTHSC, cardAUTHKEY == AUTHKEYA ? 'A' : 'B');
 				cardSTATE = MFEMUL_WORK;
 				break;
 			}
@@ -676,26 +743,27 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 						if (IsSectorTrailer(cardWRBL)) {
 							emlGetMem(response, cardWRBL, 1);
 							if (!IsAccessAllowed(cardWRBL, cardAUTHKEY, AC_KEYA_WRITE)) {
-								memcpy(receivedCmd_dec, response, 6);	// don't change KeyA
+								memcpy(receivedCmd_dec, response, 6);   // don't change KeyA
 							}
 							if (!IsAccessAllowed(cardWRBL, cardAUTHKEY, AC_KEYB_WRITE)) {
-								memcpy(receivedCmd_dec+10, response+10, 6);	// don't change KeyA
+								memcpy(receivedCmd_dec+10, response+10, 6); // don't change KeyA
 							}
 							if (!IsAccessAllowed(cardWRBL, cardAUTHKEY, AC_AC_WRITE)) {
-								memcpy(receivedCmd_dec+6, response+6, 4);	// don't change AC bits
+								memcpy(receivedCmd_dec+6, response+6, 4);   // don't change AC bits
 							}
 						} else {
 							if (!IsAccessAllowed(cardWRBL, cardAUTHKEY, AC_DATA_WRITE)) {
-								memcpy(receivedCmd_dec, response, 16);	// don't change anything
+								memcpy(receivedCmd_dec, response, 16);  // don't change anything
 							}
 						}
 						emlSetMem(receivedCmd_dec, cardWRBL, 1);
-						EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_ACK));	// always ACK?
+						EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_ACK));  // always ACK?
+						FpgaDisableTracing();
 						cardSTATE = MFEMUL_WORK;
 						break;
 					}
 				}
-				cardSTATE_TO_IDLE();
+				cardSTATE = MFEMUL_IDLE;
 				break;
 			}
 			case MFEMUL_INTREG_INC:{
@@ -703,7 +771,8 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 					mf_crypto1_decryptEx(pcs, receivedCmd, receivedCmd_len, (uint8_t*)&ans);
 					if (emlGetValBl(&cardINTREG, &cardINTBLOCK, cardWRBL)) {
 						EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_NACK_NA));
-						cardSTATE_TO_IDLE();
+						FpgaDisableTracing();
+						cardSTATE = MFEMUL_IDLE;
 						break;
 					}
 					cardINTREG = cardINTREG + ans;
@@ -716,7 +785,8 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 					mf_crypto1_decryptEx(pcs, receivedCmd, receivedCmd_len, (uint8_t*)&ans);
 					if (emlGetValBl(&cardINTREG, &cardINTBLOCK, cardWRBL)) {
 						EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_NACK_NA));
-						cardSTATE_TO_IDLE();
+						FpgaDisableTracing();
+						cardSTATE = MFEMUL_IDLE;
 						break;
 					}
 				}
@@ -728,7 +798,8 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 				mf_crypto1_decryptEx(pcs, receivedCmd, receivedCmd_len, (uint8_t*)&ans);
 				if (emlGetValBl(&cardINTREG, &cardINTBLOCK, cardWRBL)) {
 					EmSend4bit(mf_crypto1_encrypt4bit(pcs, CARD_NACK_NA));
-					cardSTATE_TO_IDLE();
+					FpgaDisableTracing();
+					cardSTATE = MFEMUL_IDLE;
 					break;
 				}
 				cardSTATE = MFEMUL_WORK;
@@ -742,7 +813,7 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 	LEDsoff();
 
 	if(flags & FLAG_NR_AR_ATTACK && MF_DBGLEVEL >= 1) {
-		for ( uint8_t	i = 0; i < ATTACK_KEY_COUNT; i++) {
+		for ( uint8_t   i = 0; i < ATTACK_KEY_COUNT; i++) {
 			if (ar_nr_collected[i] == 2) {
 				Dbprintf("Collected two pairs of AR/NR which can be used to extract %s from reader for sector %d:", (i<ATTACK_KEY_COUNT/2) ? "keyA" : "keyB", ar_nr_resp[i].sector);
 				Dbprintf("../tools/mfkey/mfkey32 %08x %08x %08x %08x %08x %08x",
@@ -754,11 +825,11 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 						ar_nr_resp[i].ar2    //AR2
 						);
 			}
-		}	
-		for ( uint8_t	i = ATTACK_KEY_COUNT; i < ATTACK_KEY_COUNT*2; i++) {
+		}
+		for ( uint8_t   i = ATTACK_KEY_COUNT; i < ATTACK_KEY_COUNT*2; i++) {
 			if (ar_nr_collected[i] == 2) {
 				Dbprintf("Collected two pairs of AR/NR which can be used to extract %s from reader for sector %d:", (i<ATTACK_KEY_COUNT/2) ? "keyA" : "keyB", ar_nr_resp[i].sector);
-				Dbprintf("../tools/mfkey/mfkey32v2 %08x %08x %08x %08x %08x %08x %08x",
+				Dbprintf("../tools/mfkey/mfkey32 %08x %08x %08x %08x %08x %08x %08x",
 						ar_nr_resp[i].cuid,  //UID
 						ar_nr_resp[i].nonce, //NT
 						ar_nr_resp[i].nr,    //NR1
@@ -770,10 +841,12 @@ void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *
 			}
 		}
 	}
-	if (MF_DBGLEVEL >= 1)	Dbprintf("Emulator stopped. Tracing: %d  trace length: %d ", get_tracing(), BigBuf_get_traceLen());
+	if (MF_DBGLEVEL >= 1)   Dbprintf("Emulator stopped. Tracing: %d  trace length: %d ", get_tracing(), BigBuf_get_traceLen());
 
 	if(flags & FLAG_INTERACTIVE) { // Interactive mode flag, means we need to send ACK
 		//Send the collected ar_nr in the response
-		cmd_send(CMD_ACK,CMD_SIMULATE_MIFARE_CARD,button_pushed,0,&ar_nr_resp,sizeof(ar_nr_resp));
+		cmd_send(CMD_ACK, CMD_SIMULATE_MIFARE_CARD, button_pushed, 0, &ar_nr_resp, sizeof(ar_nr_resp));
 	}
+	
+	LED_A_OFF();
 }

--- a/armsrc/mifaresim.h
+++ b/armsrc/mifaresim.h
@@ -15,6 +15,6 @@
 
 #include <stdint.h>
 
-extern void Mifare1ksim(uint8_t flags, uint8_t exitAfterNReads, uint8_t arg2, uint8_t *datain);
+extern void MifareSim(uint8_t flags, uint8_t exitAfterNReads, uint8_t cardsize, uint8_t *datain);
 
 #endif

--- a/armsrc/mifareutil.c
+++ b/armsrc/mifareutil.c
@@ -23,7 +23,7 @@
 #include "crapto1/crapto1.h"
 #include "mbedtls/des.h"
 
-int MF_DBGLEVEL = MF_DBG_ALL;
+int MF_DBGLEVEL = MF_DBG_INFO;
 
 // crypto1 helpers
 void mf_crypto1_decryptEx(struct Crypto1State *pcs, uint8_t *data_in, int len, uint8_t *data_out){

--- a/armsrc/mifareutil.c
+++ b/armsrc/mifareutil.c
@@ -27,9 +27,9 @@ int MF_DBGLEVEL = MF_DBG_INFO;
 
 // crypto1 helpers
 void mf_crypto1_decryptEx(struct Crypto1State *pcs, uint8_t *data_in, int len, uint8_t *data_out){
-	uint8_t	bt = 0;
+	uint8_t bt = 0;
 	int i;
-	
+
 	if (len != 1) {
 		for (i = 0; i < len; i++)
 			data_out[i] = crypto1_byte(pcs, 0x00, 0) ^ data_in[i];
@@ -37,7 +37,7 @@ void mf_crypto1_decryptEx(struct Crypto1State *pcs, uint8_t *data_in, int len, u
 		bt = 0;
 		for (i = 0; i < 4; i++)
 			bt |= (crypto1_bit(pcs, 0, 0) ^ BIT(data_in[0], i)) << i;
-				
+
 		data_out[0] = bt;
 	}
 	return;
@@ -51,14 +51,14 @@ void mf_crypto1_encryptEx(struct Crypto1State *pcs, uint8_t *data, uint8_t *in, 
 	uint8_t bt = 0;
 	int i;
 	par[0] = 0;
-	
+
 	for (i = 0; i < len; i++) {
 		bt = data[i];
 		data[i] = crypto1_byte(pcs, in==NULL?0x00:in[i], 0) ^ data[i];
-		if((i&0x0007) == 0) 
+		if((i&0x0007) == 0)
 			par[i>>3] = 0;
 		par[i>>3] |= (((filter(pcs->odd) ^ oddparity8(bt)) & 0x01)<<(7-(i&0x0007)));
-	}	
+	}
 	return;
 }
 
@@ -72,7 +72,7 @@ uint8_t mf_crypto1_encrypt4bit(struct Crypto1State *pcs, uint8_t data) {
 
 	for (i = 0; i < 4; i++)
 		bt |= (crypto1_bit(pcs, 0, 0) ^ BIT(data, i)) << i;
-		
+
 	return bt;
 }
 
@@ -98,20 +98,20 @@ int mifare_sendcmd_short(struct Crypto1State *pcs, uint8_t crypted, uint8_t cmd,
 {
 	uint8_t dcmd[4], ecmd[4];
 	uint16_t pos, res;
-	uint8_t par[1];			// 1 Byte parity is enough here
+	uint8_t par[1];         // 1 Byte parity is enough here
 	dcmd[0] = cmd;
 	dcmd[1] = data;
 	AppendCrc14443a(dcmd, 2);
-	
+
 	memcpy(ecmd, dcmd, sizeof(dcmd));
-	
+
 	if (crypted) {
 		par[0] = 0;
 		for (pos = 0; pos < 4; pos++)
 		{
 			ecmd[pos] = crypto1_byte(pcs, 0x00, 0) ^ dcmd[pos];
 			par[0] |= (((filter(pcs->odd) ^ oddparity8(dcmd[pos])) & 0x01) << (7-pos));
-		}	
+		}
 
 		ReaderTransmitPar(ecmd, sizeof(ecmd), par, timing);
 
@@ -120,17 +120,17 @@ int mifare_sendcmd_short(struct Crypto1State *pcs, uint8_t crypted, uint8_t cmd,
 	}
 
 	int len = ReaderReceive(answer, par);
-	
+
 	if (answer_parity) *answer_parity = par[0];
-	
+
 	if (crypted == CRYPT_ALL) {
 		if (len == 1) {
 			res = 0;
 			for (pos = 0; pos < 4; pos++)
 				res |= (crypto1_bit(pcs, 0, 0) ^ BIT(answer[0], pos)) << pos;
-				
+
 			answer[0] = res;
-			
+
 		} else {
 			for (pos = 0; pos < len; pos++)
 			{
@@ -138,41 +138,41 @@ int mifare_sendcmd_short(struct Crypto1State *pcs, uint8_t crypted, uint8_t cmd,
 			}
 		}
 	}
-	
+
 	return len;
 }
 
 // mifare classic commands
-int mifare_classic_auth(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t keyType, uint64_t ui64Key, uint8_t isNested) 
+int mifare_classic_auth(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t keyType, uint64_t ui64Key, uint8_t isNested)
 {
 	return mifare_classic_authex(pcs, uid, blockNo, keyType, ui64Key, isNested, NULL, NULL);
 }
 
-int mifare_classic_authex(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t keyType, uint64_t ui64Key, uint8_t isNested, uint32_t *ntptr, uint32_t *timing) 
+int mifare_classic_authex(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t keyType, uint64_t ui64Key, uint8_t isNested, uint32_t *ntptr, uint32_t *timing)
 {
 	// variables
-	int len;	
+	int len;
 	uint32_t pos;
 	uint8_t tmp4[4];
 	uint8_t par[1] = {0x00};
 	byte_t nr[4];
 	uint32_t nt, ntpp; // Supplied tag nonce
-	
+
 	uint8_t mf_nr_ar[] = { 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 };
 	uint8_t receivedAnswer[MAX_MIFARE_FRAME_SIZE];
 	uint8_t receivedAnswerPar[MAX_MIFARE_PARITY_SIZE];
-	
+
 	// Transmit MIFARE_CLASSIC_AUTH
 	len = mifare_sendcmd_short(pcs, isNested, 0x60 + (keyType & 0x01), blockNo, receivedAnswer, receivedAnswerPar, timing);
-	if (MF_DBGLEVEL >= 4)	Dbprintf("rand tag nonce len: %x", len);  
+	if (MF_DBGLEVEL >= 4)   Dbprintf("rand tag nonce len: %x", len);
 	if (len != 4) return 1;
-	
+
 	// "random" reader nonce:
 	nr[0] = 0x55;
 	nr[1] = 0x41;
 	nr[2] = 0x49;
-	nr[3] = 0x92; 
-	
+	nr[3] = 0x92;
+
 	// Save the tag nonce (nt)
 	nt = bytes_to_num(receivedAnswer, 4);
 
@@ -184,7 +184,7 @@ int mifare_classic_authex(struct Crypto1State *pcs, uint32_t uid, uint8_t blockN
 	crypto1_create(pcs, ui64Key);
 
 	if (isNested == AUTH_NESTED) {
-		// decrypt nt with help of new key 
+		// decrypt nt with help of new key
 		nt = crypto1_word(pcs, nt ^ uid, 1) ^ nt;
 	} else {
 		// Load (plain) uid^nt into the cipher
@@ -193,8 +193,8 @@ int mifare_classic_authex(struct Crypto1State *pcs, uint32_t uid, uint8_t blockN
 
 	// some statistic
 	if (!ntptr && (MF_DBGLEVEL >= 3))
-		Dbprintf("auth uid: %08x nt: %08x", uid, nt);  
-	
+		Dbprintf("auth uid: %08x nt: %08x", uid, nt);
+
 	// save Nt
 	if (ntptr)
 		*ntptr = nt;
@@ -205,8 +205,8 @@ int mifare_classic_authex(struct Crypto1State *pcs, uint32_t uid, uint8_t blockN
 	{
 		mf_nr_ar[pos] = crypto1_byte(pcs, nr[pos], 0) ^ nr[pos];
 		par[0] |= (((filter(pcs->odd) ^ oddparity8(nr[pos])) & 0x01) << (7-pos));
-	}	
-		
+	}
+
 	// Skip 32 bits in pseudo random generator
 	nt = prng_successor(nt,32);
 
@@ -216,8 +216,8 @@ int mifare_classic_authex(struct Crypto1State *pcs, uint32_t uid, uint8_t blockN
 		nt = prng_successor(nt,8);
 		mf_nr_ar[pos] = crypto1_byte(pcs,0x00,0) ^ (nt & 0xff);
 		par[0] |= (((filter(pcs->odd) ^ oddparity8(nt)) & 0x01) << (7-pos));
-	}	
-		
+	}
+
 	// Transmit reader nonce and reader answer
 	ReaderTransmitPar(mf_nr_ar, sizeof(mf_nr_ar), par, NULL);
 
@@ -225,48 +225,48 @@ int mifare_classic_authex(struct Crypto1State *pcs, uint32_t uid, uint8_t blockN
 	len = ReaderReceive(receivedAnswer, receivedAnswerPar);
 	if (!len)
 	{
-		if (MF_DBGLEVEL >= 1)	Dbprintf("Authentication failed. Card timeout.");
+		if (MF_DBGLEVEL >= 1)   Dbprintf("Authentication failed. Card timeout.");
 		return 2;
 	}
-	
+
 	memcpy(tmp4, receivedAnswer, 4);
 	ntpp = prng_successor(nt, 32) ^ crypto1_word(pcs, 0,0);
-	
+
 	if (ntpp != bytes_to_num(tmp4, 4)) {
-		if (MF_DBGLEVEL >= 1)	Dbprintf("Authentication failed. Error card response.");
+		if (MF_DBGLEVEL >= 1)   Dbprintf("Authentication failed. Error card response.");
 		return 3;
 	}
 
 	return 0;
 }
 
-int mifare_classic_readblock(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t *blockData) 
+int mifare_classic_readblock(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t *blockData)
 {
 	// variables
-	int len;	
-	uint8_t	bt[2];
-	
+	int len;
+	uint8_t bt[2];
+
 	uint8_t receivedAnswer[MAX_MIFARE_FRAME_SIZE];
 	uint8_t receivedAnswerPar[MAX_MIFARE_PARITY_SIZE];
-	
+
 	// command MIFARE_CLASSIC_READBLOCK
 	len = mifare_sendcmd_short(pcs, 1, 0x30, blockNo, receivedAnswer, receivedAnswerPar, NULL);
 	if (len == 1) {
-		if (MF_DBGLEVEL >= 1)	Dbprintf("Cmd Error: %02x", receivedAnswer[0]);  
+		if (MF_DBGLEVEL >= 1)   Dbprintf("Cmd Error: %02x", receivedAnswer[0]);
 		return 1;
 	}
 	if (len != 18) {
-		if (MF_DBGLEVEL >= 1)	Dbprintf("Cmd Error: card timeout. len: %x", len);  
+		if (MF_DBGLEVEL >= 1)   Dbprintf("Cmd Error: card timeout. len: %x", len);
 		return 2;
 	}
 
 	memcpy(bt, receivedAnswer + 16, 2);
 	AppendCrc14443a(receivedAnswer, 16);
 	if (bt[0] != receivedAnswer[16] || bt[1] != receivedAnswer[17]) {
-		if (MF_DBGLEVEL >= 1)	Dbprintf("Cmd CRC response error.");  
+		if (MF_DBGLEVEL >= 1)   Dbprintf("Cmd CRC response error.");
 		return 3;
 	}
-	
+
 	memcpy(blockData, receivedAnswer, 16);
 	return 0;
 }
@@ -281,7 +281,7 @@ int mifare_ul_ev1_auth(uint8_t *keybytes, uint8_t *pack){
 	memcpy(key, keybytes, 4);
 
 	if (MF_DBGLEVEL >= MF_DBG_EXTENDED)
-		Dbprintf("EV1 Auth : %02x%02x%02x%02x",	key[0], key[1], key[2], key[3]);
+		Dbprintf("EV1 Auth : %02x%02x%02x%02x", key[0], key[1], key[2], key[3]);
 	len = mifare_sendcmd(0x1B, key, sizeof(key), resp, respPar, NULL);
 	//len = mifare_sendcmd_short_mfuev1auth(NULL, 0, 0x1B, key, resp, respPar, NULL);
 	if (len != 4) {
@@ -326,12 +326,12 @@ int mifare_ultra_auth(uint8_t *keybytes){
 	// decrypt nonce.
 	// tdes_2key_dec(random_b, enc_random_b, sizeof(random_b), key, IV );
 	mbedtls_des3_set2key_dec(&ctx, key);
-	mbedtls_des3_crypt_cbc(&ctx  	// des3_context
-		, MBEDTLS_DES_DECRYPT    	// int mode
-		, sizeof(random_b)	// length
-		, IV            	// iv[8]
-		, enc_random_b		// input
-		, random_b			// output
+	mbedtls_des3_crypt_cbc(&ctx     // des3_context
+		, MBEDTLS_DES_DECRYPT       // int mode
+		, sizeof(random_b)  // length
+		, IV                // iv[8]
+		, enc_random_b      // input
+		, random_b          // output
 		);
 
 	rol(random_b,8);
@@ -355,12 +355,12 @@ int mifare_ultra_auth(uint8_t *keybytes){
 	// encrypt    out, in, length, key, iv
 	//tdes_2key_enc(rnd_ab, rnd_ab, sizeof(rnd_ab), key, enc_random_b);
 	mbedtls_des3_set2key_enc(&ctx, key);
-	mbedtls_des3_crypt_cbc(&ctx  	// des3_context
-		, MBEDTLS_DES_ENCRYPT    	// int mode
-		, sizeof(rnd_ab)	// length
-		, enc_random_b     	// iv[8]
-		, rnd_ab			// input
-		, rnd_ab			// output
+	mbedtls_des3_crypt_cbc(&ctx     // des3_context
+		, MBEDTLS_DES_ENCRYPT       // int mode
+		, sizeof(rnd_ab)    // length
+		, enc_random_b      // iv[8]
+		, rnd_ab            // input
+		, rnd_ab            // output
 		);
 
 	//len = mifare_sendcmd_short_mfucauth(NULL, 1, 0xAF, rnd_ab, resp, respPar, NULL);
@@ -374,15 +374,15 @@ int mifare_ultra_auth(uint8_t *keybytes){
 	uint8_t resp_random_a[8] = { 0,0,0,0,0,0,0,0 };
 	memcpy(enc_resp, resp+1, 8);
 
-	// decrypt    out, in, length, key, iv 
+	// decrypt    out, in, length, key, iv
 	// tdes_2key_dec(resp_random_a, enc_resp, 8, key, enc_random_b);
 	mbedtls_des3_set2key_dec(&ctx, key);
-	mbedtls_des3_crypt_cbc(&ctx  	// des3_context
-		, MBEDTLS_DES_DECRYPT    	// int mode
-		, 8					// length
-		, enc_random_b     	// iv[8]
-		, enc_resp			// input
-		, resp_random_a		// output
+	mbedtls_des3_crypt_cbc(&ctx     // des3_context
+		, MBEDTLS_DES_DECRYPT       // int mode
+		, 8                 // length
+		, enc_random_b      // iv[8]
+		, enc_resp          // input
+		, resp_random_a     // output
 		);
 	if ( memcmp(resp_random_a, random_a, 8) != 0 ) {
 		if (MF_DBGLEVEL >= MF_DBG_ERROR) Dbprintf("failed authentication");
@@ -390,7 +390,7 @@ int mifare_ultra_auth(uint8_t *keybytes){
 	}
 
 	if (MF_DBGLEVEL >= MF_DBG_EXTENDED) {
-		Dbprintf("e_AB: %02x %02x %02x %02x %02x %02x %02x %02x", 
+		Dbprintf("e_AB: %02x %02x %02x %02x %02x %02x %02x %02x",
 				rnd_ab[0],rnd_ab[1],rnd_ab[2],rnd_ab[3],
 				rnd_ab[4],rnd_ab[5],rnd_ab[6],rnd_ab[7]);
 
@@ -414,7 +414,7 @@ int mifare_ultra_auth(uint8_t *keybytes){
 int mifare_ultra_readblock(uint8_t blockNo, uint8_t *blockData)
 {
 	uint16_t len;
-	uint8_t	bt[2];
+	uint8_t bt[2];
 	uint8_t receivedAnswer[MAX_FRAME_SIZE];
 	uint8_t receivedAnswerPar[MAX_PARITY_SIZE];
 	uint8_t retries;
@@ -455,55 +455,55 @@ int mifare_ultra_readblock(uint8_t blockNo, uint8_t *blockData)
 	return 0;
 }
 
-int mifare_classic_writeblock(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t *blockData) 
+int mifare_classic_writeblock(struct Crypto1State *pcs, uint32_t uid, uint8_t blockNo, uint8_t *blockData)
 {
 	// variables
-	uint16_t len, i;	
+	uint16_t len, i;
 	uint32_t pos;
-	uint8_t par[3] = {0};		// enough for 18 Bytes to send
+	uint8_t par[3] = {0};       // enough for 18 Bytes to send
 	byte_t res;
-	
+
 	uint8_t d_block[18], d_block_enc[18];
 	uint8_t receivedAnswer[MAX_MIFARE_FRAME_SIZE];
 	uint8_t receivedAnswerPar[MAX_MIFARE_PARITY_SIZE];
-	
+
 	// command MIFARE_CLASSIC_WRITEBLOCK
 	len = mifare_sendcmd_short(pcs, 1, 0xA0, blockNo, receivedAnswer, receivedAnswerPar, NULL);
 
 	if ((len != 1) || (receivedAnswer[0] != 0x0A)) {   //  0x0a - ACK
-		if (MF_DBGLEVEL >= 1)	Dbprintf("Cmd Error: %02x", receivedAnswer[0]);  
+		if (MF_DBGLEVEL >= 1)   Dbprintf("Cmd Error: %02x", receivedAnswer[0]);
 		return 1;
 	}
-	
+
 	memcpy(d_block, blockData, 16);
 	AppendCrc14443a(d_block, 16);
-	
+
 	// crypto
 	for (pos = 0; pos < 18; pos++)
 	{
 		d_block_enc[pos] = crypto1_byte(pcs, 0x00, 0) ^ d_block[pos];
 		par[pos>>3] |= (((filter(pcs->odd) ^ oddparity8(d_block[pos])) & 0x01) << (7 - (pos&0x0007)));
-	}	
+	}
 
 	ReaderTransmitPar(d_block_enc, sizeof(d_block_enc), par, NULL);
 
 	// Receive the response
-	len = ReaderReceive(receivedAnswer, receivedAnswerPar);	
+	len = ReaderReceive(receivedAnswer, receivedAnswerPar);
 
 	res = 0;
 	for (i = 0; i < 4; i++)
 		res |= (crypto1_bit(pcs, 0, 0) ^ BIT(receivedAnswer[0], i)) << i;
 
 	if ((len != 1) || (res != 0x0A)) {
-		if (MF_DBGLEVEL >= 1)	Dbprintf("Cmd send data2 Error: %02x", res);  
+		if (MF_DBGLEVEL >= 1)   Dbprintf("Cmd send data2 Error: %02x", res);
 		return 2;
 	}
-	
+
 	return 0;
 }
 
 /* // command not needed, but left for future testing
-int mifare_ultra_writeblock_compat(uint8_t blockNo, uint8_t *blockData) 
+int mifare_ultra_writeblock_compat(uint8_t blockNo, uint8_t *blockData)
 {
 	uint16_t len;
 	uint8_t par[3] = {0};  // enough for 18 parity bits
@@ -557,16 +557,16 @@ int mifare_ultra_writeblock(uint8_t blockNo, uint8_t *blockData)
 	return 0;
 }
 
-int mifare_classic_halt(struct Crypto1State *pcs, uint32_t uid) 
+int mifare_classic_halt(struct Crypto1State *pcs, uint32_t uid)
 {
-	uint16_t len;	
+	uint16_t len;
 	uint8_t receivedAnswer[MAX_MIFARE_FRAME_SIZE];
 	uint8_t receivedAnswerPar[MAX_MIFARE_PARITY_SIZE];
 
 	len = mifare_sendcmd_short(pcs, pcs == NULL ? false:true, 0x50, 0x00, receivedAnswer, receivedAnswerPar, NULL);
 	if (len != 0) {
 		if (MF_DBGLEVEL >= MF_DBG_ERROR)
-			Dbprintf("halt error. response len: %x", len);  
+			Dbprintf("halt error. response len: %x", len);
 		return 1;
 	}
 
@@ -578,7 +578,7 @@ int mifare_ultra_halt()
 	uint16_t len;
 	uint8_t receivedAnswer[MAX_MIFARE_FRAME_SIZE];
 	uint8_t receivedAnswerPar[MAX_MIFARE_PARITY_SIZE];
-    
+
 	len = mifare_sendcmd_short(NULL, true, 0x50, 0x00, receivedAnswer, receivedAnswerPar, NULL);
 	if (len != 0) {
 		if (MF_DBGLEVEL >= MF_DBG_ERROR)
@@ -591,21 +591,21 @@ int mifare_ultra_halt()
 
 // Mifare Memory Structure: up to 32 Sectors with 4 blocks each (1k and 2k cards),
 // plus evtl. 8 sectors with 16 blocks each (4k cards)
-uint8_t NumBlocksPerSector(uint8_t sectorNo) 
+uint8_t NumBlocksPerSector(uint8_t sectorNo)
 {
-	if (sectorNo < 32) 
+	if (sectorNo < 32)
 		return 4;
 	else
 		return 16;
 }
 
-uint8_t FirstBlockOfSector(uint8_t sectorNo) 
+uint8_t FirstBlockOfSector(uint8_t sectorNo)
 {
 	if (sectorNo < 32)
 		return sectorNo * 4;
 	else
 		return 32*4 + (sectorNo - 32) * 16;
-		
+
 }
 
 uint8_t SectorTrailer(uint8_t blockNo)
@@ -648,7 +648,7 @@ int emlCheckValBl(int blockNum) {
 			(data[3] != (data[7] ^ 0xff)) || (data[3] != data[11]) ||
 			(data[12] != (data[13] ^ 0xff)) || (data[12] != data[14]) ||
 			(data[12] != (data[15] ^ 0xff))
-		 ) 
+		 )
 		return 1;
 	return 0;
 }
@@ -656,11 +656,11 @@ int emlCheckValBl(int blockNum) {
 int emlGetValBl(uint32_t *blReg, uint8_t *blBlock, int blockNum) {
 	uint8_t* emCARD = BigBuf_get_EM_addr();
 	uint8_t* data = emCARD + blockNum * 16;
-	
+
 	if (emlCheckValBl(blockNum)) {
 		return 1;
 	}
-	
+
 	memcpy(blReg, data, 4);
 	*blBlock = data[12];
 	return 0;
@@ -669,41 +669,41 @@ int emlGetValBl(uint32_t *blReg, uint8_t *blBlock, int blockNum) {
 int emlSetValBl(uint32_t blReg, uint8_t blBlock, int blockNum) {
 	uint8_t* emCARD = BigBuf_get_EM_addr();
 	uint8_t* data = emCARD + blockNum * 16;
-	
+
 	memcpy(data + 0, &blReg, 4);
 	memcpy(data + 8, &blReg, 4);
 	blReg = blReg ^ 0xffffffff;
 	memcpy(data + 4, &blReg, 4);
-	
+
 	data[12] = blBlock;
 	data[13] = blBlock ^ 0xff;
 	data[14] = blBlock;
 	data[15] = blBlock ^ 0xff;
-	
+
 	return 0;
 }
 
 uint64_t emlGetKey(int sectorNum, int keyType) {
 	uint8_t key[6];
 	uint8_t* emCARD = BigBuf_get_EM_addr();
-	
+
 	memcpy(key, emCARD + 16 * (FirstBlockOfSector(sectorNum) + NumBlocksPerSector(sectorNum) - 1) + keyType * 10, 6);
 	return bytes_to_num(key, 6);
 }
 
 void emlClearMem(void) {
 	int b;
-	
+
 	const uint8_t trailer[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x07, 0x80, 0x69, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 	const uint8_t uid[]   =   {0xe6, 0x84, 0x87, 0xf3, 0x16, 0x88, 0x04, 0x00, 0x46, 0x8e, 0x45, 0x55, 0x4d, 0x70, 0x41, 0x04};
 	uint8_t* emCARD = BigBuf_get_EM_addr();
-	
+
 	memset(emCARD, 0, CARD_MEMORY_SIZE);
-	
+
 	// fill sectors trailer data
 	for(b = 3; b < 256; b<127?(b+=4):(b+=16)) {
 		emlSetMem((uint8_t *)trailer, b , 1);
-	}	
+	}
 
 	// uid
 	emlSetMem((uint8_t *)uid, 0, 1);
@@ -714,35 +714,35 @@ void emlClearMem(void) {
 // Mifare desfire commands
 int mifare_sendcmd_special(struct Crypto1State *pcs, uint8_t crypted, uint8_t cmd, uint8_t* data, uint8_t* answer, uint8_t *answer_parity, uint32_t *timing)
 {
-    uint8_t dcmd[5] = {0x00};
-    dcmd[0] = cmd;
-    memcpy(dcmd+1,data,2);
+	uint8_t dcmd[5] = {0x00};
+	dcmd[0] = cmd;
+	memcpy(dcmd+1,data,2);
 	AppendCrc14443a(dcmd, 3);
-	
+
 	ReaderTransmit(dcmd, sizeof(dcmd), NULL);
 	int len = ReaderReceive(answer, answer_parity);
 	if(!len) {
-		if (MF_DBGLEVEL >= MF_DBG_ERROR) 
+		if (MF_DBGLEVEL >= MF_DBG_ERROR)
 			Dbprintf("Authentication failed. Card timeout.");
 		return 1;
-    }
+	}
 	return len;
 }
 
 int mifare_sendcmd_special2(struct Crypto1State *pcs, uint8_t crypted, uint8_t cmd, uint8_t* data, uint8_t* answer,uint8_t *answer_parity, uint32_t *timing)
 {
-    uint8_t dcmd[20] = {0x00};
-    dcmd[0] = cmd;
-    memcpy(dcmd+1,data,17);
+	uint8_t dcmd[20] = {0x00};
+	dcmd[0] = cmd;
+	memcpy(dcmd+1,data,17);
 	AppendCrc14443a(dcmd, 18);
 
 	ReaderTransmit(dcmd, sizeof(dcmd), NULL);
 	int len = ReaderReceive(answer, answer_parity);
 	if(!len){
-        if (MF_DBGLEVEL >= MF_DBG_ERROR)
+		if (MF_DBGLEVEL >= MF_DBG_ERROR)
 			Dbprintf("Authentication failed. Card timeout.");
 		return 1;
-    }
+	}
 	return len;
 }
 
@@ -753,23 +753,23 @@ int mifare_desfire_des_auth1(uint32_t uid, uint8_t *blockData){
 	uint8_t data[2]={0x0a, 0x00};
 	uint8_t receivedAnswer[MAX_FRAME_SIZE];
 	uint8_t receivedAnswerPar[MAX_PARITY_SIZE];
-	
+
 	len = mifare_sendcmd_special(NULL, 1, 0x02, data, receivedAnswer,receivedAnswerPar,NULL);
 	if (len == 1) {
 		if (MF_DBGLEVEL >= MF_DBG_ERROR)
 			Dbprintf("Cmd Error: %02x", receivedAnswer[0]);
 		return 1;
 	}
-	
+
 	if (len == 12) {
-		if (MF_DBGLEVEL >= MF_DBG_EXTENDED)	{
+		if (MF_DBGLEVEL >= MF_DBG_EXTENDED) {
 			Dbprintf("Auth1 Resp: %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
 				receivedAnswer[0],receivedAnswer[1],receivedAnswer[2],receivedAnswer[3],receivedAnswer[4],
 				receivedAnswer[5],receivedAnswer[6],receivedAnswer[7],receivedAnswer[8],receivedAnswer[9],
 				receivedAnswer[10],receivedAnswer[11]);
 			}
 			memcpy(blockData, receivedAnswer, 12);
-	        return 0;
+			return 0;
 	}
 	return 1;
 }
@@ -780,18 +780,18 @@ int mifare_desfire_des_auth2(uint32_t uid, uint8_t *key, uint8_t *blockData){
 	uint8_t data[17] = {0x00};
 	data[0] = 0xAF;
 	memcpy(data+1,key,16);
-	
+
 	uint8_t receivedAnswer[MAX_MIFARE_FRAME_SIZE];
 	uint8_t receivedAnswerPar[MAX_MIFARE_PARITY_SIZE];
-	
+
 	len = mifare_sendcmd_special2(NULL, 1, 0x03, data, receivedAnswer, receivedAnswerPar ,NULL);
-	
+
 	if ((receivedAnswer[0] == 0x03) && (receivedAnswer[1] == 0xae)) {
 		if (MF_DBGLEVEL >= MF_DBG_ERROR)
 			Dbprintf("Auth Error: %02x %02x", receivedAnswer[0], receivedAnswer[1]);
 		return 1;
 	}
-	
+
 	if (len == 12){
 		if (MF_DBGLEVEL >= MF_DBG_EXTENDED) {
 			Dbprintf("Auth2 Resp: %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
@@ -820,7 +820,7 @@ int MifareChkBlockKey(uint8_t *uid, uint32_t *cuid, uint8_t *cascade_levels, uin
 	if (*cascade_levels == 0) { // need a full select cycle to get the uid first
 		iso14a_card_select_t card_info;
 		if(!iso14443a_select_card(uid, &card_info, cuid, true, 0, true)) {
-			if (debugLevel >= 1) 	Dbprintf("ChkKeys: Can't select card");
+			if (debugLevel >= 1)    Dbprintf("ChkKeys: Can't select card");
 			return  1;
 		}
 		switch (card_info.uidlen) {
@@ -831,26 +831,26 @@ int MifareChkBlockKey(uint8_t *uid, uint32_t *cuid, uint8_t *cascade_levels, uin
 		}
 	} else { // no need for anticollision. We can directly select the card
 		if(!iso14443a_select_card(uid, NULL, NULL, false, *cascade_levels, true)) {
-			if (debugLevel >= 1)	Dbprintf("ChkKeys: Can't select card (UID) lvl=%d", *cascade_levels);
+			if (debugLevel >= 1)    Dbprintf("ChkKeys: Can't select card (UID) lvl=%d", *cascade_levels);
 			return  1;
 		}
 	}
-	
+
 	if(mifare_classic_auth(pcs, *cuid, blockNo, keyType, ui64Key, AUTH_FIRST)) {
-//		SpinDelayUs(AUTHENTICATION_TIMEOUT); // it not needs because mifare_classic_auth have timeout from iso14a_set_timeout()
+//      SpinDelayUs(AUTHENTICATION_TIMEOUT); // it not needs because mifare_classic_auth have timeout from iso14a_set_timeout()
 		return 2;
 	} else {
-/*		// let it be here. it like halt command, but maybe it will work in some strange cases
+/*      // let it be here. it like halt command, but maybe it will work in some strange cases
 		uint8_t dummy_answer = 0;
 		ReaderTransmit(&dummy_answer, 1, NULL);
-		int timeout = GetCountSspClk() + AUTHENTICATION_TIMEOUT;			
+		int timeout = GetCountSspClk() + AUTHENTICATION_TIMEOUT;
 		// wait for the card to become ready again
 		while(GetCountSspClk() < timeout) {};
 */
 		// it needs after success authentication
 		mifare_classic_halt(pcs, *cuid);
 	}
-	
+
 	return 0;
 }
 
@@ -865,14 +865,14 @@ int MifareChkBlockKeys(uint8_t *keys, uint8_t keyCount, uint8_t blockNo, uint8_t
 	for (uint8_t i = 0; i < keyCount; i++) {
 
 		// Allow button press / usb cmd to interrupt device
-		if (BUTTON_PRESS() && !usb_poll_validate_length()) { 
+		if (BUTTON_PRESS() && !usb_poll_validate_length()) {
 			Dbprintf("ChkKeys: Cancel operation. Exit...");
 			return -2;
 		}
 
 		ui64Key = bytes_to_num(keys + i * 6, 6);
 		int res = MifareChkBlockKey(uid, &cuid, &cascade_levels, ui64Key, blockNo, keyType, debugLevel);
-		
+
 		// can't select
 		if (res == 1) {
 			retryCount++;
@@ -883,10 +883,10 @@ int MifareChkBlockKeys(uint8_t *keys, uint8_t keyCount, uint8_t blockNo, uint8_t
 			--i; // try the same key once again
 
 			SpinDelay(20);
-//			Dbprintf("ChkKeys: block=%d key=%d. Try the same key once again...", blockNo, keyType);
+//          Dbprintf("ChkKeys: block=%d key=%d. Try the same key once again...", blockNo, keyType);
 			continue;
 		}
-		
+
 		// can't authenticate
 		if (res == 2) {
 			retryCount = 0;
@@ -895,15 +895,15 @@ int MifareChkBlockKeys(uint8_t *keys, uint8_t keyCount, uint8_t blockNo, uint8_t
 
 		return i + 1;
 	}
-	
+
 	return 0;
 }
 
 // multisector multikey check
 int MifareMultisectorChk(uint8_t *keys, uint8_t keyCount, uint8_t SectorCount, uint8_t keyType, uint8_t debugLevel, TKeyIndex *keyIndex) {
 	int res = 0;
-	
-//	int clk = GetCountSspClk();
+
+//  int clk = GetCountSspClk();
 
 	for(int sc = 0; sc < SectorCount; sc++){
 		WDT_HIT();
@@ -919,9 +919,9 @@ int MifareMultisectorChk(uint8_t *keys, uint8_t keyCount, uint8_t SectorCount, u
 			}
 		} while(--keyAB > 0);
 	}
-	
-//	Dbprintf("%d %d", GetCountSspClk() - clk, (GetCountSspClk() - clk)/(SectorCount*keyCount*(keyType==2?2:1)));
-	
+
+//  Dbprintf("%d %d", GetCountSspClk() - clk, (GetCountSspClk() - clk)/(SectorCount*keyCount*(keyType==2?2:1)));
+
 	return 0;
 }
 

--- a/armsrc/mifareutil.c
+++ b/armsrc/mifareutil.c
@@ -47,19 +47,23 @@ void mf_crypto1_decrypt(struct Crypto1State *pcs, uint8_t *data, int len){
 	mf_crypto1_decryptEx(pcs, data, len, data);
 }
 
-void mf_crypto1_encrypt(struct Crypto1State *pcs, uint8_t *data, uint16_t len, uint8_t *par) {
+void mf_crypto1_encryptEx(struct Crypto1State *pcs, uint8_t *data, uint8_t *in, uint16_t len, uint8_t *par) {
 	uint8_t bt = 0;
 	int i;
 	par[0] = 0;
 	
 	for (i = 0; i < len; i++) {
 		bt = data[i];
-		data[i] = crypto1_byte(pcs, 0x00, 0) ^ data[i];
+		data[i] = crypto1_byte(pcs, in==NULL?0x00:in[i], 0) ^ data[i];
 		if((i&0x0007) == 0) 
 			par[i>>3] = 0;
 		par[i>>3] |= (((filter(pcs->odd) ^ oddparity8(bt)) & 0x01)<<(7-(i&0x0007)));
 	}	
 	return;
+}
+
+void mf_crypto1_encrypt(struct Crypto1State *pcs, uint8_t *data, uint16_t len, uint8_t *par) {
+	mf_crypto1_encryptEx(pcs, data, NULL, len, par);
 }
 
 uint8_t mf_crypto1_encrypt4bit(struct Crypto1State *pcs, uint8_t data) {

--- a/armsrc/mifareutil.h
+++ b/armsrc/mifareutil.h
@@ -34,11 +34,11 @@
 #define MF_MINFIELDV      4000
 
 // debug
-// 0 - no debug messages 1 - error messages 2 - all messages 4 - extended debug mode
-#define MF_DBG_NONE          0
-#define MF_DBG_ERROR         1
-#define MF_DBG_ALL           2
-#define MF_DBG_EXTENDED      4
+#define MF_DBG_NONE          0  // no messages
+#define MF_DBG_ERROR         1  // errors only
+#define MF_DBG_INFO          2  // errors + info messages
+#define MF_DBG_DEBUG         3  // errors + info + debug messages
+#define MF_DBG_EXTENDED      4  // errors + info + debug + breaking debug messages
 
 extern int MF_DBGLEVEL;
 

--- a/armsrc/mifareutil.h
+++ b/armsrc/mifareutil.h
@@ -71,6 +71,7 @@ int mifare_desfire_des_auth2(uint32_t uid, uint8_t *key, uint8_t *blockData);
 void mf_crypto1_decrypt(struct Crypto1State *pcs, uint8_t *receivedCmd, int len);
 void mf_crypto1_decryptEx(struct Crypto1State *pcs, uint8_t *data_in, int len, uint8_t *data_out);
 void mf_crypto1_encrypt(struct Crypto1State *pcs, uint8_t *data, uint16_t len, uint8_t *par);
+void mf_crypto1_encryptEx(struct Crypto1State *pcs, uint8_t *data, uint8_t *in, uint16_t len, uint8_t *par);
 uint8_t mf_crypto1_encrypt4bit(struct Crypto1State *pcs, uint8_t data);
 
 // Mifare memory structure

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -1445,7 +1445,7 @@ int usage_hf14_mfsim(void) {
 
 int CmdHF14AMfSim(const char *Cmd) {
 	UsbCommand resp;
-	uint8_t uid[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+	uint8_t uid[7] = {0};
 	uint8_t exitAfterNReads = 0;
 	uint8_t flags = 0;
 	int uidlen = 0;
@@ -1563,7 +1563,6 @@ int CmdHF14AMfSim(const char *Cmd) {
 
 			uidlen = strlen(buf)-1;
 			switch(uidlen) {
-				case 20: flags |= FLAG_10B_UID_IN_DATA;	break; //not complete
 				case 14: flags |= FLAG_7B_UID_IN_DATA; break;
 				case  8: flags |= FLAG_4B_UID_IN_DATA; break;
 				default:
@@ -1581,8 +1580,7 @@ int CmdHF14AMfSim(const char *Cmd) {
 					cardsize == '2' ? "2K" :
 						cardsize == '4' ? "4K" : "1K",
 				flags & FLAG_4B_UID_IN_DATA ? sprint_hex(uid,4):
-					flags & FLAG_7B_UID_IN_DATA	? sprint_hex(uid,7):
-						flags & FLAG_10B_UID_IN_DATA ? sprint_hex(uid,10): "N/A",
+					flags & FLAG_7B_UID_IN_DATA	? sprint_hex(uid,7): "N/A",
 				exitAfterNReads,
 				flags,
 				flags);
@@ -1592,7 +1590,7 @@ int CmdHF14AMfSim(const char *Cmd) {
 			clearCommandBuffer();
 			SendCommand(&c);
 
-			while(! WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
+			while (! WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
 				//We're waiting only 1.5 s at a time, otherwise we get the
 				// annoying message about "Waiting for a response... "
 			}
@@ -1609,6 +1607,7 @@ int CmdHF14AMfSim(const char *Cmd) {
 			count++;
 		}
 		fclose(f);
+
 	} else { //not from file
 
 		PrintAndLog("mf sim cardsize: %s, uid: %s, numreads:%d, flags:%d (0x%02x) ",
@@ -1616,8 +1615,7 @@ int CmdHF14AMfSim(const char *Cmd) {
 				cardsize == '2' ? "2K" :
 					cardsize == '4' ? "4K" : "1K",
 			flags & FLAG_4B_UID_IN_DATA ? sprint_hex(uid,4):
-				flags & FLAG_7B_UID_IN_DATA	? sprint_hex(uid,7):
-					flags & FLAG_10B_UID_IN_DATA ? sprint_hex(uid,10): "N/A",
+				flags & FLAG_7B_UID_IN_DATA	? sprint_hex(uid,7): "N/A",
 			exitAfterNReads,
 			flags,
 			flags);

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -254,14 +254,14 @@ uint8_t NumBlocksPerSector(uint8_t sectorNo)
 }
 
 static int ParamCardSizeSectors(const char c) {
-	int numBlocks = 16;
+	int numSectors = 16;
 	switch (c) {
-		case '0' : numBlocks = 5; break;
-		case '2' : numBlocks = 32; break;
-		case '4' : numBlocks = 40; break;
-		default:   numBlocks = 16;
+		case '0' : numSectors = 5; break;
+		case '2' : numSectors = 32; break;
+		case '4' : numSectors = 40; break;
+		default:   numSectors = 16;
 	}
-	return numBlocks;
+	return numSectors;
 }
 
 static int ParamCardSizeBlocks(const char c) {
@@ -1421,11 +1421,12 @@ void readerAttack(nonces_t ar_resp[], bool setEmulatorMem, bool doStandardAttack
 	}*/
 }
 
-int usage_hf14_mf1ksim(void) {
-	PrintAndLog("Usage:  hf mf sim h u <uid (8, 14, or 20 hex symbols)> n <numreads> i x");
+int usage_hf14_mfsim(void) {
+	PrintAndLog("Usage:  hf mf sim [h] [*<card memory>] [u <uid (8, 14, or 20 hex symbols)>] [n <numreads>] [i] [x]");
 	PrintAndLog("options:");
-	PrintAndLog("      h    this help");
-	PrintAndLog("      u    (Optional) UID 4,7 or 10 bytes. If not specified, the UID 4B from emulator memory will be used");
+	PrintAndLog("      h    (Optional) this help");
+	PrintAndLog("      card memory: 0 - MINI(320 bytes), 1 - 1K, 2 - 2K, 4 - 4K, <other, default> - 1K");
+	PrintAndLog("      u    (Optional) UID 4 or 7 bytes. If not specified, the UID 4B from emulator memory will be used");
 	PrintAndLog("      n    (Optional) Automatically exit simulation after <numreads> blocks have been read by reader. 0 = infinite");
 	PrintAndLog("      i    (Optional) Interactive, means that console will not be returned until simulation finishes or is aborted");
 	PrintAndLog("      x    (Optional) Crack, performs the 'reader attack', nr/ar attack against a legitimate reader, fishes out the key(s)");
@@ -1434,21 +1435,20 @@ int usage_hf14_mf1ksim(void) {
 	PrintAndLog("      r    (Optional) Generate random nonces instead of sequential nonces. Standard reader attack won't work with this option, only moebius attack works.");
 	PrintAndLog("samples:");
 	PrintAndLog("           hf mf sim u 0a0a0a0a");
+	PrintAndLog("           hf mf sim *4");
 	PrintAndLog("           hf mf sim u 11223344556677");
-	PrintAndLog("           hf mf sim u 112233445566778899AA");
 	PrintAndLog("           hf mf sim f uids.txt");
 	PrintAndLog("           hf mf sim u 0a0a0a0a e");
 
 	return 0;
 }
 
-int CmdHF14AMf1kSim(const char *Cmd) {
+int CmdHF14AMfSim(const char *Cmd) {
 	UsbCommand resp;
 	uint8_t uid[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 	uint8_t exitAfterNReads = 0;
 	uint8_t flags = 0;
 	int uidlen = 0;
-	uint8_t pnr = 0;
 	bool setEmulatorMem = false;
 	bool attackFromFile = false;
 	FILE *f;
@@ -1459,9 +1459,21 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 
 	uint8_t cmdp = 0;
 	bool errors = false;
+	uint8_t cardsize = '1';
 
 	while(param_getchar(Cmd, cmdp) != 0x00) {
 		switch(param_getchar(Cmd, cmdp)) {
+		case '*': 
+			cardsize = param_getchar(Cmd + 1, cmdp);
+			switch(cardsize) {
+				case '0':
+				case '1':
+				case '2':
+				case '4': break;
+				default: cardsize = '1';
+			}
+			cmdp++;
+			break;
 		case 'e':
 		case 'E':
 			setEmulatorMem = true;
@@ -1485,7 +1497,7 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 			break;
 		case 'h':
 		case 'H':
-			return usage_hf14_mf1ksim();
+			return usage_hf14_mfsim();
 		case 'i':
 		case 'I':
 			flags |= FLAG_INTERACTIVE;
@@ -1493,7 +1505,7 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 			break;
 		case 'n':
 		case 'N':
-			exitAfterNReads = param_get8(Cmd, pnr+1);
+			exitAfterNReads = param_get8(Cmd, cmdp+1);
 			cmdp += 2;
 			break;
 		case 'r':
@@ -1505,10 +1517,9 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 		case 'U':
 			param_gethex_ex(Cmd, cmdp+1, uid, &uidlen);
 			switch(uidlen) {
-				case 20: flags = FLAG_10B_UID_IN_DATA;	break; //not complete
 				case 14: flags = FLAG_7B_UID_IN_DATA; break;
 				case  8: flags = FLAG_4B_UID_IN_DATA; break;
-				default: return usage_hf14_mf1ksim();
+				default: return usage_hf14_mfsim();
 			}
 			cmdp += 2;
 			break;
@@ -1525,7 +1536,7 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 		if(errors) break;
 	}
 	//Validations
-	if(errors) return usage_hf14_mf1ksim();
+	if(errors) return usage_hf14_mfsim();
 
 	//get uid from file
 	if (attackFromFile) {
@@ -1565,13 +1576,18 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 				sscanf(&buf[i], "%02x", (unsigned int *)&uid[i / 2]);
 			}
 
-			PrintAndLog("mf 1k sim uid: %s, numreads:%d, flags:%d (0x%02x) - press button to abort",
-					flags & FLAG_4B_UID_IN_DATA ? sprint_hex(uid,4):
-						flags & FLAG_7B_UID_IN_DATA	? sprint_hex(uid,7):
-							flags & FLAG_10B_UID_IN_DATA ? sprint_hex(uid,10): "N/A"
-					, exitAfterNReads, flags, flags);
+			PrintAndLog("mf sim cardsize: %s, uid: %s, numreads:%d, flags:%d (0x%02x) - press button to abort",
+				cardsize == '0' ? "Mini" :
+					cardsize == '2' ? "2K" :
+						cardsize == '4' ? "4K" : "1K",
+				flags & FLAG_4B_UID_IN_DATA ? sprint_hex(uid,4):
+					flags & FLAG_7B_UID_IN_DATA	? sprint_hex(uid,7):
+						flags & FLAG_10B_UID_IN_DATA ? sprint_hex(uid,10): "N/A",
+				exitAfterNReads,
+				flags,
+				flags);
 
-			UsbCommand c = {CMD_SIMULATE_MIFARE_CARD, {flags, exitAfterNReads,0}};
+			UsbCommand c = {CMD_SIMULATE_MIFARE_CARD, {flags, exitAfterNReads, cardsize}};
 			memcpy(c.d.asBytes, uid, sizeof(uid));
 			clearCommandBuffer();
 			SendCommand(&c);
@@ -1595,20 +1611,25 @@ int CmdHF14AMf1kSim(const char *Cmd) {
 		fclose(f);
 	} else { //not from file
 
-		PrintAndLog("mf 1k sim uid: %s, numreads:%d, flags:%d (0x%02x) ",
-				flags & FLAG_4B_UID_IN_DATA ? sprint_hex(uid,4):
-					flags & FLAG_7B_UID_IN_DATA	? sprint_hex(uid,7):
-						flags & FLAG_10B_UID_IN_DATA ? sprint_hex(uid,10): "N/A"
-				, exitAfterNReads, flags, flags);
+		PrintAndLog("mf sim cardsize: %s, uid: %s, numreads:%d, flags:%d (0x%02x) ",
+			cardsize == '0' ? "Mini" :
+				cardsize == '2' ? "2K" :
+					cardsize == '4' ? "4K" : "1K",
+			flags & FLAG_4B_UID_IN_DATA ? sprint_hex(uid,4):
+				flags & FLAG_7B_UID_IN_DATA	? sprint_hex(uid,7):
+					flags & FLAG_10B_UID_IN_DATA ? sprint_hex(uid,10): "N/A",
+			exitAfterNReads,
+			flags,
+			flags);
 
-		UsbCommand c = {CMD_SIMULATE_MIFARE_CARD, {flags, exitAfterNReads,0}};
+		UsbCommand c = {CMD_SIMULATE_MIFARE_CARD, {flags, exitAfterNReads, cardsize}};
 		memcpy(c.d.asBytes, uid, sizeof(uid));
 		clearCommandBuffer();
 		SendCommand(&c);
 
 		if(flags & FLAG_INTERACTIVE) {
 			PrintAndLog("Press pm3-button to abort simulation");
-			while(! WaitForResponseTimeout(CMD_ACK,&resp,1500)) {
+			while(! WaitForResponseTimeout(CMD_ACK, &resp, 1500)) {
 				//We're waiting only 1.5 s at a time, otherwise we get the
 				// annoying message about "Waiting for a response... "
 			}
@@ -1745,7 +1766,7 @@ int CmdHF14AMfELoad(const char *Cmd)
 		}
 	}
 
-	len = param_getstr(Cmd,nameParamNo,filename,sizeof(filename));
+	len = param_getstr(Cmd, nameParamNo, filename, sizeof(filename));
 
 	if (len > FILE_PATH_SIZE - 5) len = FILE_PATH_SIZE - 5;
 
@@ -2925,8 +2946,8 @@ static command_t CommandTable[] =
   {"hardnested",       CmdHF14AMfNestedHard,    0, "Nested attack for hardened Mifare cards"},
   {"nested",           CmdHF14AMfNested,        0, "Test nested authentication"},
   {"sniff",            CmdHF14AMfSniff,         0, "Sniff card-reader communication"},
-  {"sim",              CmdHF14AMf1kSim,         0, "Simulate MIFARE card"},
-  {"eclr",             CmdHF14AMfEClear,        0, "Clear simulator memory block"},
+  {"sim",              CmdHF14AMfSim,           0, "Simulate MIFARE card"},
+  {"eclr",             CmdHF14AMfEClear,        0, "Clear simulator memory"},
   {"eget",             CmdHF14AMfEGet,          0, "Get simulator memory block"},
   {"eset",             CmdHF14AMfESet,          0, "Set simulator memory block"},
   {"eload",            CmdHF14AMfELoad,         0, "Load from file emul dump"},

--- a/include/usb_cmd.h
+++ b/include/usb_cmd.h
@@ -226,12 +226,11 @@ typedef struct{
 
 
 //Mifare simulation flags
-#define FLAG_INTERACTIVE      0x01
-#define FLAG_4B_UID_IN_DATA   0x02
-#define FLAG_7B_UID_IN_DATA   0x04
-#define FLAG_10B_UID_IN_DATA  0x08
-#define FLAG_NR_AR_ATTACK     0x10
-#define FLAG_RANDOM_NONCE     0x20
+#define FLAG_INTERACTIVE                (1<<0)
+#define FLAG_4B_UID_IN_DATA             (1<<1)
+#define FLAG_7B_UID_IN_DATA             (1<<2)
+#define FLAG_NR_AR_ATTACK               (1<<4)
+#define FLAG_RANDOM_NONCE               (1<<5)
 
 
 //Iclass reader flags


### PR DESCRIPTION
* fix parity encryption (thanks to Eloff, http://www.proxmark.org/forum/viewtopic.php?id=6347)
* add support to simulate Mifare Mini, Mifare 2K and Mifare 4K
* change to standard LED handling (A: PM is working, B: reader is sending, C: tag is responding, D: HF field is on)
* whitespace