### PR TITLE
Add downlinks mode for lf t55xx dump

### DIFF
--- a/client/cmdlft55xx.c
+++ b/client/cmdlft55xx.c
@@ -124,8 +124,8 @@ int usage_t55xx_dump(){
 	PrintAndLog("Options:");
 	PrintAndLog("     <password>  - OPTIONAL password 4bytes (8 hex symbols)");
 	PrintAndLog("     o           - OPTIONAL override, force pwd read despite danger to card");
-	PrintAndLog("     r <mode>      - OPTIONAL downlink encoding '0' fixed bit length (default), '1' long leading reference");
-	PrintAndLog("                                                '2' leading zero,               '3' 1 of 4 coding reference"); 
+	PrintAndLog("     r <mode>    - OPTIONAL downlink encoding '0' fixed bit length (default), '1' long leading reference");
+	PrintAndLog("                                              '2' leading zero,               '3' 1 of 4 coding reference"); 
 	PrintAndLog("");
 	PrintAndLog("Examples:");
 	PrintAndLog("      lf t55xx dump");


### PR DESCRIPTION
I noticed that the "lf t55xx dump" command lacks the support of downlinks mode so I add it.
The password is always the first parameter, so I check this parameter at first.
I found the cmdp is used in two ways: a index pointing at the next parameter, or a container for param_getchar(). I use the former one according to the code of read block command.