### PR TITLE
Issue #843 - hf mf chk - t Doesnt save to emulator memory 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - AC-Mode decoding for HitagS
 - Wrong UID at HitagS simulation
 - `hf 15 sim` now works as expected (piwi)
+- 'hf mf chk t` save to emulator memory now works as expeted (mwalker)
 
 ### Added
 - Added `lf config s xxxx` option to allow skipping x samples before capture (marshmellow)

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -1054,7 +1054,7 @@ int CmdHF14AMfChk(const char *Cmd)
 		PrintAndLog("Usage:  hf mf chk <block number>|<*card memory> <key type (A/B/?)> [t|d|s|ss] [<key (12 hex symbols)>] [<dic (*.dic)>]");
 		PrintAndLog("          * - all sectors");
 		PrintAndLog("card memory - 0 - MINI(320 bytes), 1 - 1K, 2 - 2K, 4 - 4K, <other> - 1K");
-		PrintAndLog("d  - write keys to binary file\n");
+		PrintAndLog("d  - write keys to binary file (not used when <block number> supplied)\n");
 		PrintAndLog("t  - write keys to emulator memory");
 		PrintAndLog("s  - slow execute. timeout 1ms");
 		PrintAndLog("ss - very slow execute. timeout 5ms");
@@ -1066,27 +1066,27 @@ int CmdHF14AMfChk(const char *Cmd)
 		return 0;
 	}
 
-	FILE * f;
-	char filename[FILE_PATH_SIZE]={0};
-	char buf[13];
-	uint8_t *keyBlock = NULL, *p;
-	uint16_t stKeyBlock = 20;
-
-	int i, res;
-	int keycnt = 0;
-	char ctmp   = 0x00;
-	int clen = 0;
-	uint8_t blockNo = 0;
-	uint8_t SectorsCnt = 0;
-	uint8_t keyType = 0;
-	uint64_t key64 = 0;
+	FILE     * f;
+	char     filename[FILE_PATH_SIZE]={0};
+	char     buf[13];
+	uint8_t  *keyBlock        = NULL, *p;
+	uint16_t stKeyBlock       = 20;
+	int      i, res;
+	int      keycnt           = 0;
+	char     ctmp             = 0x00;
+	int      clen             = 0;
+	uint8_t  blockNo          = 0;
+	uint8_t  SectorsCnt       = 0;
+	uint8_t  keyType          = 0;
+	uint64_t key64            = 0;
 	// timeout in units. (ms * 106)/10 or us*0.0106
-	uint8_t btimeout14a = MF_CHKKEYS_DEFTIMEOUT; // fast by default
-	bool param3InUse = false;
-
-	bool transferToEml = 0;
-	bool createDumpFile = 0;
-
+	uint8_t  btimeout14a      = MF_CHKKEYS_DEFTIMEOUT; // fast by default
+	bool     param3InUse      = false;
+	bool     transferToEml    = 0;
+	bool     createDumpFile   = 0;
+    bool     SingleKey        = false;     // Flag to ID if a single or multi key check
+	uint8_t  KeyFoundCount    = 0;         // Counter to display the number of keys found/transfered to emulator
+    
 	sector_t *e_sector = NULL;
 
 	keyBlock = calloc(stKeyBlock, 6);
@@ -1100,8 +1100,12 @@ int CmdHF14AMfChk(const char *Cmd)
 	if (param_getchar(Cmd, 0)=='*') {
 		SectorsCnt = ParamCardSizeSectors(param_getchar(Cmd + 1, 0));
 	}
-	else
+    else {   
 		blockNo = param_get8(Cmd, 0);
+        // Singe Key check, so Set Sector count to cover sectors (1 to sector that contains the block)
+        SectorsCnt = (blockNo/4) + 1;   
+        SingleKey  = true;              // Set flag for single key check
+    }
 
 	ctmp = param_getchar(Cmd, 1);
 	clen = param_getlength(Cmd, 1);
