### PR TITLE
fix 'hf iclass replay'

### DIFF
--- a/armsrc/appmain.c
+++ b/armsrc/appmain.c
@@ -1315,9 +1315,6 @@ void UsbPacketReceived(uint8_t *packet, int len)
 		case CMD_READER_ICLASS:
 			ReaderIClass(c->arg[0]);
 			break;
-		case CMD_READER_ICLASS_REPLAY:
-			ReaderIClass_Replay(c->arg[0], c->d.asBytes);
-			break;
 		case CMD_ICLASS_EML_MEMSET:
 			emlSet(c->d.asBytes,c->arg[0], c->arg[1]);
 			break;

--- a/client/hid-flasher/usb_cmd.h
+++ b/client/hid-flasher/usb_cmd.h
@@ -129,7 +129,6 @@ typedef struct {
 #define CMD_SNOOP_ICLASS                                                  0x0392
 #define CMD_SIMULATE_TAG_ICLASS                                           0x0393
 #define CMD_READER_ICLASS                                                 0x0394
-#define CMD_READER_ICLASS_REPLAY                                          0x0395
 #define CMD_ICLASS_READBLOCK                                              0x0396
 #define CMD_ICLASS_WRITEBLOCK                                             0x0397
 #define CMD_ICLASS_EML_MEMSET                                             0x0398

--- a/common/iso15693tools.c
+++ b/common/iso15693tools.c
@@ -70,7 +70,7 @@ char* Iso15693sprintUID(char *target, uint8_t *uid) {
 }
 
 
-uint16_t iclass_crc16(char *data_p, unsigned short length) {
+uint16_t iclass_crc16(uint8_t *data_p, unsigned short length) {
 	unsigned char i;
 	unsigned int data;
 	uint16_t crc = ISO15693_CRC_PRESET;
@@ -79,7 +79,7 @@ uint16_t iclass_crc16(char *data_p, unsigned short length) {
 		return (~crc);
 
 	do {
-		for (i = 0, data = (unsigned int)0xff & *data_p++; i < 8; i++, data >>= 1) {
+		for (i = 0, data = 0xff & *data_p++; i < 8; i++, data >>= 1) {
 			if ((crc & 0x0001) ^ (data & 0x0001))
 				crc = (crc >> 1) ^ ISO15693_CRC_POLY;
 			else  crc >>= 1;

--- a/common/iso15693tools.h
+++ b/common/iso15693tools.h
@@ -11,6 +11,6 @@
 uint16_t Iso15693Crc(uint8_t *v, int n);
 int Iso15693AddCrc(uint8_t *req, int n);
 char* Iso15693sprintUID(char *target, uint8_t *uid);
-unsigned short iclass_crc16(char *data_p, unsigned short length);
+unsigned short iclass_crc16(uint8_t *data_p, unsigned short length);
 
 #endif

--- a/include/usb_cmd.h
+++ b/include/usb_cmd.h
@@ -161,7 +161,6 @@ typedef struct{
 #define CMD_SNOOP_ICLASS                                                  0x0392
 #define CMD_SIMULATE_TAG_ICLASS                                           0x0393
 #define CMD_READER_ICLASS                                                 0x0394
-#define CMD_READER_ICLASS_REPLAY                                          0x0395
 #define CMD_ICLASS_READBLOCK                                              0x0396
 #define CMD_ICLASS_WRITEBLOCK                                             0x0397
 #define CMD_ICLASS_EML_MEMSET                                             0x0398


### PR DESCRIPTION
* implement option -n for authentication with replayed NR/MAC pairs in 'dump' and 'readbl'
* delete 'hf iclass replay' which no longer adds value