### PR TITLE
Add 'hf 15 csetuid' command to set UID on ISO15693 Magic tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - `hf 15 sim` now works as expected (piwi)
 
 ### Added
+- Added `hf 15 csetuid` - set UID on ISO-15693 Magic tags (t0m4)
 - Added `lf config s xxxx` option to allow skipping x samples before capture (marshmellow)
 - Added `lf em 4x05protect` to support changing protection blocks on em4x05 chips (marshmellow)
 - Support Standard Communication Mode in HITAG S

--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1158,8 +1158,13 @@ void UsbPacketReceived(uint8_t *packet, int len)
 		case CMD_READER_ISO_15693:
 			ReaderIso15693(c->arg[0]);
 			break;
+
 		case CMD_SIMTAG_ISO_15693:
 			SimTagIso15693(c->arg[0], c->d.asBytes);
+			break;
+
+		case CMD_CSETUID_ISO_15693:
+			SetTag15693Uid(c->d.asBytes);
 			break;
 #endif
 

--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -1604,7 +1604,7 @@ void SetTag15693Uid(uint8_t *uid)
     uint16_t crc;
 
     int recvlen = 0;
-	uint8_t recvbuf[ISO15693_MAX_RESPONSE_LENGTH];
+    uint8_t recvbuf[ISO15693_MAX_RESPONSE_LENGTH];
 
     LED_A_ON();
 

--- a/armsrc/iso15693.c
+++ b/armsrc/iso15693.c
@@ -1591,6 +1591,85 @@ void DirectTag15693Command(uint32_t datalen, uint32_t speed, uint32_t recv, uint
 	LED_A_OFF();
 }
 
+//-----------------------------------------------------------------------------
+// Work with "magic Chinese" card.
+//
+//-----------------------------------------------------------------------------
+
+// Set the UID to the tag (based on Iceman work).
+void SetTag15693Uid(uint8_t *uid)
+{
+    uint8_t cmd[4][9] = {0x00};
+
+    uint16_t crc;
+
+    int recvlen = 0;
+	uint8_t recvbuf[ISO15693_MAX_RESPONSE_LENGTH];
+
+    LED_A_ON();
+
+    // Command 1 : 02213E00000000
+    cmd[0][0] = 0x02;
+    cmd[0][1] = 0x21;
+    cmd[0][2] = 0x3e;
+    cmd[0][3] = 0x00;
+    cmd[0][4] = 0x00;
+    cmd[0][5] = 0x00;
+    cmd[0][6] = 0x00;
+
+    // Command 2 : 02213F69960000
+    cmd[1][0] = 0x02;
+    cmd[1][1] = 0x21;
+    cmd[1][2] = 0x3f;
+    cmd[1][3] = 0x69;
+    cmd[1][4] = 0x96;
+    cmd[1][5] = 0x00;
+    cmd[1][6] = 0x00;
+
+    // Command 3 : 022138u8u7u6u5 (where uX = uid byte X)
+    cmd[2][0] = 0x02;
+    cmd[2][1] = 0x21;
+    cmd[2][2] = 0x38;
+    cmd[2][3] = uid[7];
+    cmd[2][4] = uid[6];
+    cmd[2][5] = uid[5];
+    cmd[2][6] = uid[4];
+
+    // Command 4 : 022139u4u3u2u1 (where uX = uid byte X)
+    cmd[3][0] = 0x02;
+    cmd[3][1] = 0x21;
+    cmd[3][2] = 0x39;
+    cmd[3][3] = uid[3];
+    cmd[3][4] = uid[2];
+    cmd[3][5] = uid[1];
+    cmd[3][6] = uid[0];
+
+    for (int i=0; i<4; i++) {
+        // Add the CRC
+        crc = Crc(cmd[i], 7);
+        cmd[i][7] = crc & 0xff;
+        cmd[i][8] = crc >> 8;
+
+        if (DEBUG) {
+            Dbprintf("SEND:");
+            Dbhexdump(sizeof(cmd[i]), cmd[i], false);
+        }
+
+        recvlen = SendDataTag(cmd[i], sizeof(cmd[i]), true, 1, recvbuf, sizeof(recvbuf), 0);
+
+        if (DEBUG) {
+            Dbprintf("RECV:");
+            Dbhexdump(recvlen, recvbuf, false);
+            DbdecodeIso15693Answer(recvlen, recvbuf);
+        }
+
+        cmd_send(CMD_ACK, recvlen>ISO15693_MAX_RESPONSE_LENGTH?ISO15693_MAX_RESPONSE_LENGTH:recvlen, 0, 0, recvbuf, ISO15693_MAX_RESPONSE_LENGTH);
+    }
+    
+    LED_D_OFF();
+
+    LED_A_OFF();
+}
 
 
 

--- a/armsrc/iso15693.h
+++ b/armsrc/iso15693.h
@@ -19,6 +19,7 @@ void ReaderIso15693(uint32_t parameter);
 void SimTagIso15693(uint32_t parameter, uint8_t *uid);
 void BruteforceIso15693Afi(uint32_t speed);
 void DirectTag15693Command(uint32_t datalen,uint32_t speed, uint32_t recv, uint8_t data[]); 