@@ -1142,7 +1146,7 @@ int CmdHF14AMfChk(const char *Cmd)
 				keyBlock = p;
 			}
 			PrintAndLog("chk key[%2d] %02x%02x%02x%02x%02x%02x", keycnt,
-			(keyBlock + 6*keycnt)[0],(keyBlock + 6*keycnt)[1], (keyBlock + 6*keycnt)[2],
+			(keyBlock + 6*keycnt)[0], (keyBlock + 6*keycnt)[1], (keyBlock + 6*keycnt)[2],
 			(keyBlock + 6*keycnt)[3], (keyBlock + 6*keycnt)[4], (keyBlock + 6*keycnt)[5], 6);
 			keycnt++;
 		} else {
@@ -1200,7 +1204,7 @@ int CmdHF14AMfChk(const char *Cmd)
 		PrintAndLog("No key specified, trying default keys");
 		for (;keycnt < defaultKeysSize; keycnt++)
 			PrintAndLog("chk default key[%2d] %02x%02x%02x%02x%02x%02x", keycnt,
-				(keyBlock + 6*keycnt)[0],(keyBlock + 6*keycnt)[1], (keyBlock + 6*keycnt)[2],
+				(keyBlock + 6*keycnt)[0], (keyBlock + 6*keycnt)[1], (keyBlock + 6*keycnt)[2],
 				(keyBlock + 6*keycnt)[3], (keyBlock + 6*keycnt)[4], (keyBlock + 6*keycnt)[5], 6);
 	}
 
@@ -1218,9 +1222,11 @@ int CmdHF14AMfChk(const char *Cmd)
 	}
 	printf("\n");
 
-	bool foundAKey = false;
-	uint32_t max_keys = keycnt > USB_CMD_DATA_SIZE / 6 ? USB_CMD_DATA_SIZE / 6 : keycnt;
-	if (SectorsCnt) {
+	bool     foundAKey = false;
+	uint32_t max_keys  = keycnt > USB_CMD_DATA_SIZE / 6 ? USB_CMD_DATA_SIZE / 6 : keycnt;
+
+    // !SingleKey, so all key check
+	if ((SectorsCnt) && !SingleKey) { 
 		PrintAndLog("To cancel this operation press the button on the proxmark...");
 		printf("--");
 		for (uint32_t c = 0; c < keycnt; c += max_keys) {
@@ -1250,9 +1256,15 @@ int CmdHF14AMfChk(const char *Cmd)
 
 				if (res != 1) {
 					if (!res) {
-						PrintAndLog("Found valid key:[%d:%c]%012" PRIx64, blockNo, (keyAB & 0x01)?'B':'A', key64);
+                        
+                        // Use the common format below
+						// PrintAndLog("Found valid key:[%d:%c]%012" PRIx64, blockNo, (keyAB & 0x01)?'B':'A', key64);
 						foundAKey = true;
-					}
+                       
+                        // Store the Single Key for display list
+                        e_sector[(blockNo/4)].foundKey[(keyAB & 0x01)] = true;  // flag key found 
+                        e_sector[(blockNo/4)].Key[(keyAB & 0x01)]      = key64; // Save key data  
+                    }
 				} else {
 					PrintAndLog("Command execute timeout");
 				}
@@ -1268,8 +1280,11 @@ int CmdHF14AMfChk(const char *Cmd)
 			PrintAndLog("|sec|key A           |res|key B           |res|");
 			PrintAndLog("|---|----------------|---|----------------|---|");
 			for (i = 0; i < SectorsCnt; i++) {
-				PrintAndLog("|%03d|  %012" PRIx64 "  | %d |  %012" PRIx64 "  | %d |", i,
-					e_sector[i].Key[0], e_sector[i].foundKey[0], e_sector[i].Key[1], e_sector[i].foundKey[1]);
+		        // If a block key check, only print a line if a key was found.
+                if (!SingleKey || (e_sector[i].foundKey[0]) || (e_sector[i].foundKey[1]) ){ 
+                    PrintAndLog("|%03d|  %012" PRIx64 "  | %d |  %012" PRIx64 "  | %d |", i,
+                        e_sector[i].Key[0], e_sector[i].foundKey[0], e_sector[i].Key[1], e_sector[i].foundKey[1]);
+                }
 			}
 			PrintAndLog("|---|----------------|---|----------------|---|");
 		}
@@ -1286,15 +1301,18 @@ int CmdHF14AMfChk(const char *Cmd)
 				for (uint16_t t = 0; t < 2; t++) {
 					if (e_sector[sectorNo].foundKey[t]) {
 						num_to_bytes(e_sector[sectorNo].Key[t], 6, block + t * 10);
+                        KeyFoundCount++; // Key found count for information
 					}
 				}
 				mfEmlSetMem(block, FirstBlockOfSector(sectorNo) + NumBlocksPerSector(sectorNo) - 1, 1);
 			}
 		}
