### PR TITLE
fix 'hf mf sim': wrong access rights to write key B in trailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - AC-Mode decoding for HitagS
 - Wrong UID at HitagS simulation
 - `hf 15 sim` now works as expected (piwi)
-- 'hf mf chk t` save to emulator memory now works as expeted (mwalker)
-
+- `hf mf chk t` save to emulator memory now works as expected (mwalker)
+ - Fix `hf mf sim` - wrong access rights to write key B in trailer (@McEloff)
+ 
 ### Added
 - Added `hf 15 csetuid` - set UID on ISO-15693 Magic tags (t0m4)
 - Added `lf config s xxxx` option to allow skipping x samples before capture (marshmellow)
@@ -28,7 +29,7 @@ This project uses the changelog in accordance with [keepchangelog](http://keepac
 - Added `lf hitag reader 04` - read block (instead of pages) 
 - Added `hf fido` `assert` and `make` commands from fido2 protocol (authenticatorMakeCredential and authenticatorGetAssertion) (Merlok)
 - Added `lf paradox clone` to clone a Paradox card
-- Added `emv` commmands working for both contactless and smart cards (Merlok)
+- Added `emv` commands working for both contactless and smart cards (Merlok)
 - Added `hf 15 snoop` (piwi)
 - Added support for standard USB Smartcard Readers (piwi)
 - Added `hf plot` (piwi)

--- a/armsrc/mifaresim.c
+++ b/armsrc/mifaresim.c
@@ -95,7 +95,7 @@ static bool IsTrailerAccessAllowed(uint8_t blockNo, uint8_t keytype, uint8_t act
 			break;
 		}
 		case AC_KEYB_WRITE: {
-			return ((keytype == AUTHKEYA && (AC == 0x00 || AC == 0x04))
+			return ((keytype == AUTHKEYA && (AC == 0x00 || AC == 0x01))
 				 || (keytype == AUTHKEYB && (AC == 0x04 || AC == 0x03)));
 			break;
 		}


### PR DESCRIPTION
(from PR 279 https://github.com/RfidResearchGroup/proxmark3)