### PR TITLE
fix iclass reader functions

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1324,9 +1324,6 @@ void UsbPacketReceived(uint8_t *packet, int len)
 		case CMD_ICLASS_WRITEBLOCK:
 			iClass_WriteBlock(c->arg[0], c->d.asBytes);
 			break;
-		case CMD_ICLASS_READCHECK:  // auth step 1
-			iClass_ReadCheck(c->arg[0], c->arg[1]);
-			break;
 		case CMD_ICLASS_READBLOCK:
 			iClass_ReadBlk(c->arg[0]);
 			break;

--- a/armsrc/iclass.c
+++ b/armsrc/iclass.c
@@ -1407,7 +1407,7 @@ void CodeIClassCommand(const uint8_t *cmd, int len) {
 		for (j = 0; j < 4; j++) {
 			for (k = 0; k < 4; k++) {
 				if (k == (b & 3)) {
-					ToSend[++ToSendMax] = 0xf0;
+					ToSend[++ToSendMax] = 0x0f;
 				} else {
 					ToSend[++ToSendMax] = 0x00;
 				}
@@ -1697,6 +1697,7 @@ void ReaderIClass(uint8_t arg0) {
 			if ( (result_status ^ FLAG_ICLASS_READER_CSN ^ flagReadConfig ^ flagReadCC ^ flagReadAA) == 0) {
 				cmd_send(CMD_ACK, result_status, 0, 0, card_data, sizeof(card_data));
 				if (abort_after_read) {
+					FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
 					LED_A_OFF();
 					LED_B_OFF();
 					return;
@@ -1848,15 +1849,8 @@ void ReaderIClass_Replay(uint8_t arg0, uint8_t *MAC) {
 			 card_data,
 			 0);
 
+	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
 	LED_A_OFF();
-}
-
-void iClass_ReadCheck(uint8_t blockNo, uint8_t keyType) {
-	uint8_t readcheck[] = { keyType, blockNo };
-	uint8_t resp[] = {0,0,0,0,0,0,0,0};
-	size_t isOK = 0;
-	isOK = sendCmdGetResponseWithRetries(readcheck, sizeof(readcheck), resp, sizeof(resp), 6);
-	cmd_send(CMD_ACK,isOK, 0, 0, 0, 0);
 }
 
 void iClass_Authentication(uint8_t *MAC) {
@@ -1868,7 +1862,7 @@ void iClass_Authentication(uint8_t *MAC) {
 	cmd_send(CMD_ACK,isOK, 0, 0, 0, 0);
 }
 
-bool iClass_ReadBlock(uint8_t blockNo, uint8_t *readdata) {
+static bool iClass_ReadBlock(uint8_t blockNo, uint8_t *readdata) {
 	uint8_t readcmd[] = {ICLASS_CMD_READ_OR_IDENTIFY, blockNo, 0x00, 0x00}; //0x88, 0x00 // can i use 0C?
 	char bl = blockNo;
 	uint16_t rdCrc = iclass_crc16(&bl, 1);
@@ -1889,6 +1883,7 @@ void iClass_ReadBlk(uint8_t blockno) {
 	bool isOK = false;
 	isOK = iClass_ReadBlock(blockno, readblockdata);
 	cmd_send(CMD_ACK, isOK, 0, 0, readblockdata, 8);
+	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
 }
 
 void iClass_Dump(uint8_t blockno, uint8_t numblks) {
@@ -1959,6 +1954,7 @@ void iClass_WriteBlock(uint8_t blockNo, uint8_t *data) {
 		Dbprintf("Write block [%02x] failed", blockNo);
 	}
 	cmd_send(CMD_ACK, isOK, 0, 0, 0, 0);
+	FpgaWriteConfWord(FPGA_MAJOR_MODE_OFF);
 }
 
 void iClass_Clone(uint8_t startblock, uint8_t endblock, uint8_t *data) {

--- a/armsrc/iclass.h
+++ b/armsrc/iclass.h
@@ -25,9 +25,7 @@ extern void IClass_iso14443A_GetPublic(uint8_t arg0);
 extern void iClass_Authentication(uint8_t *MAC);
 extern void iClass_WriteBlock(uint8_t blockNo, uint8_t *data);
 extern void iClass_ReadBlk(uint8_t blockNo);
-extern bool iClass_ReadBlock(uint8_t blockNo, uint8_t *readdata);
 extern void iClass_Dump(uint8_t blockno, uint8_t numblks);
 extern void iClass_Clone(uint8_t startblock, uint8_t endblock, uint8_t *data);
-extern void iClass_ReadCheck(uint8_t blockNo, uint8_t keyType);
 
 #endif

--- a/client/hid-flasher/usb_cmd.h
+++ b/client/hid-flasher/usb_cmd.h
@@ -124,7 +124,6 @@ typedef struct {
 #define CMD_WRITER_LEGIC_RF                                               0x0389
 #define CMD_EPA_PACE_COLLECT_NONCE                                        0x038A
 
-#define CMD_ICLASS_READCHECK                                              0x038F
 #define CMD_ICLASS_CLONE                                                  0x0390
 #define CMD_ICLASS_DUMP                                                   0x0391
 #define CMD_SNOOP_ICLASS                                                  0x0392

--- a/include/usb_cmd.h
+++ b/include/usb_cmd.h
@@ -156,7 +156,6 @@ typedef struct{
 #define CMD_EPA_PACE_COLLECT_NONCE                                        0x038A
 #define CMD_EPA_PACE_REPLAY                                               0x038B
 
-#define CMD_ICLASS_READCHECK                                              0x038F
 #define CMD_ICLASS_CLONE                                                  0x0390
 #define CMD_ICLASS_DUMP                                                   0x0391
 #define CMD_SNOOP_ICLASS                                                  0x0392


### PR DESCRIPTION
* remove unused CMD_ICLASS_READCHECK
* fix wrong command coding in CodeIClassCommand()
* switch field off at end of commands to avoid RDV4 overheating