-		PrintAndLog("Found keys have been transferred to the emulator memory");
+		// PrintAndLog("Found keys have been transferred to the emulator memory");
+        // Updated to show the actual number of keys found/transfered.
+   		PrintAndLog("%d keys(s) found have been transferred to the emulator memory",KeyFoundCount);
 	}
 
-	if (createDumpFile) {
+	if (createDumpFile && !SingleKey) {
 		FILE *fkeys = fopen("dumpkeys.bin","wb");
 		if (fkeys == NULL) {
 			PrintAndLog("Could not create file dumpkeys.bin");
@@ -1312,6 +1330,7 @@ int CmdHF14AMfChk(const char *Cmd)
 		fclose(fkeys);
 		PrintAndLog("Found keys have been dumped to file dumpkeys.bin. 0xffffffffffff has been inserted for unknown keys.");
 	}
+    
 
 	free(e_sector);
 	free(keyBlock);

--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -1054,7 +1054,7 @@ int CmdHF14AMfChk(const char *Cmd)
 		PrintAndLog("Usage:  hf mf chk <block number>|<*card memory> <key type (A/B/?)> [t|d|s|ss] [<key (12 hex symbols)>] [<dic (*.dic)>]");
 		PrintAndLog("          * - all sectors");
 		PrintAndLog("card memory - 0 - MINI(320 bytes), 1 - 1K, 2 - 2K, 4 - 4K, <other> - 1K");
-		PrintAndLog("d  - write keys to binary file (not used when <block number> supplied)\n");
+		PrintAndLog("d  - write keys to binary file (not used when <block number> supplied)");
 		PrintAndLog("t  - write keys to emulator memory");
 		PrintAndLog("s  - slow execute. timeout 1ms");
 		PrintAndLog("ss - very slow execute. timeout 5ms");
@@ -1131,8 +1131,14 @@ int CmdHF14AMfChk(const char *Cmd)
 			return 1;
 		};
 	}
-
+	
 	parseParamTDS(Cmd, 2, &transferToEml, &createDumpFile, &btimeout14a);
+
+	if (singleBlock & createDumpFile) {
+		PrintAndLog (" block key check (<block no>) and write to dump file (d) combination is not supported ");
+		PrintAndLog (" please remove option d and try again");
+		return 1;
+	}
 
 	param3InUse = transferToEml | createDumpFile | (btimeout14a != MF_CHKKEYS_DEFTIMEOUT);
 
@@ -1230,7 +1236,7 @@ int CmdHF14AMfChk(const char *Cmd)
 	uint32_t	max_keys  = keycnt > USB_CMD_DATA_SIZE / 6 ? USB_CMD_DATA_SIZE / 6 : keycnt;
 
 	// !SingleKey, so all key check (if SectorsCnt > 0)
-	if (SectorsCnt && !singleBlock) { 
+	if (!singleBlock) { 
 		PrintAndLog("To cancel this operation press the button on the proxmark...");
 		printf("--");
 		for (uint32_t c = 0; c < keycnt; c += max_keys) {
@@ -1250,7 +1256,7 @@ int CmdHF14AMfChk(const char *Cmd)
 				PrintAndLog("Command execute timeout");
 			}
 		}
-	} else if (singleBlock) { // Ensure single block mode in case SectorsCnt == 0
+	} else { 
 		int keyAB = keyType;
 		do {
 			for (uint32_t c = 0; c < keycnt; c+=max_keys) {


### PR DESCRIPTION
Patched so that a single block key check will write to the emulator if found.
Updated the display output for a single block check to use the same format as the full card check.
Added a count and display the number of keys found and transferred.
Ensured that a write to the dump file wont happen if a single block check was used.

