### PR TITLE
"hf mf ekeyprn d" doesn't works properly

### DIFF
--- a/client/cmdhfmf.c
+++ b/client/cmdhfmf.c
@@ -2060,7 +2060,7 @@ int CmdHF14AMfEKeyPrn(const char *Cmd)
 				PrintAndLog("error get block %d", FirstBlockOfSector(i) + NumBlocksPerSector(i) - 1);
 				break;
 			}
-			fwrite(data+6, 1, 6, fkeys);
+			fwrite(data, 1, 6, fkeys);
 		}
 		for(i = 0; i < numSectors; i++) {
 			if (mfEmlGetMem(data, FirstBlockOfSector(i) + NumBlocksPerSector(i) - 1, 1)) {


### PR DESCRIPTION
FIX: command "hf mf ekeyprn  d" doesn't use the correct offset to locate the A key in data[] array and record the 2 last bytes followed by 4 0x00 instead of the 6 good bytes (All the A keys are corrupted in file dumpkeys.bin). B keys are not affected.
Fix issue #903 