+void SetTag15693Uid(uint8_t *uid);
 void SetDebugIso15693(uint32_t flag);
 
 #endif

--- a/client/cmdhf15.c
+++ b/client/cmdhf15.c
@@ -957,10 +957,8 @@ int CmdHF15CmdWrite(const char *Cmd) {
 
 int CmdHF15CSetUID(const char *Cmd)
 {
-  uint8_t uid[16] = {0x00};
-  uint8_t oldUidReversed[8], oldUid[8] = {0x00};
-  uint8_t newUidReversed[8], newUid[8] = {0x00};
-  int res;
+  uint8_t uid[8] = {0x00};
+  uint8_t oldUid[8], newUid[8] = {0x00};
 
   uint8_t needHelp = 0;
   char cmdp = 1;
@@ -970,7 +968,7 @@ int CmdHF15CSetUID(const char *Cmd)
     return 1;
   }
 
-  if (strcmp(sprint_hex_inrow_ex(uid, 1, 2), "e0") != 0) {
+  if (uid[0] != 0xe0) {
     PrintAndLog("UID must begin with the byte 'E0'");
     return 1;
   }
@@ -1003,11 +1001,7 @@ int CmdHF15CSetUID(const char *Cmd)
   PrintAndLog("new UID | %s", sprint_hex(uid, 8));
   PrintAndLog("Using backdoor Magic tag function");
 
-  if (getUID(oldUidReversed)) {
-    for (int i=0; i<sizeof(oldUidReversed); i++) {
-      oldUid[i] = oldUidReversed[sizeof(oldUidReversed)-1-i];
-    }
-  } else {
+  if (!getUID(oldUid)) {
     PrintAndLog("Can't get old UID.");
     return 1;
   }
@@ -1037,18 +1031,14 @@ int CmdHF15CSetUID(const char *Cmd)
     }
   }
 
-  if (getUID(newUidReversed)) {
-    for (int i=0; i<sizeof(newUidReversed); i++) {
-      newUid[i] = newUidReversed[sizeof(newUidReversed)-1-i];
-    }
-  } else {
+  if (!getUID(newUid)) {
     PrintAndLog("Can't get new UID.");
     return 1;
   }
 
   PrintAndLog("");
-  PrintAndLog("old UID : %s", sprint_hex(oldUid, 8));
-  PrintAndLog("new UID : %s", sprint_hex(newUid, 8));
+  PrintAndLog("old UID : %02X %02X %02X %02X %02X %02X %02X %02X", oldUid[7], oldUid[6], oldUid[5], oldUid[4], oldUid[3], oldUid[2], oldUid[1], oldUid[0]);
+  PrintAndLog("new UID : %02X %02X %02X %02X %02X %02X %02X %02X", newUid[7], newUid[6], newUid[5], newUid[4], newUid[3], newUid[2], newUid[1], newUid[0]);
   return 0;
 }
 

--- a/client/cmdhf15.h
+++ b/client/cmdhf15.h
@@ -22,6 +22,7 @@ int CmdHF15Reader(const char *Cmd);
 int CmdHF15Sim(const char *Cmd);
 int CmdHF15Record(const char *Cmd);
 int CmdHF15Cmd(const char*Cmd);
+int CmdHF15CSetUID(const char *Cmd);
 int CmdHF15CmdHelp(const char*Cmd);
 int CmdHF15Help(const char*Cmd);
 

--- a/include/usb_cmd.h
+++ b/include/usb_cmd.h
@@ -132,6 +132,7 @@ typedef struct{
 #define CMD_ISO_15693_FIND_AFI                                            0x0315
 #define CMD_ISO_15693_DEBUG                                               0x0316
 #define CMD_LF_SNOOP_RAW_ADC_SAMPLES                                      0x0317
+#define CMD_CSETUID_ISO_15693                                             0x0318
 
 // For Hitag2 transponders
 #define CMD_SNOOP_HITAG                                                   0x0370


### PR DESCRIPTION
Based on the commands in Iceman's lua script, here is the command to set UID on ISO15693 Magic tags.

```
proxmark3> hf 15 reader
proxmark3> #db# 12 octets read from IDENTIFY request:
#db# NoErr CrcOK
#db# 00 00 11 11 11 11 11 11
#db# 11 e0 28 01
#db# UID = E011111111111111

proxmark3> hf 15 csetuid E022222222222222

new UID | e0 22 22 22 22 22 22 22
Using backdoor Magic tag function
received 0 octets

received 0 octets

received 3 octets
00 78 F0
received 3 octets
00 78 F0

old UID : e0 11 11 11 11 11 11 11
new UID : e0 22 22 22 22 22 22 22
proxmark3> hf 15 reader
proxmark3> #db# 12 octets read from IDENTIFY request:
#db# NoErr CrcOK
#db# 00 00 22 22 22 22 22 22
#db# 22 e0 db 86
#db# UID = E022222222222222

proxmark3>
```