### PR TITLE
Added support for Legic tags to `hf search` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added `hf plot` (piwi)
 - Added `hf mfp mad` `hf mf mad` parsing MAD1 and MAD2 (Merlok)
 - Added `hf mfp ndef` `hf mf ndef` parsing NDEF records (Merlok)
+- Added Legic detection to `hf search` (dnet)
 
 ## [v3.1.0][2018-10-10]
 

--- a/client/cmdhf.c
+++ b/client/cmdhf.c
@@ -66,6 +66,11 @@ int CmdHFSearch(const char *Cmd){
 		PrintAndLog("\nValid ISO14443B Tag Found - Quiting Search\n");
 		return ans;
 	}
+	ans = CmdLegicRFRead("");
+	if (ans == 0) {
+		PrintAndLog("\nValid Legic Tag Found - Quiting Search\n");
+		return ans;
+	}
 	PrintAndLog("\nno known/supported 13.56 MHz tags found\n");
 	return 0;
 }


### PR DESCRIPTION
Before these commits, `hf search` didn't try reading Legic tags. To include these, I also had to improve the handling of the `hf legic` command, since from the client perspective, it was pretty much fire-and-forget, as the only feedback came in the form of human-readable `DbpString` calls. I replaced these with proper `CMD_ACK` responses, it worked on my setup:

```
proxmark3> hf search

#db# Reading card ...
Waiting for a response from the proxmark...
You can cancel this operation by pressing the pm3 button
Card (MIM 1024) read, use 'hf legic decode' or
'data hexsamples 1024' to view results

Valid Legic Tag Found - Quiting Search
```