### PR TITLE
Fix #912: ukbhit() false positive

### DIFF
--- a/client/util.c
+++ b/client/util.c
@@ -49,7 +49,7 @@ int ukbhit(void)
 	error += tcsetattr(STDIN_FILENO, TCSANOW, &Otty);             // reset attributes
   }
 
-  return ( error == 0 ? cnt : -1 );
+  return cnt;
 }
 
 char getch(void)


### PR DESCRIPTION
Mindless fix for #912, returning `0` in case of error instead of `-1`.