### PR TITLE
Compile Error: Add string.h to ui.c

### DIFF
--- a/client/ui.c
+++ b/client/ui.c
@@ -13,6 +13,7 @@
 #ifndef EXTERNAL_PRINTANDLOG
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <stdarg.h>
 #include <readline/readline.h>
 #include <pthread.h>


### PR DESCRIPTION
Failed to compile without adding <string.h> lib to ui.c in /client on MacOS Big Sur Developer Beta. Received this error when doing `make clean; make` to compile the software in Step 19 of the Getting Started [instructions](https://github.com/Proxmark/proxmark3/wiki/MacOS): 

> ui.c:52:4: error: implicitly declaring library function 'strncpy' with type
      'char *(char *, const char *, unsigned long)'
      [-Werror,-Wimplicit-function-declaration]
                        strncpy(prefix,_RED_(FAILED: ), sizeof(prefix)-1);
                        ^
ui.c:52:4: note: include the header <string.h> or explicitly provide a
      declaration for 'strncpy'
ui.c:79:6: error: implicitly declaring library function 'strchr' with type 'char
      *(const char *, int)' [-Werror,-Wimplicit-function-declaration]
        if (strchr(buffer, '\n')) {
            ^
ui.c:79:6: note: include the header <string.h> or explicitly provide a
      declaration for 'strchr'
ui.c:87:11: error: implicitly declaring library function 'strtok' with type
      'char *(char *, const char *)' [-Werror,-Wimplicit-function-declaration]
                token = strtok(buffer, delim);
                        ^
ui.c:87:11: note: include the header <string.h> or explicitly provide a
      declaration for 'strtok'
ui.c:91:11: error: implicitly declaring library function 'strlen' with type
      'unsigned long (const char *)' [-Werror,-Wimplicit-function-declaration]
                        size = strlen(buffer2);
                               ^
ui.c:91:11: note: include the header <string.h> or explicitly provide a
      declaration for 'strlen'

Everything compiles fine now. I'm not sure if this is an issue with Big Sur itself as this has worked fine on my other machines.